### PR TITLE
Extract parameter names from byte code when no name is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Swift
 
-Swift is an easy-to-use, annotation-based Java library for creating Thrift serializable types and services.
+Swift is an easy-to-use, annotation-based Java library for creating Thrift
+serializable types and services.
 
 # Swift Codec
 
-[Swift Codec](swift-codec/README.md) is a simple library specifying how Java objects are convered to and from Thrift.  This library is simmilar to JaxRS (XML) and Jackson (JSON), but for Thirft.  Swift codec supports field, method, costructor, and builder injection.  For example:
+[Swift Codec](swift-codec/README.md) is a simple library specifying how Java
+objects are converted to and from Thrift.  This library is similar to JaxB
+(XML) and Jackson (JSON), but for Thrift.  Swift codec supports field, method,
+constructor, and builder injection.  For example:
 
     @ThriftStruct
     public class LogEntry {
@@ -12,10 +16,7 @@ Swift is an easy-to-use, annotation-based Java library for creating Thrift seria
       private final String message;
     
       @ThriftConstructor
-      public LogEntry(
-          @ThriftField(name = "category") String category,
-          @ThriftField(name = "message") String message
-      ) {
+      public LogEntry(String category, String message) {
         this.category = category;
         this.message = message;
       }
@@ -34,7 +35,8 @@ Swift is an easy-to-use, annotation-based Java library for creating Thrift seria
 
 # Swift Service
 
-[Swift Service](swift-service/README.md) is a simple library annotating services to be exported with Thrift.   For example:
+[Swift Service](swift-service/README.md) is a simple library annotating
+services to be exported with Thrift.   For example:
 
     @ThriftService("scribe")
     public class InMemoryScribe {

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
       </dependency>
 
       <dependency>
+          <groupId>com.thoughtworks.paranamer</groupId>
+          <artifactId>paranamer</artifactId>
+          <version>2.5</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>1.6.4</version>

--- a/swift-codec/README.md
+++ b/swift-codec/README.md
@@ -1,10 +1,23 @@
 # Swift Codec
 
-Swift Codec is a simple library specifying how Java objects are convered to and from Thrift.  This library is simmilar to JaxRS (XML) and Jackson (JSON), but for Thirft.  Swift codec supports field, method, costructor, and builder injection.
+Swift Codec is a simple library specifying how Java objects are converted to and
+from Thrift.  This library is similar to JaxB (XML) and Jackson (JSON), but
+for Thrift.  Swift codec supports field, method, constructor, and builder
+injection.
 
 # Structs 
 
+To make a Java class a Thrift struct simply add the `@ThriftStruct` annotation.
+Swift will assume the Java class and the Thrift struct have the same name, so
+if the Thrift struct has a different name, you will need to add a value to
+annotation like this: `@ThriftStruct("MyStructName")`.
+
 ## Field
+
+The simplest way to add a Thrift field is to annotate a public Java field with
+`@ThriftField(42)`.  As with structs, Swift will assume the Java field and
+Thrift field have the same name, so if they don't just add a name to the
+annotation like this: `@ThriftField(value = 1, name="myFieldName")`.
 
     @ThriftStruct
     public class Bonk {
@@ -19,6 +32,11 @@ Swift Codec is a simple library specifying how Java objects are convered to and 
     } 
 
 ## Beans
+
+Traditional Java beans can easily be converted to Thrift structs by annotating
+the getters and setters.  Swift will link the getter and setter by name, so you
+only need to specify the Thrift field id on one of them.  You can override the
+Thrift field name in the annotation if necessary.
 
     @ThriftStruct
     public class Bonk {
@@ -48,6 +66,14 @@ Swift Codec is a simple library specifying how Java objects are convered to and 
  
 ## Constructor
 
+Swift support immutable Java objects using constructor injection.  Simply,
+annotate the constructor you want Swift to use with `@ThriftConstructor`, and
+Swift will automatically supply the constructor with the specified fields.
+Assuming you have compiled with debug symbols on, the parameters are
+automatically matched to a Thrift field (getter or Java field) by name.
+Otherwise, you will need to annotate the parameters with
+`@ThriftField(name = "myName")`.
+
     @Immutable
     @ThriftStruct
     public class Bonk {
@@ -55,10 +81,7 @@ Swift Codec is a simple library specifying how Java objects are convered to and 
       private final int type;
     
       @ThriftConstructor
-      public Bonk(
-        @ThriftField(name = "message") String message,
-        @ThriftField(name = "type") int type
-      ) {
+      public Bonk(String message, int type) {
         this.message = message;
         this.type = type;
       }
@@ -75,6 +98,13 @@ Swift Codec is a simple library specifying how Java objects are convered to and 
     }
 
 ## Builder
+
+For larger immutable objects, Swift supports the builder pattern.  The Thrift
+struct is linked to the builder class using the `builder` property on the
+`@ThriftStruct` annotation.  Swift will look for a factory method annotated
+with `@ThriftConstructor` on the builder class.  The builder can use field,
+method and/or constructor injection in addition to injection into the factory
+method itself.
 
     @Immutable
     @ThriftStruct(builder = Builder.class)
@@ -125,13 +155,21 @@ Swift Codec is a simple library specifying how Java objects are convered to and 
 
 # Enumerations
 
+Swift automatically maps Java enumerations to a Thrift int.
+
 ## Implicit Value
+
+Swift supports standard Java enumerations directly as a Thrift enumeration
+using the Java ordinal value as the Thrift enum value.
 
     public enum Fruit {
       APPLE, BANANA, CHERRY
     }
 
 ## Explicit Value
+
+For custom enumerations, you can annotate a method on the enumeration to
+supply an int value.
 
     public enum Letter {
       A(65), B(66), C(67), D(68);

--- a/swift-codec/pom.xml
+++ b/swift-codec/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+        <groupId>com.thoughtworks.paranamer</groupId>
+        <artifactId>paranamer</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkConstructor.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkConstructor.java
@@ -12,10 +12,7 @@ public class BonkConstructor {
   private final int type;
 
   @ThriftConstructor
-  public BonkConstructor(
-      @ThriftField(name = "message") String message,
-      @ThriftField(name = "type") int type
-  ) {
+  public BonkConstructor(String message, int type) {
     this.message = message;
     this.type = type;
   }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkMethod.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkMethod.java
@@ -27,10 +27,7 @@ public class BonkMethod {
   }
 
   @ThriftField
-  public void setData(
-      @ThriftField(name = "message") String message,
-      @ThriftField(name = "type") int type
-  ) {
+  public void setData(String message, int type) {
     this.message = message;
     this.type = type;
   }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestReflectionHelper.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestReflectionHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */
+package com.facebook.swift.codec.metadata;
+
+import com.facebook.swift.codec.ThriftField;
+import org.testng.annotations.Test;
+
+import static com.facebook.swift.codec.metadata.ReflectionHelper.extractParameterNames;
+import static org.testng.Assert.assertEquals;
+
+public class TestReflectionHelper {
+
+  @Test
+  public void testExtractParameterNamesNoAnnotations() throws Exception {
+    assertEquals(
+        extractParameterNames(
+            getClass().getDeclaredMethod(
+                "noAnnotations",
+                String.class,
+                String.class,
+                String.class
+            )
+        ),
+        new String[]{"a", "b", "c"}
+    );
+  }
+  private static void noAnnotations(String a, String b, String c) {
+  }
+
+  @Test
+  public void testExtractParameterNamesThriftFieldAnnotation() throws Exception {
+    assertEquals(
+        extractParameterNames(
+            getClass().getDeclaredMethod(
+                "thriftFieldAnnotation",
+                String.class,
+                String.class,
+                String.class
+            )
+        ),
+        new String[]{"a", "b", "c"}
+    );
+  }
+
+  private static void thriftFieldAnnotation(
+      @ThriftField(name = "a") String arg0,
+      @ThriftField(name = "b") String arg1,
+      @ThriftField(name = "c") String arg2
+  ) {
+  }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -15,6 +15,37 @@ import static org.fest.assertions.Assertions.assertThat;
 public class TestThriftStructMetadataBuilder {
 
   @Test
+  public void testNoId() throws Exception {
+    ThriftStructMetadataBuilder<NoId> builder = new ThriftStructMetadataBuilder<>(
+        new ThriftCatalog(),
+        NoId.class
+    );
+
+    MetadataErrors metadataErrors = builder.getMetadataErrors();
+
+    assertThat(metadataErrors.getErrors())
+        .as("metadata errors")
+        .hasSize(1);
+
+    assertThat(metadataErrors.getWarnings())
+        .as("metadata warnings")
+        .isEmpty();
+
+    assertThat(metadataErrors.getErrors().get(0).getMessage())
+        .as("error message")
+        .containsIgnoringCase("not have an id");
+  }
+
+  @ThriftStruct
+  public static class NoId {
+    @ThriftField
+    public String getField1() { return null; }
+
+    @ThriftField
+    public void setField1(String value) { }
+  }
+
+  @Test
   public void testMultipleIds() throws Exception {
     ThriftStructMetadataBuilder<MultipleIds> builder = new ThriftStructMetadataBuilder<>(
         new ThriftCatalog(),

--- a/swift-service/README.md
+++ b/swift-service/README.md
@@ -1,6 +1,7 @@
 # Swift Service
 
-Swift Service is a simple library annotating services to be exported with Thrift.
+Swift Service is a simple library annotating services to be exported with
+Thrift.
 
 ## Service
 


### PR DESCRIPTION
This means that we no longer have to annotate method and constructor parameters to link them to a Thrift field.
