### PR TITLE
Don't require that ThriftMethods throw TException

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/RuntimeTApplicationException.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/RuntimeTApplicationException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service;
+
+import org.apache.thrift.TApplicationException;
+
+/**
+ * Runtime equivalent of TApplicationException.  If a swift client receives a
+ * TApplicationException for a method that doesn't declare
+ * TApplicationException to be thrown, the underlying exception is wrapped in
+ * this class and rethrown.
+ */
+public class RuntimeTApplicationException extends RuntimeTException
+{
+    public RuntimeTApplicationException(String message, TApplicationException cause)
+    {
+        super(message, cause);
+    }
+}

--- a/swift-service/src/main/java/com/facebook/swift/service/RuntimeTException.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/RuntimeTException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service;
+
+import org.apache.thrift.TException;
+
+/**
+ * Runtime equivalent of TException.  If a swift client receives a TException
+ * for a method that doesn't declare TException to be thrown, the underlying
+ * exception is wrapped in this class and rethrown.
+ */
+public class RuntimeTException extends RuntimeException
+{
+    public RuntimeTException(String message, TException cause)
+    {
+        super(message, cause);
+    }
+}

--- a/swift-service/src/main/java/com/facebook/swift/service/RuntimeTProtocolException.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/RuntimeTProtocolException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service;
+
+import org.apache.thrift.protocol.TProtocolException;
+
+/**
+ * Runtime equivalent of TProtocolException.  If a swift client receives a
+ * TProtocolException for a method that doesn't declare TProtocolException
+ * to be thrown, the underlying exception is wrapped in this class and
+ * rethrown.
+ */
+public class RuntimeTProtocolException extends RuntimeTException
+{
+    public RuntimeTProtocolException(String message, TProtocolException cause)
+    {
+        super(message, cause);
+    }
+}

--- a/swift-service/src/main/java/com/facebook/swift/service/RuntimeTTransportException.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/RuntimeTTransportException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service;
+
+import org.apache.thrift.transport.TTransportException;
+
+/**
+ * Runtime equivalent of TTransportException.  If a swift client receives a
+ * TTransportException for a method that doesn't declare TTransportException
+ * to be thrown, the underlying exception is wrapped in this class and
+ * rethrown.
+ */
+public class RuntimeTTransportException extends RuntimeTException
+{
+    public RuntimeTTransportException(String message, TTransportException cause)
+    {
+        super(message, cause);
+    }
+}

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -157,10 +157,6 @@ public class ThriftMethodMetadata
                                                               ThriftMethod thriftMethod) {
         ImmutableMap.Builder<Short, ThriftType> exceptions = ImmutableMap.builder();
 
-        Preconditions.checkArgument(throwsTException(method),
-                                    "Thrift method %s must declare TException as throwable",
-                                    method.toGenericString());
-
         if (thriftMethod.exception().length > 0) {
             for (ThriftException thriftException : thriftMethod.exception()) {
                 exceptions.put(thriftException.id(), catalog.getThriftType(thriftException.type()));
@@ -178,14 +174,5 @@ public class ThriftMethodMetadata
         }
 
         return exceptions.build();
-    }
-
-    private static boolean throwsTException(Method method) {
-        for (Class<?> exceptionClass : method.getExceptionTypes()) {
-            if (exceptionClass.isAssignableFrom(TException.class)) {
-                return true;
-            }
-        }
-        return false;
     }
 }


### PR DESCRIPTION
Wraps T_Exception in RunnableT_Exception if method doesn't declare it throws it.
