### PR TITLE
Shut down server channels before killing io thread pool executor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,19 +85,19 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>configuration</artifactId>
-                <version>0.66-SNAPSHOT</version>
+                <version>0.66</version>
             </dependency>
 
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>stats</artifactId>
-                <version>0.66-SNAPSHOT</version>
+                <version>0.66</version>
             </dependency>
 
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>units</artifactId>
-                <version>0.66-SNAPSHOT</version>
+                <version>0.66</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,12 +101,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.facebook.nifty</groupId>
-                <artifactId>nifty-core-asf</artifactId>
-                <version>0.0.1</version>
-            </dependency>
-
-            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
                 <version>3.4.0.Final</version>

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>jmx</artifactId>
-            <version>0.66-SNAPSHOT</version>
+            <version>0.66</version>
         </dependency>
 
         <dependency>

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
@@ -50,6 +50,7 @@ public class ThriftServer implements Closeable
     private final NettyServerTransport transport;
     private final int workerThreads;
     private final int port;
+    private final DefaultChannelGroup allChannels = new DefaultChannelGroup();
 
     private final ExecutorService acceptorExecutor;
     private final ExecutorService ioExecutor;
@@ -86,7 +87,9 @@ public class ThriftServer implements Closeable
                 workerExecutor
         );
 
-        transport = new NettyServerTransport(thriftServerDef, new NettyConfigBuilder(), new DefaultChannelGroup());
+        acceptorThreads = config.getAcceptorThreads();
+        workerThreads = config.getWorkerThreads();
+        transport = new NettyServerTransport(thriftServerDef, new NettyConfigBuilder(), allChannels);
     }
 
     private int getSpecifiedOrRandomPort(ThriftServerConfig config)
@@ -156,6 +159,9 @@ public class ThriftServer implements Closeable
         if (workerExecutor != null) {
             shutdownExecutor(workerExecutor);
         }
+
+        // TODO: allow an option here to control if we need to drain connections and wait instead of killing them all
+        allChannels.close();
 
         // finally the reader writer
         if (ioExecutor != null) {


### PR DESCRIPTION
Avoids a hang on shut down (e.g. while running tests during development) if the client got stuck and didn't close the connection
