### PR TITLE
Add ThriftDocumentation annotation and create annotation processor to save javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
   </distributionManagement>
 
   <modules>
+    <module>swift-annotator</module>
     <module>swift-codec</module>
     <module>swift-idl-parser</module>
     <module>swift-service</module>

--- a/swift-annotator/pom.xml
+++ b/swift-annotator/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.swift</groupId>
+        <artifactId>swift-root</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>com.facebook.swift</groupId>
+    <artifactId>swift-annotator</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>${project.artifactId}</name>
+
+    <description>Java 6 annotator for saving JavaDocs</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.7.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.</pattern>
+                            <shadedPattern>com.facebook.swift.annotator.shaded.org.</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- need to disable annotation processors, or it will try to run the one we're building while we build it... -->
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/swift-annotator/src/main/java/com/facebook/swift/annotator/JavaDocProcessor.java
+++ b/swift-annotator/src/main/java/com/facebook/swift/annotator/JavaDocProcessor.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.annotator;
+
+import org.apache.commons.lang.StringEscapeUtils;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@SupportedAnnotationTypes({"com.facebook.swift.service.ThriftService", "com.facebook.swift.codec.ThriftStruct"})
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
+public class JavaDocProcessor extends AbstractProcessor
+{
+    private Messager messager;
+    private Elements elementUtils;
+    private Filer filer;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv)
+    {
+        super.init(processingEnv);
+        messager = processingEnv.getMessager();
+        elementUtils = processingEnv.getElementUtils();
+        filer = processingEnv.getFiler();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)
+    {
+        for (TypeElement annotation : annotations) {
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                if (element instanceof TypeElement) {
+                    note("Processing compile-time metadata of %s", element);
+                    export((TypeElement) element);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private void export(TypeElement typeElement)
+    {
+        if (typeElement.getQualifiedName().toString().contains("$swift_docs")) {
+            return;
+        }
+
+        switch (typeElement.getKind()) {
+            case CLASS:
+            case INTERFACE:
+                break;
+            default:
+                warn("Non-class was annotated: %s %s", typeElement.getKind(), typeElement);
+
+                return;
+        }
+
+        FileObject file;
+
+        try {
+            file = filer.createSourceFile(typeElement.getQualifiedName() + "$swift_docs", typeElement);
+        }
+        catch (IOException e) {
+            error("Failed to create %s$swift_docs file", typeElement);
+
+            return;
+        }
+
+        List<String> serviceDocumentation = getComment(typeElement);
+        Map<String, List<String>> methodDocumentation = new LinkedHashMap<>();
+
+        for (Element member : elementUtils.getAllMembers(typeElement)) {
+            if (member instanceof ExecutableElement && isAnnotatedWith(member, "com.facebook.swift.service.ThriftMethod")) {
+                ExecutableElement executableElement = (ExecutableElement) member;
+                String methodName = executableElement.getSimpleName().toString();
+                List<String> methodComment = getComment(member);
+
+                methodDocumentation.put(methodName, methodComment);
+            }
+        }
+
+        try (PrintStream out = new PrintStream(file.openOutputStream())) {
+            // need to do the indexOf() stuff in order to handle nested classes properly
+            String binaryName = elementUtils.getBinaryName(typeElement).toString();
+            String className = binaryName.substring(binaryName.lastIndexOf('.') + 1);
+
+            out.printf("package %s;%n", elementUtils.getPackageOf(typeElement).getQualifiedName());
+            out.println();
+            out.println("import com.facebook.swift.codec.ThriftDocumentation;");
+            out.println();
+
+            if (!serviceDocumentation.isEmpty()) {
+                out.println("@ThriftDocumentation({");
+
+                for (String doc : serviceDocumentation) {
+                    out.printf("    \"%s\",%n", StringEscapeUtils.escapeJava(doc));
+                }
+
+                out.println("})");
+            }
+
+            out.printf("class %s$swift_docs%n", className);
+            out.println("{");
+
+            for (Map.Entry<String, List<String>> entry : methodDocumentation.entrySet()) {
+                String methodName = entry.getKey();
+                List<String> docs = entry.getValue();
+
+                if (!docs.isEmpty()) {
+                    out.println("    @ThriftDocumentation({");
+
+                    for (String doc : docs) {
+                        out.printf("        \"%s\",%n", StringEscapeUtils.escapeJava(doc));
+                    }
+
+                    out.println("    })");
+                }
+
+                out.printf("    private void %s() {}%n", methodName);
+                out.println();
+            }
+
+            out.println("}");
+        }
+        catch (IOException e) {
+            error("Failed to write to %s$swift_docs file", typeElement);
+        }
+    }
+
+    private boolean isAnnotatedWith(Element element, String annotation)
+    {
+        for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+            if (annotation.equals(annotationMirror.getAnnotationType().toString())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private List<String> getComment(Element element)
+    {
+        String docComment = elementUtils.getDocComment(element);
+
+        if (docComment == null) {
+            return Collections.emptyList();
+        }
+
+        if (docComment.startsWith(" ")) {
+            docComment = docComment.substring(1);
+        }
+
+        return Arrays.asList(docComment.split("\n ?"));
+    }
+
+    private void note(String format, Object... args)
+    {
+        log(Diagnostic.Kind.NOTE, format, args);
+    }
+
+    private void warn(String format, Object... args)
+    {
+        log(Diagnostic.Kind.WARNING, format, args);
+    }
+
+    private void error(String format, Object... args)
+    {
+        log(Diagnostic.Kind.ERROR, format, args);
+    }
+
+    private void log(Diagnostic.Kind kind, String format, Object... args)
+    {
+        String message = format;
+
+        if (args.length > 0) {
+            try {
+                message = String.format(format, args);
+            }
+            catch (Exception e) {
+                message = format + ": " + Arrays.asList(args) + " (" + e.getMessage() + ")";
+            }
+        }
+
+        messager.printMessage(kind, message);
+    }
+}

--- a/swift-annotator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/swift-annotator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.facebook.swift.annotator.JavaDocProcessor

--- a/swift-codec/src/main/java/com/facebook/swift/codec/ThriftDocumentation.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/ThriftDocumentation.java
@@ -1,0 +1,17 @@
+package com.facebook.swift.codec;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface ThriftDocumentation
+{
+    String[] value() default {};
+}

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.swift.codec.metadata;
 
+import com.facebook.swift.codec.ThriftDocumentation;
 import com.facebook.swift.codec.ThriftStruct;
 import com.facebook.swift.codec.internal.coercion.DefaultJavaCoercions;
 import com.facebook.swift.codec.internal.coercion.FromThrift;
@@ -359,6 +360,43 @@ public class ThriftCatalog
         return (ThriftStructMetadata<T>) structMetadata;
     }
 
+    public static ImmutableList<String> getThriftDocumentation(Class<?> objectClass)
+    {
+        ThriftDocumentation documentation = objectClass.getAnnotation(ThriftDocumentation.class);
+
+        if (documentation == null) {
+            try {
+                Class<?> swiftDocsClass = objectClass.getClassLoader().loadClass(objectClass.getName() + "$swift_docs");
+
+                documentation = swiftDocsClass.getAnnotation(ThriftDocumentation.class);
+            }
+            catch (ClassNotFoundException e) {
+                // ignored
+            }
+        }
+
+        return documentation == null ? ImmutableList.<String>of() : ImmutableList.copyOf(documentation.value());
+    }
+
+    public static ImmutableList<String> getThriftDocumentation(Method method)
+    {
+        ThriftDocumentation documentation = method.getAnnotation(ThriftDocumentation.class);
+
+        if (documentation == null) {
+            try {
+                Class<?> objectClass = method.getDeclaringClass();
+                Class<?> swiftDocsClass = objectClass.getClassLoader().loadClass(objectClass.getName() + "$swift_docs");
+
+                documentation = swiftDocsClass.getMethod(method.getName()).getAnnotation(ThriftDocumentation.class);
+            }
+            catch (ReflectiveOperationException e) {
+                // ignored
+            }
+        }
+
+        return documentation == null ? ImmutableList.<String>of() : ImmutableList.copyOf(documentation.value());
+    }
+
     private <T> ThriftStructMetadata<T> extractThriftStructMetadata(Class<T> structClass)
     {
         Preconditions.checkNotNull(structClass, "structClass is null");
@@ -390,4 +428,5 @@ public class ThriftCatalog
                     top);
         }
     }
+
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
@@ -37,6 +37,7 @@ public class ThriftStructMetadata<T>
     private final Class<?> builderClass;
     private final ThriftMethodInjection builderMethod;
 
+    private final ImmutableList<String> documentation;
     private final SortedMap<Short, ThriftFieldMetadata> fields;
 
     private final ThriftConstructorInjection constructor;
@@ -47,6 +48,7 @@ public class ThriftStructMetadata<T>
             Class<T> structClass,
             Class<?> builderClass,
             ThriftMethodInjection builderMethod,
+            List<String> documentation,
             List<ThriftFieldMetadata> fields,
             ThriftConstructorInjection constructor,
             List<ThriftMethodInjection> methodInjections)
@@ -56,6 +58,7 @@ public class ThriftStructMetadata<T>
         this.structName = checkNotNull(structName, "structName is null");
         this.structClass = checkNotNull(structClass, "structClass is null");
         this.constructor = checkNotNull(constructor, "constructor is null");
+        this.documentation = ImmutableList.copyOf(checkNotNull(documentation, "documentation is null"));
         this.fields = ImmutableSortedMap.copyOf(uniqueIndex(checkNotNull(fields, "fields is null"), new Function<ThriftFieldMetadata, Short>()
         {
             @Override
@@ -90,6 +93,11 @@ public class ThriftStructMetadata<T>
     public ThriftFieldMetadata getField(int id)
     {
         return fields.get((short) id);
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
     }
 
     public Collection<ThriftFieldMetadata> getFields()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
@@ -69,6 +69,7 @@ public class ThriftStructMetadataBuilder<T>
     private final Class<T> structClass;
     private final Class<?> builderClass;
 
+    private final List<String> documentation;
     private final List<FieldMetadata> fields = newArrayList();
 
     // readers
@@ -96,6 +97,8 @@ public class ThriftStructMetadataBuilder<T>
         structName = extractStructName();
         // get the builder class from the annotation or from the Java class
         builderClass = extractBuilderClass();
+        // grab any documentation from the annotation or saved JavaDocs
+        documentation = ThriftCatalog.getThriftDocumentation(structClass);
         // extract all of the annotated constructor and report an error if
         // there is more than one or none
         // also extract thrift fields from the annotated parameters and verify
@@ -619,6 +622,7 @@ public class ThriftStructMetadataBuilder<T>
                 structClass,
                 builderClass,
                 builderMethodInjection,
+                ImmutableList.copyOf(documentation),
                 ImmutableList.copyOf(fieldsMetadata),
                 constructorInjection,
                 methodInjections

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -52,6 +52,7 @@ public class ThriftMethodMetadata
     private final List<ThriftFieldMetadata> parameters;
     private final Method method;
     private final ImmutableMap<Short, ThriftType> exceptions;
+    private final ImmutableList<String> documentation;
     private final boolean oneway;
 
     public ThriftMethodMetadata(Method method, ThriftCatalog catalog)
@@ -73,6 +74,7 @@ public class ThriftMethodMetadata
             name = thriftMethod.value();
         }
 
+        documentation = ThriftCatalog.getThriftDocumentation(method);
         returnType = catalog.getThriftType(method.getGenericReturnType());
 
         ImmutableList.Builder<ThriftFieldMetadata> builder = ImmutableList.builder();
@@ -147,6 +149,11 @@ public class ThriftMethodMetadata
     public ThriftType getException(short id)
     {
         return exceptions.get(id);
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
     }
 
     public Method getMethod()

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftServiceMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftServiceMetadata.java
@@ -19,6 +19,7 @@ import com.facebook.swift.codec.metadata.ThriftCatalog;
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
@@ -35,6 +36,7 @@ public class ThriftServiceMetadata
 {
     private final String name;
     private final Map<String, ThriftMethodMetadata> methods;
+    private final ImmutableList<String> documentation;
 
     public ThriftServiceMetadata(Class<?> serviceClass, ThriftCatalog catalog)
     {
@@ -47,6 +49,8 @@ public class ThriftServiceMetadata
         else {
             name = thriftService.value();
         }
+
+        documentation = ThriftCatalog.getThriftDocumentation(serviceClass);
 
         ImmutableMap.Builder<String, ThriftMethodMetadata> builder = ImmutableMap.builder();
         for (Method method : findAnnotatedMethods(serviceClass, ThriftMethod.class)) {
@@ -67,6 +71,7 @@ public class ThriftServiceMetadata
             builder.put(method.getName(), method);
         }
         this.methods = builder.build();
+        this.documentation = ImmutableList.of();
     }
 
     public String getName()
@@ -82,6 +87,11 @@ public class ThriftServiceMetadata
     public Map<String, ThriftMethodMetadata> getMethods()
     {
         return methods;
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
     }
 
     public static ThriftService getThriftServiceAnnotation(Class<?> serviceClass)


### PR DESCRIPTION
Adds a ThriftDocumentation annotation that can be applied to services, structs, and methods.  Also introduces a JavaDocProcessor annotation processor that will save javadocs on ThriftService- and ThriftStruct-annotated classes to specially-named mirror classes with ThriftDocumentation annotations, e.g., the javadocs for Foo are saved to Foo$swift_docs.
