### PR TITLE
Support for one-way methods, and fixes for exception handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,19 +85,19 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>configuration</artifactId>
-                <version>0.66-SNAPSHOT</version>
+                <version>0.66</version>
             </dependency>
 
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>stats</artifactId>
-                <version>0.66-SNAPSHOT</version>
+                <version>0.66</version>
             </dependency>
 
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>units</artifactId>
-                <version>0.66-SNAPSHOT</version>
+                <version>0.66</version>
             </dependency>
 
             <dependency>

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>jmx</artifactId>
-            <version>0.66-SNAPSHOT</version>
+            <version>0.66</version>
         </dependency>
 
         <dependency>

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethod.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethod.java
@@ -32,5 +32,7 @@ public @interface ThriftMethod
 {
     String value() default "";
 
+    boolean oneway() default false;
+
     ThriftException[] exception() default {};
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
@@ -48,6 +48,7 @@ public class ThriftMethodProcessor
     private final Object service;
     private final Method method;
     private final String resultStructName;
+    private final boolean oneway;
     private final Map<Short, ThriftCodec<?>> parameterCodecs;
     private final ThriftCodec<Object> successCodec;
     private final Map<Class<?>, ExceptionProcessor> exceptionCodecs;
@@ -66,6 +67,7 @@ public class ThriftMethodProcessor
         resultStructName = name + "_result";
 
         method = methodMetadata.getMethod();
+        oneway = methodMetadata.getOneway();
 
         ImmutableMap.Builder<Short, ThriftCodec<?>> builder = ImmutableMap.builder();
         for (ThriftFieldMetadata fieldMetadata : methodMetadata.getParameters()) {
@@ -113,24 +115,48 @@ public class ThriftMethodProcessor
         Object result;
         try {
             result = invokeMethod(args);
-            // write success reply
-            writeResponse(out, sequenceId, "success", 0, successCodec, result);
+
+            if (!oneway) {
+                // write success reply
+                writeResponse(out,
+                              sequenceId,
+                              TMessageType.REPLY,
+                              "success",
+                              (short) 0,
+                              successCodec,
+                              result);
+            }
 
             stats.addSuccessTime(nanosSince(start));
         }
         catch (Exception e) {
-            ExceptionProcessor exceptionCodec = exceptionCodecs.get(e.getClass());
-            if (exceptionCodec != null) {
-                // write application exception response
-                writeResponse(out, sequenceId, "exception", exceptionCodec.getId(), exceptionCodec.getCodec(), e);
-                stats.addErrorTime(nanosSince(start));
-            }
-            else {
-                // unexpected exception
-                TApplicationException applicationException = new TApplicationException(INTERNAL_ERROR, "Internal error processing " + method.getName());
-                applicationException.initCause(e);
-                stats.addErrorTime(nanosSince(start));
-                throw applicationException;
+            if (!oneway) {
+                ExceptionProcessor exceptionCodec = exceptionCodecs.get(e.getClass());
+                if (exceptionCodec != null) {
+                    // write expected exception response
+                    writeResponse(out,
+                                  sequenceId,
+                                  TMessageType.EXCEPTION,
+                                  "exception",
+                                  exceptionCodec.getId(),
+                                  exceptionCodec.getCodec(),
+                                  e);
+                    stats.addErrorTime(nanosSince(start));
+                } else {
+                    // unexpected exception
+                    TApplicationException applicationException =
+                      new TApplicationException(INTERNAL_ERROR,
+                                                "Internal error processing " + method.getName());
+                    applicationException.initCause(e);
+
+                    // Application exceptions are sent to client, and the connection can be reused
+                    out.writeMessageBegin(new TMessage(name, TMessageType.EXCEPTION, sequenceId));
+                    applicationException.write(out);
+                    out.writeMessageEnd();
+                    out.getTransport().flush();
+
+                    stats.addErrorTime(nanosSince(start));
+                }
             }
         }
     }
@@ -195,9 +221,13 @@ public class ThriftMethodProcessor
         }
     }
 
-    private <T> void writeResponse(TProtocol out, int sequenceId, String responseFieldName, int responseFieldId, ThriftCodec<T> responseCodec, T result)
-            throws Exception
-    {
+    private <T> void writeResponse(TProtocol out,
+                                   int sequenceId,
+                                   byte responseType,
+                                   String responseFieldName,
+                                   short responseFieldId,
+                                   ThriftCodec<T> responseCodec,
+                                   T result) throws Exception {
         long start = System.nanoTime();
 
         out.writeMessageBegin(new TMessage(name, TMessageType.REPLY, sequenceId));

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceProcessor.java
@@ -110,14 +110,6 @@ public class ThriftServiceProcessor implements TProcessor
 
             return true;
         }
-        catch (TApplicationException e) {
-            // Application exceptions are sent to client, and the connection can be reused
-            out.writeMessageBegin(new TMessage(methodName, TMessageType.EXCEPTION, sequenceId));
-            e.write(out);
-            out.writeMessageEnd();
-            out.getTransport().flush();
-            return true;
-        }
         catch (Exception e) {
             // Other exceptions are not recoverable. The input or output streams may be corrupt.
             Throwables.propagateIfInstanceOf(e, TException.class);

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftService.java
@@ -128,7 +128,7 @@ public class TestThriftService
     public class ConflictingLogService
     {
         @ThriftMethod
-        public void Log(List<String> messages)
+        public void Log(List<String> messages) throws TException
         {
         }
     }

--- a/swift-service/src/test/java/com/facebook/swift/service/base/TestSuiteBase.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/base/TestSuiteBase.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.base;
+
+import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.service.ThriftClientManager;
+import com.facebook.swift.service.ThriftServer;
+import com.facebook.swift.service.ThriftServiceProcessor;
+import com.google.common.net.HostAndPort;
+import org.apache.thrift.transport.TTransportException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+
+public class TestSuiteBase<ServiceInterface> {
+    private ThriftCodecManager codecManager = new ThriftCodecManager();
+    private ThriftClientManager clientManager;
+    private Class<? extends ServiceInterface> clientClass;
+    private Class<? extends ServiceInterface> handlerClass;
+    private ServiceInterface client;
+    private ThriftServer server;
+
+    public TestSuiteBase(Class<? extends ServiceInterface> handlerClass, Class<? extends ServiceInterface>
+      clientClass) {
+        this.clientClass = clientClass;
+        this.handlerClass = handlerClass;
+    }
+
+    @BeforeClass
+    public void setupSuite() throws InstantiationException, IllegalAccessException {
+        server = createServer().start();
+    }
+
+    @BeforeMethod
+    public void setupTest() throws TTransportException {
+        clientManager = new ThriftClientManager(codecManager);
+        client = createClient(clientManager);
+    }
+
+    @AfterMethod
+    public void tearDownTest() throws Exception {
+        AutoCloseable closeable = (AutoCloseable) client;
+        closeable.close();
+        clientManager.close();
+    }
+
+    @AfterClass
+    public void tearDownSuite() {
+        server.close();
+    }
+
+    private ThriftServer createServer() throws IllegalAccessException, InstantiationException {
+        ThriftServiceProcessor processor = new ThriftServiceProcessor(codecManager,
+                                                                      handlerClass.newInstance());
+        return new ThriftServer(processor);
+    }
+
+    private ServiceInterface createClient(ThriftClientManager clientManager) throws
+      TTransportException {
+        HostAndPort address = HostAndPort.fromParts("localhost", server.getPort());
+        return clientManager.createClient(address, clientClass);
+    }
+
+    protected ServiceInterface getClient() {
+        return client;
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/NonThriftCheckedException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/NonThriftCheckedException.java
@@ -13,19 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.exceptions;
 
-import org.apache.thrift.TException;
-
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
-
-    @Override
-    void close();
+class NonThriftCheckedException extends Exception {
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/NonThriftUncheckedException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/NonThriftUncheckedException.java
@@ -13,19 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.exceptions;
 
-import org.apache.thrift.TException;
-
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
-
-    @Override
-    void close();
+class NonThriftUncheckedException extends RuntimeException {
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestService.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.exceptions;
+
+import com.facebook.swift.service.ThriftException;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+import org.apache.thrift.TException;
+
+@ThriftService
+public interface TestService {
+
+    @ThriftMethod(exception = { @ThriftException(type = ThriftCheckedException.class, id = 1) })
+    public void throwExpectedThriftCheckedException() throws ThriftCheckedException,
+      TException;
+
+    @ThriftMethod(exception = { @ThriftException(type = ThriftUncheckedException.class, id = 1) })
+    public void throwExpectedThriftUncheckedException() throws TException;
+
+    @ThriftMethod(exception = { @ThriftException(type = ThriftCheckedException.class, id = 1) })
+    public void throwWrongThriftException() throws TException, ThriftCheckedException;
+
+    @ThriftMethod
+    public void throwUnexpectedThriftCheckedException() throws ThriftCheckedException,
+      TException;
+
+    @ThriftMethod
+    public void throwUnexpectedThriftUncheckedException() throws TException;
+
+    @ThriftMethod
+    public void throwUnexpectedNonThriftCheckedException() throws TException,
+      NonThriftCheckedException;
+
+    @ThriftMethod
+    public void throwUnexpectedNonThriftUncheckedException() throws TException;
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestServiceClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestServiceClient.java
@@ -13,19 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.exceptions;
 
-import org.apache.thrift.TException;
-
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
-
+public interface TestServiceClient extends TestService, AutoCloseable {
     @Override
-    void close();
+    public void close();
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestServiceHandler.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.exceptions;
+
+import org.apache.thrift.TException;
+
+public class TestServiceHandler implements TestService {
+    @Override
+    public void throwExpectedThriftCheckedException()
+      throws TException, ThriftCheckedException {
+        throw new ThriftCheckedException();
+    }
+
+    @Override
+    public void throwUnexpectedThriftCheckedException()
+      throws TException, ThriftCheckedException {
+        throw new ThriftCheckedException();
+    }
+
+    @Override
+    public void throwUnexpectedThriftUncheckedException()
+      throws TException {
+        throw new ThriftUncheckedException();
+    }
+
+    @Override
+    public void throwExpectedThriftUncheckedException()
+      throws TException, ThriftUncheckedException {
+        throw new ThriftUncheckedException();
+    }
+
+    @Override
+    public void throwWrongThriftException() throws TException, ThriftCheckedException {
+        throw new ThriftUncheckedException();
+    }
+
+    @Override
+    public void throwUnexpectedNonThriftCheckedException()
+      throws TException, NonThriftCheckedException {
+        throw new NonThriftCheckedException();
+    }
+
+    @Override
+    public void throwUnexpectedNonThriftUncheckedException()
+      throws TException {
+        throw new NonThriftUncheckedException();
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestSuite.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.exceptions;
+
+import com.facebook.swift.service.base.TestSuiteBase;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TException;
+import org.testng.annotations.Test;
+
+public class TestSuite extends TestSuiteBase<TestService> {
+
+    public TestSuite() {
+        super(TestServiceHandler.class, TestServiceClient.class);
+    }
+
+    @Test(expectedExceptions = { ThriftCheckedException.class })
+    public void testThrowExpectedCheckedException() throws ThriftCheckedException, TException {
+        getClient().throwExpectedThriftCheckedException();
+    }
+
+    @Test(expectedExceptions = { ThriftUncheckedException.class })
+    public void testThrowExceptedUncheckedException() throws ThriftUncheckedException, TException {
+        getClient().throwExpectedThriftUncheckedException();
+    }
+
+    @Test(expectedExceptions = { TApplicationException.class })
+    public void testThrowWrongThriftException() throws TException, ThriftCheckedException {
+        getClient().throwWrongThriftException();
+    }
+
+    // Doesn't work because even though throwUnexpectedThriftCheckedException doesn't explicitly
+    // declare a @ThriftException for the exception type ThriftCheckedException, Swift infers
+    // it from the java exception specification, so a ThriftCheckedException is caught.
+    @Test(enabled = false, expectedExceptions = { TApplicationException.class })
+    public void testThrowUnexpectedThriftCheckedException() throws ThriftCheckedException,
+      TException {
+        getClient().throwUnexpectedThriftCheckedException();
+    }
+
+    @Test(expectedExceptions = { TApplicationException.class })
+    public void testThrowUnexpectedThriftUncheckedException() throws TException {
+        getClient().throwUnexpectedThriftUncheckedException();
+    }
+
+    @Test(expectedExceptions = { TApplicationException.class })
+    public void testThrowUnexpectedNonThriftCheckedException() throws TException, NonThriftCheckedException {
+        getClient().throwUnexpectedNonThriftCheckedException();
+    }
+
+    @Test(expectedExceptions = { TApplicationException.class })
+    public void testThrowUnexpectedNonThriftUncheckedException() throws TException {
+        getClient().throwUnexpectedNonThriftUncheckedException();
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftCheckedException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftCheckedException.java
@@ -13,19 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.exceptions;
 
-import org.apache.thrift.TException;
+import com.facebook.swift.codec.ThriftStruct;
 
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
-
-    @Override
-    void close();
+@ThriftStruct
+public class ThriftCheckedException extends Exception {
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftUncheckedException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftUncheckedException.java
@@ -13,19 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.exceptions;
 
-import org.apache.thrift.TException;
+import com.facebook.swift.codec.ThriftStruct;
 
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
-
-    @Override
-    void close();
+@ThriftStruct
+public class ThriftUncheckedException extends RuntimeException {
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/OneWayException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/OneWayException.java
@@ -13,19 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.oneway;
 
-import org.apache.thrift.TException;
+import com.facebook.swift.codec.ThriftStruct;
 
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
-
-    @Override
-    void close();
+@ThriftStruct
+public class OneWayException extends Exception {
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/TestService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/TestService.java
@@ -13,19 +13,20 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.oneway;
 
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
 import org.apache.thrift.TException;
 
-import java.io.Closeable;
-import java.util.List;
+@ThriftService
+public interface TestService {
+    @ThriftMethod
+    public void verifyConnectionState() throws TException;
 
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
+    @ThriftMethod(oneway = true)
+    public void onewayMethod() throws TException;
 
-    @Override
-    void close();
+    @ThriftMethod(oneway = true)
+    public void onewayThrow() throws TException, OneWayException;
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/TestServiceClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/TestServiceClient.java
@@ -13,19 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.oneway;
 
-import org.apache.thrift.TException;
-
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
-
+public interface TestServiceClient extends TestService, AutoCloseable {
     @Override
-    void close();
+    public void close();
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/TestServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/TestServiceHandler.java
@@ -13,19 +13,23 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.service;
+package com.facebook.swift.service.oneway;
 
 import org.apache.thrift.TException;
 
-import java.io.Closeable;
-import java.util.List;
-
-@ThriftService("scribe")
-public interface Scribe extends Closeable
-{
-    @ThriftMethod("Log")
-    ResultCode log(List<LogEntry> messages) throws TException;
+public class TestServiceHandler implements TestService {
+    @Override
+    public void verifyConnectionState() throws TException {
+        // do nothing, used only to verify two-way communication still works
+    }
 
     @Override
-    void close();
+    public void onewayMethod() throws TException {
+        return;
+    }
+
+    @Override
+    public void onewayThrow() throws TException, OneWayException {
+        throw new OneWayException();
+    }
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/TestSuite.java
@@ -1,0 +1,41 @@
+/**
+* Copyright 2012 Facebook, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may
+* not use this file except in compliance with the License. You may obtain
+* a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package com.facebook.swift.service.oneway;
+
+import com.facebook.swift.service.base.TestSuiteBase;
+import org.apache.thrift.TException;
+import org.testng.annotations.Test;
+
+@Test
+public class TestSuite extends TestSuiteBase<TestService> {
+
+    public TestSuite() {
+        super(TestServiceHandler.class, TestServiceClient.class);
+    }
+
+    @Test
+    public void testOnewayCall() throws TException {
+        getClient().onewayMethod();
+        getClient().verifyConnectionState();
+    }
+
+    @Test
+    public void testOneWayThrow() throws TException, OneWayException {
+        getClient().onewayThrow();
+        getClient().verifyConnectionState();
+    }
+
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/swift/PumaReadService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/swift/PumaReadService.java
@@ -15,8 +15,10 @@
  */
 package com.facebook.swift.service.puma.swift;
 
+import com.facebook.swift.service.ThriftException;
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
+import org.apache.thrift.TException;
 
 import java.io.Closeable;
 import java.util.List;
@@ -26,25 +28,25 @@ public interface PumaReadService extends Closeable
 {
     @ThriftMethod
     List<ReadResultQueryInfo> getResult(List<ReadQueryInfoTimeString> reader)
-            throws ReadSemanticException;
+            throws TException, ReadSemanticException;
 
     @ThriftMethod
     List<ReadResultQueryInfoTimeString> getResultTimeString(List<ReadQueryInfoTimeString> reader)
-            throws ReadSemanticException;
+            throws TException, ReadSemanticException;
 
     @ThriftMethod
     List<ReadResultQueryInfo> mergeQueryAggregation(
             MergeAggregationQueryInfo mergeAggregationQueryInfo
     )
-            throws ReadSemanticException;
+            throws TException, ReadSemanticException;
 
     @ThriftMethod
     long latestQueryableTime(String category, String appName, List<Integer> bucketNumbers)
-            throws ReadSemanticException;
+            throws TException, ReadSemanticException;
 
     @ThriftMethod
     List<Long> latestQueryableTimes(String category, String appName, List<Integer> bucketNumbers)
-            throws ReadSemanticException;
+            throws TException, ReadSemanticException;
 
     @Override
     void close();


### PR DESCRIPTION
Also fixes client calls to functions with void return types.

Exception fixes are mostly related to making sure clients can always receive TApplicationException (which is thrown in the case of an undeclared exception thrown by the server method, or for other types of internal errors).
