### PR TITLE
Move io.airlift:jmx dependency to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>jmx</artifactId>
+                <version>0.66</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
                 <version>3.4.0.Final</version>

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -50,12 +50,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>jmx</artifactId>
-            <version>0.66</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 
@@ -84,6 +78,12 @@
         <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>jmx</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This (in combination with the airlift pull request, and an update to swift-service/pom.xml to point to the new airlift artifact once its available) should relieve swift of its dependency on specific logging frameworks, so it won't clash with projects that use other logging frameworks.
