### PR TITLE
Proper handling of args with explicit identifiers

### DIFF
--- a/swift-service/src/test/java/com/facebook/swift/service/base/TestSuiteBase.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/base/TestSuiteBase.java
@@ -26,16 +26,16 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
-public class TestSuiteBase<ServiceInterface> {
+public class TestSuiteBase<ServiceInterface, ClientInterface> {
     private ThriftCodecManager codecManager = new ThriftCodecManager();
     private ThriftClientManager clientManager;
-    private Class<? extends ServiceInterface> clientClass;
+    private Class<? extends ClientInterface> clientClass;
     private Class<? extends ServiceInterface> handlerClass;
-    private ServiceInterface client;
+    private ClientInterface client;
     private ThriftServer server;
 
-    public TestSuiteBase(Class<? extends ServiceInterface> handlerClass, Class<? extends ServiceInterface>
-      clientClass) {
+    public TestSuiteBase(Class<? extends ServiceInterface> handlerClass,
+                         Class<? extends ClientInterface> clientClass) {
         this.clientClass = clientClass;
         this.handlerClass = handlerClass;
     }
@@ -69,13 +69,13 @@ public class TestSuiteBase<ServiceInterface> {
         return new ThriftServer(processor);
     }
 
-    private ServiceInterface createClient(ThriftClientManager clientManager) throws
+    private ClientInterface createClient(ThriftClientManager clientManager) throws
       TTransportException {
         HostAndPort address = HostAndPort.fromParts("localhost", server.getPort());
         return clientManager.createClient(address, clientClass);
     }
 
-    protected ServiceInterface getClient() {
+    protected ClientInterface getClient() {
         return client;
     }
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestSuite.java
@@ -20,7 +20,7 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
-public class TestSuite extends TestSuiteBase<TestService> {
+public class TestSuite extends TestSuiteBase<TestService, TestService> {
 
     public TestSuite() {
         super(TestServiceHandler.class, TestServiceClient.class);

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
@@ -1,0 +1,53 @@
+package com.facebook.swift.service.explicitidentifiers;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+import org.apache.thrift.TException;
+
+import java.io.Closeable;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: andrewcox
+ * Date: 9/21/12
+ * Time: 10:01 AM
+ * To change this template use File | Settings | File Templates.
+ */
+@ThriftService
+public interface TestServiceClient extends Closeable
+{
+    public void close();
+
+    @ThriftMethod
+    void explicitParameterOrdering(
+            @ThriftField(value = 30) String stringParam,
+            @ThriftField(value = 10) int integerParam,
+            @ThriftField(value = 20) boolean booleanParam,
+            @ThriftField(value = 40) byte dummy
+    ) throws TException;
+
+    @ThriftMethod
+    public void missingIncomingParameter(
+            @ThriftField(value = 1) int firstParameter
+    ) throws TException;
+
+    @ThriftMethod
+    public void extraIncomingParameter(
+            @ThriftField(value = 1) int firstParameter,
+            @ThriftField(value = 2) String secondParameter
+    ) throws TException;
+
+    @ThriftMethod
+    public void missingAndReorderedParameters(
+            @ThriftField(value = 1) int integerOne,
+            @ThriftField(value = 2) String stringTwo
+    );
+
+    @ThriftMethod
+    public void extraAndReorderedParameters(
+            @ThriftField(value = 1) int integerOne,
+            @ThriftField(value = 2) String stringTwo,
+            @ThriftField(value = 3) boolean booleanTrue
+    );
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
@@ -1,0 +1,55 @@
+package com.facebook.swift.service.explicitidentifiers;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+
+import static org.testng.Assert.*;
+
+@ThriftService
+public class TestServiceHandler
+{
+    @ThriftMethod
+    public void explicitParameterOrdering(
+            @ThriftField(value = 20) boolean booleanParam,
+            @ThriftField(value = 30) String stringParam,
+            @ThriftField(value = 10) int integerParam,
+            @ThriftField(value = 40) byte dummy
+    ) {}
+
+    @ThriftMethod
+    public void missingIncomingParameter(
+            @ThriftField(value = 1) int integerOne,
+            @ThriftField(value = 2) String defaultString
+    ) {
+        assertEquals(integerOne, 1);
+        assertEquals(defaultString, null);
+    }
+
+    @ThriftMethod
+    public void extraIncomingParameter(
+            @ThriftField(value = 1) int integerOne
+    ) {
+        assertEquals(integerOne, 1);
+    }
+
+    @ThriftMethod
+    public void missingAndReorderedParameters(
+            @ThriftField(value = 3) boolean defaultBoolean,
+            @ThriftField(value = 2) String stringTwo,
+            @ThriftField(value = 1) int integerOne
+    ) {
+        assertEquals(integerOne, 1);
+        assertEquals(stringTwo, "2");
+        assertEquals(defaultBoolean, false);
+    }
+
+    @ThriftMethod
+    public void extraAndReorderedParameters(
+            @ThriftField(value = 3) boolean booleanTrue,
+            @ThriftField(value = 2) String stringTwo
+    ) {
+        assertEquals(stringTwo, "2");
+        assertEquals(booleanTrue, true);
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestSuite.java
@@ -1,0 +1,51 @@
+package com.facebook.swift.service.explicitidentifiers;
+
+import com.facebook.swift.service.base.TestSuiteBase;
+import org.apache.thrift.TException;
+import org.testng.annotations.Test;
+
+public class TestSuite extends TestSuiteBase<TestServiceHandler, TestServiceClient>
+{
+    public TestSuite()
+    {
+        super(TestServiceHandler.class, TestServiceClient.class);
+    }
+
+    // Client passes all parameters, but in a different order than the server expects
+    @Test
+    public void testExplicitParameterOrdering()
+            throws TException
+    {
+        getClient().explicitParameterOrdering("STRING", Integer.MAX_VALUE, Boolean.TRUE, Byte.MAX_VALUE);
+    }
+
+    // Client passes only one parameter, server expects two
+    @Test
+    public void testMissingParameter()
+        throws TException
+    {
+        getClient().missingIncomingParameter(1);
+    }
+
+    // Client passes two parameters, server expects only one
+    @Test
+    public void testExtraParameter()
+        throws TException
+    {
+        getClient().extraIncomingParameter(1, "2");
+    }
+
+    // Client passes two parameters in ID order (1,2), server expects three in ID order (3,2,1)
+    @Test
+    public void testMissingAndReorderedParameters()
+    {
+        getClient().missingAndReorderedParameters(1, "2");
+    }
+
+    // Client passes three parameters in ID order (1,2,3), server expects two in ID order (3,2)
+    @Test
+    public void testExtraAndReorderedParameters()
+    {
+        getClient().extraAndReorderedParameters(1, "2", true);
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/TestSuite.java
@@ -20,7 +20,7 @@ import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
 @Test
-public class TestSuite extends TestSuiteBase<TestService> {
+public class TestSuite extends TestSuiteBase<TestService, TestService> {
 
     public TestSuite() {
         super(TestServiceHandler.class, TestServiceClient.class);


### PR DESCRIPTION
Proper handling of args with explicit identifiers, as well as reordered, missing, and extra parameters when comparing client and server views of the thrift interface.
