### PR TITLE
Explicit identifiers

### DIFF
--- a/swift-parent/pom.xml
+++ b/swift-parent/pom.xml
@@ -9,6 +9,7 @@
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
+    <relativePath></relativePath>
   </parent>
 
   <groupId>com.facebook.swift</groupId>

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/TestSuite.java
@@ -20,7 +20,7 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
-public class TestSuite extends TestSuiteBase<TestService> {
+public class TestSuite extends TestSuiteBase<TestService, TestService> {
 
     public TestSuite() {
         super(TestServiceHandler.class, TestServiceClient.class);

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
@@ -1,0 +1,24 @@
+package com.facebook.swift.service.explicitidentifiers;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+@ThriftStruct
+public class CustomArgument
+{
+    public CustomArgument() {
+        this.integerField = 0;
+        this.stringField = null;
+    }
+
+    public CustomArgument(int integerField, String stringField) {
+        this.integerField = integerField;
+        this.stringField = stringField;
+    }
+
+    @ThriftField(value = 1)
+    public int integerField;
+
+    @ThriftField(value = 2)
+    public String stringField;
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
@@ -1,0 +1,55 @@
+package com.facebook.swift.service.explicitidentifiers;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+import org.apache.thrift.TException;
+
+import java.io.Closeable;
+
+@ThriftService
+public interface TestServiceClient extends Closeable
+{
+    public void close();
+
+    @ThriftMethod
+    void explicitParameterOrdering(
+            @ThriftField(value = 30) String stringParam,
+            @ThriftField(value = 10) int integerParam,
+            @ThriftField(value = 20) boolean booleanParam,
+            @ThriftField(value = 40) byte dummy
+    ) throws TException;
+
+    @ThriftMethod
+    public void missingIncomingParameter(
+            @ThriftField(value = 1) int firstParameter
+    ) throws TException;
+
+    @ThriftMethod
+    public void extraIncomingParameter(
+            @ThriftField(value = 1) int firstParameter,
+            @ThriftField(value = 2) String secondParameter
+    ) throws TException;
+
+    @ThriftMethod
+    public void missingAndReorderedParameters(
+            @ThriftField(value = 1) int integerOne,
+            @ThriftField(value = 2) String stringTwo
+    );
+
+    @ThriftMethod
+    public void extraAndReorderedParameters(
+            @ThriftField(value = 1) int integerOne,
+            @ThriftField(value = 2) String stringTwo,
+            @ThriftField(value = 3) boolean booleanTrue
+    );
+
+    @ThriftMethod
+    public void missingInteger();
+
+    @ThriftMethod
+    public void missingStruct();
+
+    @ThriftMethod
+    public void extraStruct(CustomArgument customArgument);
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
@@ -1,0 +1,176 @@
+package com.facebook.swift.service.explicitidentifiers;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+import com.google.common.base.Optional;
+
+import static org.testng.Assert.*;
+
+@ThriftService
+public class TestServiceHandler
+{
+    private Object lastStringParam;
+    private Object lastBooleanParam;
+    private Object lastIntegerParam;
+    private Object lastByteParam;
+    private Object lastCustomParam;
+
+    private void initializeLastParamValues() {
+        this.lastBooleanParam = null;
+        this.lastStringParam = null;
+        this.lastByteParam = null;
+        this.lastCustomParam = null;
+        this.lastIntegerParam = null;
+    }
+
+    @ThriftMethod
+    public void explicitParameterOrdering(
+            @ThriftField(value = 20) boolean booleanParam,
+            @ThriftField(value = 30) String stringParam,
+            @ThriftField(value = 10) int integerParam,
+            @ThriftField(value = 40) byte byteParam
+    ) {
+        initializeLastParamValues();
+        this.lastBooleanParam = Optional.of(booleanParam);
+        this.lastIntegerParam = Optional.of(integerParam);
+        this.lastByteParam = Optional.of(byteParam);
+        this.lastStringParam = Optional.fromNullable(stringParam);
+    }
+
+    @ThriftMethod
+    public void missingIncomingParameter(
+            @ThriftField(value = 1) int integerParam,
+            @ThriftField(value = 2) String stringParam
+    ) {
+        initializeLastParamValues();
+        this.lastIntegerParam = Optional.of(integerParam);
+        this.lastStringParam = Optional.fromNullable(stringParam);
+    }
+
+    @ThriftMethod
+    public void extraIncomingParameter(
+            @ThriftField(value = 1) int integerParam
+    ) {
+        initializeLastParamValues();
+        this.lastIntegerParam = Optional.of(integerParam);
+    }
+
+    @ThriftMethod
+    public void missingAndReorderedParameters(
+            @ThriftField(value = 3) boolean booleanParam,
+            @ThriftField(value = 2) String stringParam,
+            @ThriftField(value = 1) int integerParam
+    ) {
+        initializeLastParamValues();
+        this.lastBooleanParam = Optional.of(booleanParam);
+        this.lastIntegerParam = Optional.of(integerParam);
+        this.lastStringParam = Optional.fromNullable(stringParam);
+    }
+
+    @ThriftMethod
+    public void extraAndReorderedParameters(
+            @ThriftField(value = 3) boolean booleanParam,
+            @ThriftField(value = 2) String stringParam
+    ) {
+        initializeLastParamValues();
+        this.lastBooleanParam = Optional.of(booleanParam);
+        this.lastStringParam = Optional.fromNullable(stringParam);
+    }
+
+    @ThriftMethod
+    public void missingInteger(
+            @ThriftField(value = 1) int integerParam
+    ) {
+        initializeLastParamValues();
+        this.lastIntegerParam = Optional.of(integerParam);
+    }
+
+    @ThriftMethod
+    public void missingStruct(
+            @ThriftField(value = 1) CustomArgument customParam
+    ) {
+        initializeLastParamValues();
+        this.lastCustomParam = Optional.fromNullable(customParam);
+    }
+
+    @ThriftMethod
+    public void extraStruct() {
+        initializeLastParamValues();
+    }
+
+    public boolean hasLastBooleanParam()
+    {
+        return lastBooleanParam != null;
+    }
+
+    public boolean hasLastStringParam()
+    {
+        return lastStringParam != null;
+    }
+
+    public boolean hasLastIntegerParam()
+    {
+        return lastIntegerParam != null;
+    }
+
+    public boolean hasLastByteParam()
+    {
+        return lastByteParam != null;
+    }
+
+    public boolean hasLastCustomParam()
+    {
+        return lastCustomParam != null;
+    }
+
+    public Optional<Boolean> getLastBooleanParam()
+    {
+        return (Optional<Boolean>)lastBooleanParam;
+    }
+
+    public Optional<String> getLastStringParam()
+    {
+        return (Optional<String>)lastStringParam;
+    }
+
+    public Optional<Integer> getLastIntegerParam()
+    {
+        return (Optional<Integer>)lastIntegerParam;
+    }
+
+    public Optional<Byte> getLastByteParam()
+    {
+        return (Optional<Byte>)lastByteParam;
+    }
+
+    public Optional<CustomArgument> getLastCustomParam()
+    {
+        return ((Optional<CustomArgument>)lastCustomParam);
+    }
+
+    public void setLastBooleanParam(boolean lastBooleanParam)
+    {
+        this.lastBooleanParam = Optional.of(lastBooleanParam);
+    }
+
+    public void setLastIntegerParam(int lastIntegerParam)
+    {
+        this.lastIntegerParam = Optional.of(lastIntegerParam);
+    }
+
+    public void setLastByteParam(byte lastByteParam)
+    {
+        this.lastByteParam = Optional.of(lastByteParam);
+    }
+
+    public void setLastStringParam(String lastStringParam)
+    {
+        this.lastStringParam = Optional.fromNullable(lastStringParam);
+    }
+
+    public void setLastCustomParam(CustomArgument lastCustomParam)
+    {
+        this.lastCustomParam = Optional.fromNullable(lastCustomParam);
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestSuite.java
@@ -1,0 +1,157 @@
+package com.facebook.swift.service.explicitidentifiers;
+
+import com.facebook.swift.service.base.TestSuiteBase;
+import org.apache.thrift.TException;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestSuite extends TestSuiteBase<TestServiceHandler, TestServiceClient>
+{
+    public TestSuite()
+    {
+        super(TestServiceHandler.class, TestServiceClient.class);
+    }
+
+    // Client passes all parameters, but in a different order than the server expects
+    @Test
+    public void testExplicitParameterOrdering()
+            throws TException
+    {
+        int integerParam = Integer.MAX_VALUE;
+        byte byteParam = Byte.MAX_VALUE;
+        Boolean booleanParam = Boolean.TRUE;
+
+        getClient().explicitParameterOrdering("STRING", integerParam, booleanParam, byteParam);
+
+        assertEquals(getHandler().getLastIntegerParam().get(), (Integer) integerParam);
+        assertEquals(getHandler().getLastBooleanParam().get(), booleanParam);
+        assertEquals(getHandler().getLastByteParam().get(), (Byte) byteParam);
+        assertEquals(getHandler().getLastStringParam().get(), "STRING");
+
+        // other params are not sent or received
+        assertFalse(getHandler().hasLastCustomParam());
+    }
+
+    // Client passes only one parameter, server expects two
+    @Test
+    public void testMissingParameter()
+        throws TException
+    {
+        getClient().missingIncomingParameter(1);
+
+        assertEquals(getHandler().getLastIntegerParam().get(), (Integer) 1);
+
+        // integer should be received by the handler
+        assertEquals(getHandler().getLastIntegerParam().get(), (Integer) 1);
+
+        // string is not passed, so thrift will fill in the default value for the handler
+        assertFalse(getHandler().getLastStringParam().isPresent());
+
+        // other params are neither sent nor received
+        assertFalse(getHandler().hasLastBooleanParam());
+        assertFalse(getHandler().hasLastByteParam());
+        assertFalse(getHandler().hasLastCustomParam());
+    }
+
+    // Client passes two parameters, server expects only one
+    @Test
+    public void testExtraParameter()
+        throws TException
+    {
+        getClient().extraIncomingParameter(1, "2");
+
+        // integer should be received by handler
+        assertEquals(getHandler().getLastIntegerParam().get(), (Integer) 1);
+
+        // string is an extra that is sent, but not received by handler
+        assertFalse(getHandler().hasLastStringParam());
+
+        // other params are not sent or received
+        assertFalse(getHandler().hasLastBooleanParam());
+        assertFalse(getHandler().hasLastByteParam());
+        assertFalse(getHandler().hasLastCustomParam());
+    }
+
+    // Client passes two parameters in ID order (1,2), server expects three in ID order (3,2,1)
+    @Test
+    public void testMissingAndReorderedParameters()
+    {
+        getClient().missingAndReorderedParameters(1, "2");
+
+        // integer and string should be received by handler
+        assertEquals(getHandler().getLastIntegerParam().get(), (Integer) 1);
+        assertEquals(getHandler().getLastStringParam().get(), "2");
+
+        // bool is not sent, so thrift will fill in the default value for the handler
+        assertEquals(getHandler().getLastBooleanParam().get(), Boolean.FALSE);
+
+        // other params are not sent or received
+        assertFalse(getHandler().hasLastByteParam());
+        assertFalse(getHandler().hasLastCustomParam());
+    }
+
+    // Client passes three parameters in ID order (1,2,3), server expects two in ID order (3,2)
+    @Test
+    public void testExtraAndReorderedParameters()
+    {
+        getClient().extraAndReorderedParameters(1, "2", true);
+
+        // bool and string should be received by handler
+        assertEquals(getHandler().getLastStringParam().get(), "2");
+        assertEquals(getHandler().getLastBooleanParam().get(), Boolean.TRUE);
+
+        // integer is an extra param that is sent, but not received by handler
+        assertFalse(getHandler().hasLastIntegerParam());
+
+        // other params are not sent or received
+        assertFalse(getHandler().hasLastByteParam());
+        assertFalse(getHandler().hasLastCustomParam());
+    }
+
+    @Test
+    public void testMissingInteger()
+    {
+        getClient().missingInteger();
+
+        // int is not sent, but is synthesized by thrift to the default value (0)
+        assertEquals(getHandler().getLastIntegerParam().get(), (Integer) 0);
+
+        // other params are not sent or received
+        assertFalse(getHandler().hasLastByteParam());
+        assertFalse(getHandler().hasLastCustomParam());
+        assertFalse(getHandler().hasLastStringParam());
+        assertFalse(getHandler().hasLastBooleanParam());
+    }
+
+    @Test
+    public void testMissingStruct()
+    {
+        getClient().missingStruct();
+
+        // struct is not sent, but is synthesized by thrift to the default value (null)
+        assertFalse(getHandler().getLastCustomParam().isPresent());
+
+        // other params are not sent or received
+        assertFalse(getHandler().hasLastByteParam());
+        assertFalse(getHandler().hasLastStringParam());
+        assertFalse(getHandler().hasLastIntegerParam());
+        assertFalse(getHandler().hasLastBooleanParam());
+    }
+
+    @Test
+    public void testExtraStruct()
+    {
+        getClient().extraStruct(new CustomArgument(1, "2"));
+
+        // struct is sent, but is not received by the handler
+        assertFalse(getHandler().hasLastCustomParam());
+
+        // other params are not sent or received
+        assertFalse(getHandler().hasLastByteParam());
+        assertFalse(getHandler().hasLastStringParam());
+        assertFalse(getHandler().hasLastIntegerParam());
+        assertFalse(getHandler().hasLastBooleanParam());
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/TestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/TestSuite.java
@@ -20,7 +20,7 @@ import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
 @Test
-public class TestSuite extends TestSuiteBase<TestService> {
+public class TestSuite extends TestSuiteBase<TestService, TestService> {
 
     public TestSuite() {
         super(TestServiceHandler.class, TestServiceClient.class);


### PR DESCRIPTION
Second take, updated based on Martin's feedback.

Proper handling of args with explicit identifiers, as well as reordered, missing, and extra parameters when comparing client and server views of the thrift interface.
