### PR TITLE
expose maxFrameSize for NiftyClient in ThriftClientManager

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -74,10 +74,21 @@ public class ThriftClientManager implements Closeable
         this(new ThriftCodecManager());
     }
 
+    public ThriftClientManager(int maxFrameSize)
+    {
+      this(new ThriftCodecManager(), maxFrameSize);
+    }
+
     public ThriftClientManager(ThriftCodecManager codecManager)
     {
         this.codecManager = codecManager;
         niftyClient = new NiftyClient();
+    }
+
+    public ThriftClientManager(ThriftCodecManager codecManager, int maxFrameSize)
+    {
+      this.codecManager = codecManager;
+      niftyClient = new NiftyClient(maxFrameSize);
     }
 
     public <T> T createClient(HostAndPort address, Class<T> type)

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientManagerProvider.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientManagerProvider.java
@@ -1,0 +1,27 @@
+package com.facebook.swift.service.guice;
+
+import com.facebook.swift.service.ThriftClientManager;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+
+public class ThriftClientManagerProvider implements Provider<ThriftClientManager>
+{
+    private Integer maxFrameSize;
+
+    @Inject(optional = true)
+    public void setMaxFrameSize(@Named("thrift_client_max_frame_size") Integer maxFrameSize)
+    {
+        this.maxFrameSize = maxFrameSize;
+    }
+
+    @Override
+    public ThriftClientManager get()
+    {
+        if (maxFrameSize == null) {
+            return new ThriftClientManager();
+        }
+
+        return new ThriftClientManager(maxFrameSize);
+    }
+}

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
@@ -43,7 +43,7 @@ public class ThriftClientModule implements Module
     public void configure(Binder binder)
     {
         // Bind single shared ThriftClientManager
-        binder.bind(ThriftClientManager.class).in(Scopes.SINGLETON);
+        binder.bind(ThriftClientManager.class).toProvider(ThriftClientManagerProvider.class).in(Scopes.SINGLETON);
 
         // We bind the ThriftClientProviderProviders in a Set so below we can export the thrift methods to JMX
         newSetBinder(binder, ThriftClientProviderProvider.class).permitDuplicates();


### PR DESCRIPTION
Allow tuning maxFrameSize as required, to avoid a TooLongFrameException 
