### PR TITLE
Add support for HTTP and unframed clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <dep.airlift.version>0.67-SNAPSHOT</dep.airlift.version>
     <dep.slf4j.version>1.7.2</dep.slf4j.version>
     <dep.logback.version>1.0.7</dep.logback.version>
-    <dep.nifty.version>0.0.2</dep.nifty.version>
+    <dep.nifty.version>0.0.3-SNAPSHOT</dep.nifty.version>
   </properties>
 
   <dependencyManagement>

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestBytecodeReaderParanamer.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestBytecodeReaderParanamer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.codec.metadata;
 
 import org.testng.Assert;

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AbstractClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AbstractClientWorker.java
@@ -29,7 +29,9 @@ public abstract class AbstractClientWorker implements Runnable
     protected AtomicLong requestsFailed = new AtomicLong(0);
     protected AtomicLong requestsPending = new AtomicLong(0);
 
-    public AbstractClientWorker(ThriftClientManager clientManager, LoadGeneratorCommandLineConfig config)
+    public AbstractClientWorker(
+            ThriftClientManager clientManager,
+            LoadGeneratorCommandLineConfig config)
     {
         this.clientManager = clientManager;
         this.config = config;
@@ -51,8 +53,8 @@ public abstract class AbstractClientWorker implements Runnable
         return config.operationsPerConnection;
     }
 
-    public void bump() {
-
+    public void reconnect()
+    {
     }
 
     public abstract void shutdown();

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AsyncClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AsyncClientWorker.java
@@ -15,11 +15,7 @@
  */
 package com.facebook.swift.perf.loadgenerator;
 
-import com.facebook.nifty.client.FramedClientChannel;
-import com.facebook.nifty.client.HttpClientChannel;
-import com.facebook.nifty.client.NiftyClient;
 import com.facebook.nifty.client.NiftyClientChannel;
-import com.facebook.nifty.client.UnframedClientChannel;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
@@ -49,6 +45,7 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
     private final long pendingOperationsHighWaterMark;
     private final Executor simpleExecutor;
     private NiftyClientChannel channel;
+    private NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory;
     private LoadTest client;
 
     @Override
@@ -68,9 +65,13 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
     }
 
     @Inject
-    public AsyncClientWorker(final LoadGeneratorCommandLineConfig config, ThriftClientManager clientManager)
+    public AsyncClientWorker(LoadGeneratorCommandLineConfig config,
+                             ThriftClientManager clientManager,
+                             NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory)
     {
         super(clientManager, config);
+
+        this.channelFactory = channelFactory;
 
         // Keep the pipe full with between target and target * 2 operations
         pendingOperationsLowWaterMark = max(config.targetAsyncOperationsPending * 9 / 10, 1);
@@ -93,15 +94,6 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
     {
         try {
             ListenableFuture<LoadTest> clientFuture;
-
-            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory;
-            if (config.transport == TransportType.FRAMED) {
-                channelFactory = new FramedClientChannel.Factory();
-            } else if (config.transport == TransportType.UNFRAMED) {
-                channelFactory = new UnframedClientChannel.Factory();
-            } else {
-                throw new IllegalStateException("Unknown transport");
-            }
 
             clientFuture = clientManager.createClient(HostAndPort.fromParts(config.serverAddress, config.serverPort),
                                                       LoadTest.class,

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AsyncClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AsyncClientWorker.java
@@ -59,15 +59,16 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
     {
         @ThriftMethod
         public ListenableFuture<Void> noop()
-            throws TException;
+                throws TException;
 
         public void close();
     }
 
     @Inject
-    public AsyncClientWorker(LoadGeneratorCommandLineConfig config,
-                             ThriftClientManager clientManager,
-                             NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory)
+    public AsyncClientWorker(
+            LoadGeneratorCommandLineConfig config,
+            ThriftClientManager clientManager,
+            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory)
     {
         super(clientManager, config);
 
@@ -123,17 +124,19 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
                         @Override
                         public void run()
                         {
-                        fillRequestPipeline(client);
+                            fillRequestPipeline(client);
                         }
                     });
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable t)
+                {
                     onConnectFailed(t);
                 }
             });
-        } catch (Throwable t) {
+        }
+        catch (Throwable t) {
             onConnectFailed(t);
         }
     }
@@ -149,7 +152,7 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
     }
 
     @Override
-    public void bump()
+    public void reconnect()
     {
         if (client != null) {
             client.close();
@@ -167,7 +170,8 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
         return pending;
     }
 
-    protected void fillRequestPipeline(final LoadTest client) {
+    protected void fillRequestPipeline(final LoadTest client)
+    {
         try {
             while (!shutdownRequested) {
                 if (channel.hasError()) {

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AsyncClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AsyncClientWorker.java
@@ -15,7 +15,11 @@
  */
 package com.facebook.swift.perf.loadgenerator;
 
+import com.facebook.nifty.client.FramedClientChannel;
+import com.facebook.nifty.client.HttpClientChannel;
+import com.facebook.nifty.client.NiftyClient;
 import com.facebook.nifty.client.NiftyClientChannel;
+import com.facebook.nifty.client.UnframedClientChannel;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
@@ -89,8 +93,19 @@ public final class AsyncClientWorker extends AbstractClientWorker implements Fut
     {
         try {
             ListenableFuture<LoadTest> clientFuture;
+
+            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory;
+            if (config.transport == TransportType.FRAMED) {
+                channelFactory = new FramedClientChannel.Factory();
+            } else if (config.transport == TransportType.UNFRAMED) {
+                channelFactory = new UnframedClientChannel.Factory();
+            } else {
+                throw new IllegalStateException("Unknown transport");
+            }
+
             clientFuture = clientManager.createClient(HostAndPort.fromParts(config.serverAddress, config.serverPort),
                                                       LoadTest.class,
+                                                      channelFactory,
                                                       new Duration(config.connectTimeoutMilliseconds, TimeUnit.SECONDS),
                                                       new Duration(config.sendTimeoutMilliseconds, TimeUnit.MILLISECONDS),
                                                       new Duration(config.receiveTimeoutMilliseconds, TimeUnit.MILLISECONDS),

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
@@ -16,6 +16,9 @@
 package com.facebook.swift.perf.loadgenerator;
 
 import com.beust.jcommander.JCommander;
+import com.facebook.nifty.client.FramedClientChannel;
+import com.facebook.nifty.client.NiftyClientChannel;
+import com.facebook.nifty.client.UnframedClientChannel;
 import com.facebook.swift.codec.guice.ThriftCodecModule;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.guice.ThriftClientModule;
@@ -28,6 +31,7 @@ import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
+import com.google.inject.TypeLiteral;
 import com.proofpoint.bootstrap.LifeCycleManager;
 import com.proofpoint.bootstrap.LifeCycleModule;
 import io.airlift.configuration.ConfigurationFactory;
@@ -77,6 +81,18 @@ public class LoadGenerator
                                 binder.bind(AbstractClientWorker.class).to(SyncClientWorker.class);
                             } else {
                                 binder.bind(AbstractClientWorker.class).to(AsyncClientWorker.class);
+                            }
+
+                            TypeLiteral<NiftyClientChannel.Factory<? extends NiftyClientChannel>> channelFactoryType =
+                                    new TypeLiteral<NiftyClientChannel.Factory<? extends NiftyClientChannel>>() {};
+                            if (config.transport == TransportType.FRAMED) {
+                                binder.bind(channelFactoryType)
+                                      .to(FramedClientChannel.Factory.class);
+                            } else if (config.transport == TransportType.UNFRAMED) {
+                                binder.bind(channelFactoryType)
+                                      .to(UnframedClientChannel.Factory.class);
+                            } else {
+                                throw new IllegalStateException("Unknown transport");
                             }
                         }
                     }

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
@@ -85,14 +85,17 @@ public class LoadGenerator
 
                             TypeLiteral<NiftyClientChannel.Factory<? extends NiftyClientChannel>> channelFactoryType =
                                     new TypeLiteral<NiftyClientChannel.Factory<? extends NiftyClientChannel>>() {};
-                            if (config.transport == TransportType.FRAMED) {
-                                binder.bind(channelFactoryType)
-                                      .to(FramedClientChannel.Factory.class);
-                            } else if (config.transport == TransportType.UNFRAMED) {
-                                binder.bind(channelFactoryType)
-                                      .to(UnframedClientChannel.Factory.class);
-                            } else {
-                                throw new IllegalStateException("Unknown transport");
+                            switch (config.transport) {
+                                case FRAMED:
+                                    binder.bind(channelFactoryType)
+                                          .to(FramedClientChannel.Factory.class);
+                                    break;
+                                case UNFRAMED:
+                                    binder.bind(channelFactoryType)
+                                          .to(UnframedClientChannel.Factory.class);
+                                    break;
+                                default:
+                                    throw new IllegalStateException("Unknown transport");
                             }
                         }
                     }

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
@@ -102,9 +102,11 @@ public class LoadGenerator
     }
 
     @Inject
-    public LoadGenerator(LoadGeneratorCommandLineConfig config,
-                         Provider<AbstractClientWorker> clientWorkerProvider,
-                         ThriftClientManager clientManager) {
+    public LoadGenerator(
+            LoadGeneratorCommandLineConfig config,
+            Provider<AbstractClientWorker> clientWorkerProvider,
+            ThriftClientManager clientManager)
+    {
         this.config = config;
         this.clientWorkerProvider = clientWorkerProvider;
         this.clientManager = clientManager;
@@ -130,7 +132,8 @@ public class LoadGenerator
     }
 
     @PreDestroy
-    public void stop() {
+    public void stop()
+    {
         for (AbstractClientWorker worker : clientWorkers) {
             worker.shutdown();
         }

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGeneratorCommandLineConfig.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGeneratorCommandLineConfig.java
@@ -30,6 +30,9 @@ public class LoadGeneratorCommandLineConfig
     @Parameter(names = "-port", description = "Port number of load test server")
     public int serverPort = 1234;
 
+    @Parameter(names = "-transport", description = "Type of Thrift transport to use for connecting")
+    public TransportType transport = TransportType.FRAMED;
+
     @Parameter(names = "-num_threads", description = "Number of workers to create")
     public int numThreads = 1;
 

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadStatsThread.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadStatsThread.java
@@ -54,7 +54,8 @@ public class LoadStatsThread extends Thread
                     long workerOpsFailed = worker.collectFailedOperationCount();
 
                     if (workerOpsCompleted + workerOpsFailed == 0) {
-                        worker.bump();
+                        // No work was completed, so try reconnecting
+                        worker.reconnect();
                     }
 
                     deltaSuccessfulOperations += workerOpsCompleted;
@@ -72,13 +73,15 @@ public class LoadStatsThread extends Thread
                         " Total failed: " + failedOperations);
 
                 lastTime = currentTime;
-            } catch (InterruptedException e) {
+            }
+            catch (InterruptedException e) {
                 logger.error("Stats thread was interrupted");
             }
         }
     }
 
-    public void shutdown() {
+    public void shutdown()
+    {
         shutdown = true;
     }
 }

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/SyncClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/SyncClientWorker.java
@@ -50,9 +50,10 @@ public class SyncClientWorker extends AbstractClientWorker
     }
 
     @Inject
-    public SyncClientWorker(LoadGeneratorCommandLineConfig config,
-                            ThriftClientManager clientManager,
-                            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory)
+    public SyncClientWorker(
+            LoadGeneratorCommandLineConfig config,
+            ThriftClientManager clientManager,
+            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory)
     {
         super(clientManager, config);
         this.channelFactory = channelFactory;
@@ -89,7 +90,8 @@ public class SyncClientWorker extends AbstractClientWorker
     {
         try {
             client.noop();
-        } catch (TException ex) {
+        }
+        catch (TException ex) {
             requestsFailed.incrementAndGet();
             return;
         }

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/SyncClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/SyncClientWorker.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutionException;
 
 public class SyncClientWorker extends AbstractClientWorker
 {
-    private static final Logger logger = LoggerFactory.getLogger(AsyncClientWorker.class);
+    private static final Logger logger = LoggerFactory.getLogger(SyncClientWorker.class);
     private volatile boolean shutdownRequested = false;
 
     @Override

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/TransportType.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/TransportType.java
@@ -1,0 +1,7 @@
+package com.facebook.swift.perf.loadgenerator;
+
+public enum TransportType
+{
+    FRAMED,
+    UNFRAMED,
+}

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/TransportType.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/TransportType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.perf.loadgenerator;
 
 public enum TransportType

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -16,6 +16,10 @@
   <name>${project.artifactId}</name>
   <description>Annotation based encoder and decoder for Thrift</description>
 
+  <properties>
+    <dep.jetty.version>8.0.3.v20111011</dep.jetty.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.facebook.swift</groupId>
@@ -123,21 +127,33 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>8.0.3.v20111011</version>
+      <version>${dep.jetty.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.0.3.v20111011</version>
+      <version>${dep.jetty.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>3.0.20100224</version>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -119,5 +119,26 @@
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>8.0.3.v20111011</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>8.0.3.v20111011</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>3.0.20100224</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClient.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClient.java
@@ -22,10 +22,7 @@ import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import io.airlift.units.Duration;
-import org.apache.thrift.transport.TTransportException;
 import org.weakref.jmx.Managed;
-
-import java.util.concurrent.ExecutionException;
 
 public class ThriftClient<T>
 {
@@ -45,19 +42,21 @@ public class ThriftClient<T>
         this(clientManager, clientType, new ThriftClientConfig(), ThriftClientManager.DEFAULT_NAME);
     }
 
-    public ThriftClient(ThriftClientManager clientManager,
-                        Class<T> clientType,
-                        ThriftClientConfig clientConfig,
-                        String clientName)
+    public ThriftClient(
+            ThriftClientManager clientManager,
+            Class<T> clientType,
+            ThriftClientConfig clientConfig,
+            String clientName)
     {
         this(clientManager, clientType, defaultChannelFactory, clientConfig, clientName);
     }
 
-    public ThriftClient(ThriftClientManager clientManager,
-                        Class<T> clientType,
-                        NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory,
-                        ThriftClientConfig clientConfig,
-                        String clientName)
+    public ThriftClient(
+            ThriftClientManager clientManager,
+            Class<T> clientType,
+            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory,
+            ThriftClientConfig clientConfig,
+            String clientName)
     {
         Preconditions.checkNotNull(clientManager, "clientManager is null");
         Preconditions.checkNotNull(clientType, "clientInterface is null");
@@ -126,6 +125,6 @@ public class ThriftClient<T>
 
     public T open(NiftyClientChannel channel)
     {
-      return clientManager.createClient(channel, clientType, clientName);
+        return clientManager.createClient(channel, clientType, clientName);
     }
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClient.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClient.java
@@ -48,15 +48,15 @@ public class ThriftClient<T>
             ThriftClientConfig clientConfig,
             String clientName)
     {
-        this(clientManager, clientType, defaultChannelFactory, clientConfig, clientName);
+        this(clientManager, clientType, clientConfig, clientName, defaultChannelFactory);
     }
 
     public ThriftClient(
             ThriftClientManager clientManager,
             Class<T> clientType,
-            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory,
             ThriftClientConfig clientConfig,
-            String clientName)
+            String clientName,
+            NiftyClientChannel.Factory<? extends NiftyClientChannel> channelFactory)
     {
         Preconditions.checkNotNull(clientManager, "clientManager is null");
         Preconditions.checkNotNull(clientType, "clientInterface is null");

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClient.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClient.java
@@ -113,7 +113,6 @@ public class ThriftClient<T>
     }
 
     public ListenableFuture<T> open(HostAndPort address)
-            throws TTransportException, InterruptedException, ExecutionException
     {
         return clientManager.createClient(address,
                                           clientType,
@@ -126,7 +125,6 @@ public class ThriftClient<T>
     }
 
     public T open(NiftyClientChannel channel)
-            throws TTransportException, InterruptedException
     {
       return clientManager.createClient(channel, clientType, clientName);
     }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -40,16 +40,16 @@ import org.apache.thrift.protocol.TProtocolException;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TTransportException;
 
-import javax.annotation.PreDestroy;
-import javax.annotation.concurrent.Immutable;
 import java.io.Closeable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.Immutable;
 
 import static com.facebook.swift.service.ThriftClientConfig.DEFAULT_CONNECT_TIMEOUT;
 import static com.facebook.swift.service.ThriftClientConfig.DEFAULT_READ_TIMEOUT;
@@ -81,7 +81,7 @@ public class ThriftClientManager implements Closeable
 
     public ThriftClientManager(int maxFrameSize)
     {
-      this(new ThriftCodecManager(), maxFrameSize);
+        this(new ThriftCodecManager(), maxFrameSize);
     }
 
     public ThriftClientManager(ThriftCodecManager codecManager)
@@ -92,8 +92,8 @@ public class ThriftClientManager implements Closeable
 
     public ThriftClientManager(ThriftCodecManager codecManager, int maxFrameSize)
     {
-      this.codecManager = codecManager;
-      niftyClient = new NiftyClient(maxFrameSize);
+        this.codecManager = codecManager;
+        niftyClient = new NiftyClient(maxFrameSize);
     }
 
     public <T> ListenableFuture<T> createClient(HostAndPort address, Class<T> type)
@@ -102,10 +102,10 @@ public class ThriftClientManager implements Closeable
         return createClient(address, type, channelFactory);
     }
 
-    public <T, C extends NiftyClientChannel>
-    ListenableFuture<T> createClient(HostAndPort address,
-                                     Class<T> type,
-                                     NiftyClientChannel.Factory<C> channelFactory)
+    public <T, C extends NiftyClientChannel> ListenableFuture<T> createClient(
+            HostAndPort address,
+            Class<T> type,
+            NiftyClientChannel.Factory<C> channelFactory)
     {
         return createClient(address,
                             type,
@@ -117,15 +117,15 @@ public class ThriftClientManager implements Closeable
                             null);
     }
 
-    public <T, C extends NiftyClientChannel>
-    ListenableFuture<T> createClient(final HostAndPort address,
-                                     final Class<T> type,
-                                     final NiftyClientChannel.Factory<C> channelFactory,
-                                     final Duration connectTimeout,
-                                     final Duration readTimeout,
-                                     final Duration writeTimeout,
-                                     final String clientName,
-                                     HostAndPort socksProxy)
+    public <T, C extends NiftyClientChannel> ListenableFuture<T> createClient(
+            final HostAndPort address,
+            final Class<T> type,
+            final NiftyClientChannel.Factory<C> channelFactory,
+            final Duration connectTimeout,
+            final Duration readTimeout,
+            final Duration writeTimeout,
+            final String clientName,
+            HostAndPort socksProxy)
     {
         NiftyClientChannel channel = null;
         try {
@@ -219,7 +219,8 @@ public class ThriftClientManager implements Closeable
             InvocationHandler genericHandler = Proxy.getInvocationHandler(client);
             ThriftInvocationHandler thriftHandler = ThriftInvocationHandler.class.cast(genericHandler);
             return thriftHandler.getChannel();
-        } catch (ClassCastException e) {
+        }
+        catch (ClassCastException e) {
             throw new IllegalArgumentException("Not a swift client object", e);
         }
     }
@@ -232,7 +233,10 @@ public class ThriftClientManager implements Closeable
         private final ThriftServiceMetadata thriftServiceMetadata;
         private final Map<Method, ThriftMethodHandler> methodHandlers;
 
-        private ThriftClientMetadata(Class<?> clientType, String clientName, ThriftCodecManager codecManager)
+        private ThriftClientMetadata(
+                Class<?> clientType,
+                String clientName,
+                ThriftCodecManager codecManager)
         {
             Preconditions.checkNotNull(clientType, "clientType is null");
             Preconditions.checkNotNull(clientName, "clientName is null");
@@ -281,11 +285,11 @@ public class ThriftClientManager implements Closeable
 
         private final Map<Method, ThriftMethodHandler> methods;
         private final AtomicInteger sequenceId = new AtomicInteger(1);
+
         private ThriftInvocationHandler(
                 String clientDescription,
                 NiftyClientChannel channel,
-                Map<Method, ThriftMethodHandler> methods
-        )
+                Map<Method, ThriftMethodHandler> methods)
         {
             this.clientDescription = clientDescription;
             this.channel = channel;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -99,32 +99,51 @@ public class ThriftClientManager implements Closeable
     public <T> ListenableFuture<T> createClient(HostAndPort address, Class<T> type)
             throws TTransportException, InterruptedException, ExecutionException
     {
-        return createClient(address, type, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_WRITE_TIMEOUT, DEFAULT_NAME, null);
+        FramedClientChannel.Factory channelFactory = new FramedClientChannel.Factory();
+        return createClient(address, type, channelFactory);
     }
 
-    public <T> ListenableFuture<T> createClient(final HostAndPort address,
-                                                final Class<T> type,
-                                                final Duration connectTimeout,
-                                                final Duration readTimeout,
-                                                final Duration writeTimeout,
-                                                final String clientName,
-                                                HostAndPort socksProxy)
+    public <T, C extends NiftyClientChannel>
+    ListenableFuture<T> createClient(HostAndPort address,
+                                     Class<T> type,
+                                     NiftyClientChannel.Factory<C> channelFactory)
+            throws TTransportException, InterruptedException, ExecutionException
+    {
+        return createClient(address,
+                            type,
+                            channelFactory,
+                            DEFAULT_CONNECT_TIMEOUT,
+                            DEFAULT_READ_TIMEOUT,
+                            DEFAULT_WRITE_TIMEOUT,
+                            DEFAULT_NAME,
+                            null);
+    }
+
+    public <T, C extends NiftyClientChannel>
+    ListenableFuture<T> createClient(final HostAndPort address,
+                                     final Class<T> type,
+                                     final NiftyClientChannel.Factory<C> channelFactory,
+                                     final Duration connectTimeout,
+                                     final Duration readTimeout,
+                                     final Duration writeTimeout,
+                                     final String clientName,
+                                     HostAndPort socksProxy)
             throws TTransportException, InterruptedException
     {
         NiftyClientChannel channel = null;
         try {
             final SettableFuture<T> clientFuture = SettableFuture.create();
-            ListenableFuture<FramedClientChannel> connectFuture =
-                    niftyClient.connectAsync(new FramedClientChannel.Factory(),
+            ListenableFuture<C> connectFuture =
+                    niftyClient.connectAsync(channelFactory,
                                              toInetSocketAddress(address),
                                              connectTimeout,
                                              readTimeout,
                                              writeTimeout,
                                              this.toSocksProxyAddress(socksProxy));
-            Futures.addCallback(connectFuture, new FutureCallback<FramedClientChannel>()
+            Futures.addCallback(connectFuture, new FutureCallback<C>()
             {
                 @Override
-                public void onSuccess(FramedClientChannel result)
+                public void onSuccess(C result)
                 {
                     NiftyClientChannel channel = result;
 

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -97,7 +97,6 @@ public class ThriftClientManager implements Closeable
     }
 
     public <T> ListenableFuture<T> createClient(HostAndPort address, Class<T> type)
-            throws TTransportException, InterruptedException, ExecutionException
     {
         FramedClientChannel.Factory channelFactory = new FramedClientChannel.Factory();
         return createClient(address, type, channelFactory);
@@ -107,7 +106,6 @@ public class ThriftClientManager implements Closeable
     ListenableFuture<T> createClient(HostAndPort address,
                                      Class<T> type,
                                      NiftyClientChannel.Factory<C> channelFactory)
-            throws TTransportException, InterruptedException, ExecutionException
     {
         return createClient(address,
                             type,
@@ -128,7 +126,6 @@ public class ThriftClientManager implements Closeable
                                      final Duration writeTimeout,
                                      final String clientName,
                                      HostAndPort socksProxy)
-            throws TTransportException, InterruptedException
     {
         NiftyClientChannel channel = null;
         try {

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientManagerProvider.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientManagerProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.guice;
 
 import com.facebook.swift.service.ThriftClientManager;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncClient.java
@@ -101,10 +101,12 @@ public class AsyncClient extends AsyncTestBase
                         assertEquals(Uninterruptibles.getUninterruptibly(getBeforeFuture), "default");
                         assertEquals(Uninterruptibles.getUninterruptibly(getAfterFuture), "testValue");
                         Uninterruptibles.getUninterruptibly(putFuture);
-                    } finally {
+                    }
+                    finally {
                         client.close();
                     }
-                } catch (Throwable t) {
+                }
+                catch (Throwable t) {
                     onFailure(t);
                 }
 
@@ -190,8 +192,8 @@ public class AsyncClient extends AsyncTestBase
                 @Override
                 public void onFailure(Throwable t)
                 {
-                    assert(t instanceof TTransportException &&
-                           t.getCause() instanceof TimeoutException);
+                    assertTrue(t instanceof TTransportException);
+                    assertTrue(t.getCause() instanceof TimeoutException);
                     latch.countDown();
                 }
             });

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.facebook.swift.codec.ThriftCodecManager;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncHttpClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncHttpClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.facebook.swift.service.LogEntry;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncHttpClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncHttpClient.java
@@ -1,0 +1,201 @@
+package com.facebook.swift.service.async;
+
+import com.facebook.swift.service.LogEntry;
+import com.facebook.swift.service.Scribe;
+import com.facebook.swift.service.ThriftClientManager;
+import com.facebook.swift.service.ResultCode;
+import com.facebook.swift.service.scribe.scribe;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.server.TServlet;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.testng.annotations.Test;
+
+import javax.servlet.ServletException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.testng.Assert.assertEquals;
+
+public class AsyncHttpClient extends AsyncTestBase
+{
+    private Server httpServer = null;
+
+    // Test a simple sync client call through HTTP (in this case, to a TServlet running under Jetty)
+    @Test
+    public void testHttpClient() throws Exception
+    {
+        clientManager = new ThriftClientManager();
+        Server jettyServer = createServer();
+
+        // Server was just started, it shouldn't have recorded any messages yet
+        assertEquals(getServerServlet(jettyServer).getLogEntries().size(), 0);
+
+        int serverPort = jettyServer.getConnectors()[0].getLocalPort();
+
+        try (Scribe client = createHttpClient(Scribe.class, serverPort).get()) {
+            client.log(Lists.newArrayList(new LogEntry("testCategory", "testMessage")));
+        }
+
+        // Blocking call completed, check that it was successful in logging a message.
+        assertEquals(getServerServlet(jettyServer).getLogEntries().size(), 1);
+
+        shutdownServer();
+    }
+
+    // Test a simple async client call to the same servlet
+    @Test
+    public void testHttpAsyncClient() throws Exception
+    {
+        clientManager = new ThriftClientManager();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Server jettyServer = createServer();
+
+        // Server was just started, it shouldn't have recorded any messages yet
+        assertEquals(getServerServlet(jettyServer).getLogEntries().size(), 0);
+
+        int serverPort = jettyServer.getConnectors()[0].getLocalPort();
+
+        ListenableFuture<AsyncScribe> clientFuture = createHttpClient(AsyncScribe.class, serverPort);
+        Futures.addCallback(clientFuture, new FutureCallback<AsyncScribe>() {
+            @Override
+            public void onSuccess(AsyncScribe client)
+            {
+                try {
+                    ListenableFuture<ResultCode> methodFuture =
+                        client.log(Lists.newArrayList(new LogEntry("testCategory", "testMessage")));
+
+                    // Connected a client, and made an async call against it, but the call shouldn't
+                    // be completed right away. Check that it isn't.
+                    assertEquals(getServerServlet(jettyServer).getLogEntries().size(), 0);
+
+                    Futures.addCallback(methodFuture, new FutureCallback<ResultCode>()
+                    {
+                        @Override
+                        public void onSuccess(ResultCode result)
+                        {
+                            latch.countDown();
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t)
+                        {
+                            latch.countDown();
+                        }
+                    });
+                }
+                catch (Throwable th) {
+                    onFailure(th);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t)
+            {
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+
+        // Now that the latch is clear, client should have connected and the async call completed
+        // so check that it did so successfully.
+        assertEquals(getServerServlet(jettyServer).getLogEntries().size(), 1);
+
+        shutdownServer();
+    }
+
+    private Server createServer() throws Exception
+    {
+        httpServer = new Server();
+
+        SelectChannelConnector connector = new SelectChannelConnector();
+        connector.setPort(0);
+        httpServer.addConnector(connector);
+
+        List<com.facebook.swift.service.scribe.LogEntry> logEntries =
+                new ArrayList<com.facebook.swift.service.scribe.LogEntry>();
+        com.facebook.swift.service.scribe.scribe.Iface handler =
+                new TestThriftServletHandler(logEntries);
+        TServlet servlet = new TestThriftServlet(handler, logEntries);
+
+        ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        contextHandler.setContextPath("/thrift");
+        contextHandler.addServlet(new ServletHolder(servlet), "/*");
+
+        httpServer.setHandler(contextHandler);
+
+        httpServer.start();
+
+        return httpServer;
+    }
+
+    private int getServerPort(Server server) {
+        return server.getConnectors()[0].getLocalPort();
+    }
+
+    private TestThriftServlet getServerServlet(Server server)
+            throws ServletException
+    {
+        ServletContextHandler handler = (ServletContextHandler)server.getHandlers()[0];
+        return (TestThriftServlet)handler.getServletHandler().getServlets()[0].getServlet();
+    }
+
+    private void shutdownServer() throws Exception
+    {
+        if (httpServer != null)
+        {
+            httpServer.stop();
+            httpServer.join();
+        }
+    }
+
+    private static class TestThriftServletHandler implements com.facebook.swift.service.scribe.scribe.Iface
+    {
+        private final List<com.facebook.swift.service.scribe.LogEntry> logEntries;
+
+        private TestThriftServletHandler(List<com.facebook.swift.service.scribe.LogEntry> logEntries)
+        {
+            this.logEntries = logEntries;
+        }
+
+        @Override
+        public com.facebook.swift.service.scribe.ResultCode Log(List<com.facebook.swift.service.scribe.LogEntry> messages)
+                throws TException
+        {
+            try {
+                Thread.sleep(100);
+                logEntries.addAll(messages);
+            }
+            catch (InterruptedException e) {
+                throw new TApplicationException(TApplicationException.UNKNOWN);
+            }
+            return com.facebook.swift.service.scribe.ResultCode.OK;
+        }
+    }
+
+    private class TestThriftServlet extends TServlet
+    {
+        public List<com.facebook.swift.service.scribe.LogEntry> getLogEntries()
+        {
+            return logEntries;
+        }
+
+        private final List<com.facebook.swift.service.scribe.LogEntry> logEntries;
+
+        public TestThriftServlet(scribe.Iface handler, List<com.facebook.swift.service.scribe.LogEntry> logEntries)
+        {
+            super(new scribe.Processor<>(handler), new TBinaryProtocol.Factory());
+            this.logEntries = logEntries;
+        }
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncHttpClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncHttpClient.java
@@ -16,9 +16,9 @@
 package com.facebook.swift.service.async;
 
 import com.facebook.swift.service.LogEntry;
+import com.facebook.swift.service.ResultCode;
 import com.facebook.swift.service.Scribe;
 import com.facebook.swift.service.ThriftClientManager;
-import com.facebook.swift.service.ResultCode;
 import com.facebook.swift.service.scribe.scribe;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.FutureCallback;
@@ -34,10 +34,11 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.testng.annotations.Test;
 
-import javax.servlet.ServletException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
+import javax.servlet.ServletException;
 
 import static org.testng.Assert.assertEquals;
 
@@ -47,7 +48,8 @@ public class AsyncHttpClient extends AsyncTestBase
 
     // Test a simple sync client call through HTTP (in this case, to a TServlet running under Jetty)
     @Test
-    public void testHttpClient() throws Exception
+    public void testHttpClient()
+            throws Exception
     {
         clientManager = new ThriftClientManager();
         Server jettyServer = createServer();
@@ -69,7 +71,8 @@ public class AsyncHttpClient extends AsyncTestBase
 
     // Test a simple async client call to the same servlet
     @Test
-    public void testHttpAsyncClient() throws Exception
+    public void testHttpAsyncClient()
+            throws Exception
     {
         clientManager = new ThriftClientManager();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -81,7 +84,8 @@ public class AsyncHttpClient extends AsyncTestBase
         int serverPort = jettyServer.getConnectors()[0].getLocalPort();
 
         ListenableFuture<AsyncScribe> clientFuture = createHttpClient(AsyncScribe.class, serverPort);
-        Futures.addCallback(clientFuture, new FutureCallback<AsyncScribe>() {
+        Futures.addCallback(clientFuture, new FutureCallback<AsyncScribe>()
+        {
             @Override
             public void onSuccess(AsyncScribe client)
             {
@@ -129,7 +133,8 @@ public class AsyncHttpClient extends AsyncTestBase
         shutdownServer();
     }
 
-    private Server createServer() throws Exception
+    private Server createServer()
+            throws Exception
     {
         httpServer = new Server();
 
@@ -154,7 +159,8 @@ public class AsyncHttpClient extends AsyncTestBase
         return httpServer;
     }
 
-    private int getServerPort(Server server) {
+    private int getServerPort(Server server)
+    {
         return server.getConnectors()[0].getLocalPort();
     }
 
@@ -165,10 +171,10 @@ public class AsyncHttpClient extends AsyncTestBase
         return (TestThriftServlet)handler.getServletHandler().getServlets()[0].getServlet();
     }
 
-    private void shutdownServer() throws Exception
+    private void shutdownServer()
+            throws Exception
     {
-        if (httpServer != null)
-        {
+        if (httpServer != null) {
             httpServer.stop();
             httpServer.join();
         }
@@ -207,7 +213,9 @@ public class AsyncHttpClient extends AsyncTestBase
 
         private final List<com.facebook.swift.service.scribe.LogEntry> logEntries;
 
-        public TestThriftServlet(scribe.Iface handler, List<com.facebook.swift.service.scribe.LogEntry> logEntries)
+        public TestThriftServlet(
+                scribe.Iface handler,
+                List<com.facebook.swift.service.scribe.LogEntry> logEntries)
         {
             super(new scribe.Processor<>(handler), new TBinaryProtocol.Factory());
             this.logEntries = logEntries;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncScribe.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncScribe.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.facebook.swift.service.LogEntry;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncScribe.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncScribe.java
@@ -29,5 +29,5 @@ public interface AsyncScribe extends AutoCloseable
 {
     @ThriftMethod(value = "Log")
     public ListenableFuture<ResultCode> log(List<LogEntry> logEntries)
-        throws TException;
+            throws TException;
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncScribe.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncScribe.java
@@ -1,0 +1,18 @@
+package com.facebook.swift.service.async;
+
+import com.facebook.swift.service.LogEntry;
+import com.facebook.swift.service.ResultCode;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.thrift.TException;
+
+import java.util.List;
+
+@ThriftService
+public interface AsyncScribe extends AutoCloseable
+{
+    @ThriftMethod(value = "Log")
+    public ListenableFuture<ResultCode> log(List<LogEntry> logEntries)
+        throws TException;
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncService.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.facebook.swift.codec.ThriftCodecManager;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncService.java
@@ -19,16 +19,12 @@ import com.facebook.swift.codec.ThriftCodecManager;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftServer;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.thrift.TException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
@@ -64,7 +64,7 @@ public class AsyncTestBase
                                                             .setWriteTimeout(new Duration(1, TimeUnit.SECONDS));
         HttpClientChannel.Factory channelFactory =
                 new HttpClientChannel.Factory("localhost:4567", "/thrift/");
-        return new ThriftClient<>(clientManager, clientClass, channelFactory, config, "asyncTestClient").open(address);
+        return new ThriftClient<>(clientManager, clientClass, config, "asyncTestClient", channelFactory).open(address);
     }
 
     protected ThriftServer createAsyncServer()

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.facebook.nifty.client.HttpClientChannel;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
@@ -1,5 +1,7 @@
 package com.facebook.swift.service.async;
 
+import com.facebook.nifty.client.HttpClientChannel;
+import com.facebook.nifty.client.NiftyClient;
 import com.facebook.swift.codec.ThriftCodecManager;
 import com.facebook.swift.service.ThriftClient;
 import com.facebook.swift.service.ThriftClientConfig;
@@ -7,13 +9,18 @@ import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftServer;
 import com.facebook.swift.service.ThriftServerConfig;
 import com.facebook.swift.service.ThriftServiceProcessor;
+import com.google.common.base.Function;
 import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.AsyncFunction;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 
+import javax.annotation.Nullable;
+import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -26,11 +33,29 @@ public class AsyncTestBase
     protected <T> ListenableFuture<T> createClient(Class<T> clientClass, ThriftServer server)
             throws TTransportException, InterruptedException, ExecutionException
     {
-        HostAndPort address = HostAndPort.fromParts("localhost", server.getPort());
+        return createClient(clientClass, server.getPort());
+    }
+
+    protected <T> ListenableFuture<T> createClient(Class<T> clientClass, int serverPort)
+            throws TTransportException, InterruptedException, ExecutionException
+    {
+        HostAndPort address = HostAndPort.fromParts("localhost", serverPort);
         ThriftClientConfig config = new ThriftClientConfig().setConnectTimeout(new Duration(1, TimeUnit.SECONDS))
                                                             .setReadTimeout(new Duration(1, TimeUnit.SECONDS))
                                                             .setWriteTimeout(new Duration(1, TimeUnit.SECONDS));
         return new ThriftClient<>(clientManager, clientClass, config, "asyncTestClient").open(address);
+    }
+
+    protected <T> ListenableFuture<T> createHttpClient(Class<T> clientClass, int serverPort)
+            throws TTransportException, InterruptedException, ExecutionException
+    {
+        HostAndPort address = HostAndPort.fromParts("localhost", serverPort);
+        ThriftClientConfig config = new ThriftClientConfig().setConnectTimeout(new Duration(1, TimeUnit.SECONDS))
+                                                            .setReadTimeout(new Duration(1, TimeUnit.SECONDS))
+                                                            .setWriteTimeout(new Duration(1, TimeUnit.SECONDS));
+        HttpClientChannel.Factory channelFactory =
+                new HttpClientChannel.Factory("localhost:4567", "/thrift/");
+        return new ThriftClient<>(clientManager, clientClass, channelFactory, config, "asyncTestClient").open(address);
     }
 
     protected ThriftServer createAsyncServer()

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncTestBase.java
@@ -16,7 +16,6 @@
 package com.facebook.swift.service.async;
 
 import com.facebook.nifty.client.HttpClientChannel;
-import com.facebook.nifty.client.NiftyClient;
 import com.facebook.swift.codec.ThriftCodecManager;
 import com.facebook.swift.service.ThriftClient;
 import com.facebook.swift.service.ThriftClientConfig;
@@ -24,18 +23,13 @@ import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftServer;
 import com.facebook.swift.service.ThriftServerConfig;
 import com.facebook.swift.service.ThriftServiceProcessor;
-import com.google.common.base.Function;
 import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.AsyncFunction;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 
-import javax.annotation.Nullable;
-import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMap.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMap.java
@@ -80,8 +80,7 @@ public class DelayedMap
     public interface AsyncClient extends Closeable
     {
         @ThriftMethod
-        public ListenableFuture<String> getValueSlowly(long timeout, TimeUnit unit,
-                                                            String key)
+        public ListenableFuture<String> getValueSlowly(long timeout, TimeUnit unit, String key)
                 throws TException;
 
         @ThriftMethod

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMap.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMap.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.facebook.swift.service.ThriftMethod;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapAsyncHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapAsyncHandler.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.google.common.util.concurrent.Futures;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.async;
 
 import com.facebook.swift.service.async.DelayedMap;

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.swift.service.async;
 
-import com.facebook.swift.service.async.DelayedMap;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
@@ -21,12 +21,14 @@ import com.facebook.swift.codec.ThriftStruct;
 @ThriftStruct
 public class CustomArgument
 {
-    public CustomArgument() {
+    public CustomArgument()
+    {
         this.integerField = 0;
         this.stringField = null;
     }
 
-    public CustomArgument(int integerField, String stringField) {
+    public CustomArgument(int integerField, String stringField)
+    {
         this.integerField = integerField;
         this.stringField = stringField;
     }

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.explicitidentifiers;
 
 import com.facebook.swift.codec.ThriftField;

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/ExplicitIdentifiersTestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/ExplicitIdentifiersTestSuite.java
@@ -52,7 +52,7 @@ public class ExplicitIdentifiersTestSuite extends TestSuiteBase<TestServiceHandl
     // Client passes only one parameter, server expects two
     @Test
     public void testMissingParameter()
-        throws TException
+            throws TException
     {
         getClient().missingIncomingParameter(1);
 
@@ -73,7 +73,7 @@ public class ExplicitIdentifiersTestSuite extends TestSuiteBase<TestServiceHandl
     // Client passes two parameters, server expects only one
     @Test
     public void testExtraParameter()
-        throws TException
+            throws TException
     {
         getClient().extraIncomingParameter(1, "2");
 

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/ExplicitIdentifiersTestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/ExplicitIdentifiersTestSuite.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.explicitidentifiers;
 
 import com.facebook.swift.service.base.TestSuiteBase;

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
@@ -32,32 +32,30 @@ public interface TestServiceClient extends Closeable
             @ThriftField(value = 30) String stringParam,
             @ThriftField(value = 10) int integerParam,
             @ThriftField(value = 20) boolean booleanParam,
-            @ThriftField(value = 40) byte dummy
-    ) throws TException;
+            @ThriftField(value = 40) byte dummy)
+            throws TException;
 
     @ThriftMethod
     public void missingIncomingParameter(
-            @ThriftField(value = 1) int firstParameter
-    ) throws TException;
+            @ThriftField(value = 1) int firstParameter)
+            throws TException;
 
     @ThriftMethod
     public void extraIncomingParameter(
             @ThriftField(value = 1) int firstParameter,
-            @ThriftField(value = 2) String secondParameter
-    ) throws TException;
+            @ThriftField(value = 2) String secondParameter)
+            throws TException;
 
     @ThriftMethod
     public void missingAndReorderedParameters(
             @ThriftField(value = 1) int integerOne,
-            @ThriftField(value = 2) String stringTwo
-    );
+            @ThriftField(value = 2) String stringTwo);
 
     @ThriftMethod
     public void extraAndReorderedParameters(
             @ThriftField(value = 1) int integerOne,
             @ThriftField(value = 2) String stringTwo,
-            @ThriftField(value = 3) boolean booleanTrue
-    );
+            @ThriftField(value = 3) boolean booleanTrue);
 
     @ThriftMethod
     public void missingInteger();

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceClient.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.explicitidentifiers;
 
 import com.facebook.swift.codec.ThriftField;

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
@@ -20,8 +20,6 @@ import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
 import com.google.common.base.Optional;
 
-import static org.testng.Assert.*;
-
 @ThriftService
 public class TestServiceHandler
 {
@@ -31,7 +29,8 @@ public class TestServiceHandler
     private Object lastByteParam;
     private Object lastCustomParam;
 
-    private void initializeLastParamValues() {
+    private void initializeLastParamValues()
+    {
         this.lastBooleanParam = null;
         this.lastStringParam = null;
         this.lastByteParam = null;
@@ -44,8 +43,8 @@ public class TestServiceHandler
             @ThriftField(value = 20) boolean booleanParam,
             @ThriftField(value = 30) String stringParam,
             @ThriftField(value = 10) int integerParam,
-            @ThriftField(value = 40) byte byteParam
-    ) {
+            @ThriftField(value = 40) byte byteParam)
+    {
         initializeLastParamValues();
         this.lastBooleanParam = Optional.of(booleanParam);
         this.lastIntegerParam = Optional.of(integerParam);
@@ -56,8 +55,8 @@ public class TestServiceHandler
     @ThriftMethod
     public void missingIncomingParameter(
             @ThriftField(value = 1) int integerParam,
-            @ThriftField(value = 2) String stringParam
-    ) {
+            @ThriftField(value = 2) String stringParam)
+    {
         initializeLastParamValues();
         this.lastIntegerParam = Optional.of(integerParam);
         this.lastStringParam = Optional.fromNullable(stringParam);
@@ -65,8 +64,8 @@ public class TestServiceHandler
 
     @ThriftMethod
     public void extraIncomingParameter(
-            @ThriftField(value = 1) int integerParam
-    ) {
+            @ThriftField(value = 1) int integerParam)
+    {
         initializeLastParamValues();
         this.lastIntegerParam = Optional.of(integerParam);
     }
@@ -75,8 +74,8 @@ public class TestServiceHandler
     public void missingAndReorderedParameters(
             @ThriftField(value = 3) boolean booleanParam,
             @ThriftField(value = 2) String stringParam,
-            @ThriftField(value = 1) int integerParam
-    ) {
+            @ThriftField(value = 1) int integerParam)
+    {
         initializeLastParamValues();
         this.lastBooleanParam = Optional.of(booleanParam);
         this.lastIntegerParam = Optional.of(integerParam);
@@ -86,8 +85,8 @@ public class TestServiceHandler
     @ThriftMethod
     public void extraAndReorderedParameters(
             @ThriftField(value = 3) boolean booleanParam,
-            @ThriftField(value = 2) String stringParam
-    ) {
+            @ThriftField(value = 2) String stringParam)
+    {
         initializeLastParamValues();
         this.lastBooleanParam = Optional.of(booleanParam);
         this.lastStringParam = Optional.fromNullable(stringParam);
@@ -95,22 +94,23 @@ public class TestServiceHandler
 
     @ThriftMethod
     public void missingInteger(
-            @ThriftField(value = 1) int integerParam
-    ) {
+            @ThriftField(value = 1) int integerParam)
+    {
         initializeLastParamValues();
         this.lastIntegerParam = Optional.of(integerParam);
     }
 
     @ThriftMethod
     public void missingStruct(
-            @ThriftField(value = 1) CustomArgument customParam
-    ) {
+            @ThriftField(value = 1) CustomArgument customParam)
+    {
         initializeLastParamValues();
         this.lastCustomParam = Optional.fromNullable(customParam);
     }
 
     @ThriftMethod
-    public void extraStruct() {
+    public void extraStruct()
+    {
         initializeLastParamValues();
     }
 

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/TestServiceHandler.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.explicitidentifiers;
 
 import com.facebook.swift.codec.ThriftField;

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/OnewayTestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/OnewayTestSuite.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
 * Copyright 2012 Facebook, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/OnewayTestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/OnewayTestSuite.java
@@ -13,21 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
-* Copyright 2012 Facebook, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License"); you may
-* not use this file except in compliance with the License. You may obtain
-* a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*/
 package com.facebook.swift.service.oneway;
 
 import com.facebook.swift.service.base.TestSuiteBase;
@@ -35,20 +20,26 @@ import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
 @Test
-public class OnewayTestSuite extends TestSuiteBase<TestService, TestService> {
+public class OnewayTestSuite extends TestSuiteBase<TestService, TestService>
+{
 
-    public OnewayTestSuite() {
+    public OnewayTestSuite()
+    {
         super(TestServiceHandler.class, TestServiceClient.class);
     }
 
     @Test
-    public void testOnewayCall() throws TException {
+    public void testOnewayCall()
+            throws TException
+    {
         getClient().onewayMethod();
         getClient().verifyConnectionState();
     }
 
     @Test
-    public void testOneWayThrow() throws TException, OneWayException {
+    public void testOneWayThrow()
+            throws TException, OneWayException
+    {
         getClient().onewayThrow();
         getClient().verifyConnectionState();
     }

--- a/swift-service/src/test/java/com/facebook/swift/service/unframed/UnframedTestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/unframed/UnframedTestSuite.java
@@ -15,15 +15,12 @@
  */
 package com.facebook.swift.service.unframed;
 
-import com.facebook.nifty.client.NiftyClient;
-import com.facebook.nifty.client.NiftyClientChannel;
 import com.facebook.nifty.client.UnframedClientChannel;
+import com.facebook.swift.service.LogEntry;
+import com.facebook.swift.service.ResultCode;
 import com.facebook.swift.service.Scribe;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.async.AsyncScribe;
-import com.facebook.swift.service.LogEntry;
-import com.facebook.swift.service.ResultCode;
-import com.facebook.swift.service.base.TestSuiteBase;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.FutureCallback;
@@ -36,7 +33,6 @@ import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TServerSocket;
 import org.testng.annotations.Test;
 
-import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
@@ -45,7 +41,8 @@ import static org.testng.Assert.assertEquals;
 public class UnframedTestSuite
 {
     @Test
-    public void testUnframedSyncMethod() throws Exception
+    public void testUnframedSyncMethod()
+            throws Exception
     {
         TestServerInfo info = startServer();
         ThriftClientManager clientManager = new ThriftClientManager();
@@ -60,7 +57,8 @@ public class UnframedTestSuite
     }
 
     @Test
-    public void testUnframedAsyncMethod() throws Exception
+    public void testUnframedAsyncMethod()
+            throws Exception
     {
         TestServerInfo info = startServer();
         ThriftClientManager clientManager = new ThriftClientManager();
@@ -109,9 +107,10 @@ public class UnframedTestSuite
         stopServer(info);
     }
 
-    private <T> ListenableFuture<T> createUnframedClient(ThriftClientManager clientManager,
-                                                         Class<T> clientType,
-                                                         int servicePort)
+    private <T> ListenableFuture<T> createUnframedClient(
+            ThriftClientManager clientManager,
+            Class<T> clientType,
+            int servicePort)
             throws Exception
     {
         return clientManager.createClient(HostAndPort.fromParts("localhost", servicePort),
@@ -119,7 +118,8 @@ public class UnframedTestSuite
                                           new UnframedClientChannel.Factory());
     }
 
-    public TestServerInfo startServer() throws Exception
+    public TestServerInfo startServer()
+            throws Exception
     {
         final TestServerInfo info = new TestServerInfo();
         TServerSocket serverSocket = new TServerSocket(0);
@@ -145,7 +145,8 @@ public class UnframedTestSuite
         return info;
     }
 
-    public void stopServer(TestServerInfo info) throws Exception
+    public void stopServer(TestServerInfo info)
+            throws Exception
     {
         info.server.stop();
     }

--- a/swift-service/src/test/java/com/facebook/swift/service/unframed/UnframedTestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/unframed/UnframedTestSuite.java
@@ -1,0 +1,160 @@
+package com.facebook.swift.service.unframed;
+
+import com.facebook.nifty.client.NiftyClient;
+import com.facebook.nifty.client.NiftyClientChannel;
+import com.facebook.nifty.client.UnframedClientChannel;
+import com.facebook.swift.service.Scribe;
+import com.facebook.swift.service.ThriftClientManager;
+import com.facebook.swift.service.async.AsyncScribe;
+import com.facebook.swift.service.LogEntry;
+import com.facebook.swift.service.ResultCode;
+import com.facebook.swift.service.base.TestSuiteBase;
+import com.google.common.collect.Lists;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.thrift.TException;
+import org.apache.thrift.TProcessor;
+import org.apache.thrift.server.TServer;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.transport.TServerSocket;
+import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.testng.Assert.assertEquals;
+
+public class UnframedTestSuite
+{
+    @Test
+    public void testUnframedSyncMethod() throws Exception
+    {
+        TestServerInfo info = startServer();
+        ThriftClientManager clientManager = new ThriftClientManager();
+
+        try (Scribe client = createUnframedClient(clientManager, Scribe.class, info.port).get()) {
+            ResultCode result = client.log(Lists.newArrayList(
+                    new LogEntry("testCategory", "testMessage")));
+            assertEquals(result, ResultCode.OK);
+        }
+
+        stopServer(info);
+    }
+
+    @Test
+    public void testUnframedAsyncMethod() throws Exception
+    {
+        TestServerInfo info = startServer();
+        ThriftClientManager clientManager = new ThriftClientManager();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final ResultCode[] resultHolder = new ResultCode[0];
+
+        ListenableFuture<AsyncScribe> clientFuture = createUnframedClient(clientManager, AsyncScribe.class, info.port);
+        Futures.addCallback(clientFuture, new FutureCallback<AsyncScribe>()
+        {
+            @Override
+            public void onSuccess(AsyncScribe client)
+            {
+                try {
+                    ListenableFuture<ResultCode> methodFuture =
+                            client.log(Lists.newArrayList(new LogEntry("testCategory", "testMessage")));
+                    Futures.addCallback(methodFuture, new FutureCallback<ResultCode>()
+                    {
+                        @Override
+                        public void onSuccess(ResultCode result)
+                        {
+                            resultHolder[0] = result;
+                            latch.countDown();
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t)
+                        {
+                            latch.countDown();
+                        }
+                    });
+                }
+                catch (TException e) {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t)
+            {
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+
+        stopServer(info);
+    }
+
+    private <T> ListenableFuture<T> createUnframedClient(ThriftClientManager clientManager,
+                                                         Class<T> clientType,
+                                                         int servicePort)
+            throws Exception
+    {
+        return clientManager.createClient(HostAndPort.fromParts("localhost", servicePort),
+                                          clientType,
+                                          new UnframedClientChannel.Factory());
+    }
+
+    public TestServerInfo startServer() throws Exception
+    {
+        final TestServerInfo info = new TestServerInfo();
+        TServerSocket serverSocket = new TServerSocket(0);
+        com.facebook.swift.service.scribe.scribe.Iface handler = new PlainScribeHandler();
+        TProcessor processor = new com.facebook.swift.service.scribe.scribe.Processor<>(handler);
+
+        TThreadPoolServer.Args args = new TThreadPoolServer.Args(serverSocket).processor(processor);
+        final TServer thriftServer = info.server = new TThreadPoolServer(args);
+
+        new Thread() {
+            @Override
+            public void run()
+            {
+                thriftServer.serve();
+            }
+        }.start();
+
+        while (!info.server.isServing()) {
+            Thread.sleep(10);
+        }
+        info.port = serverSocket.getServerSocket().getLocalPort();
+
+        return info;
+    }
+
+    public void stopServer(TestServerInfo info) throws Exception
+    {
+        info.server.stop();
+    }
+
+    private class PlainScribeHandler implements com.facebook.swift.service.scribe.scribe.Iface
+    {
+        @Override
+        public com.facebook.swift.service.scribe.ResultCode
+            Log(List<com.facebook.swift.service.scribe.LogEntry> messages)
+                throws TException
+        {
+            try {
+                Thread.sleep(100);
+            }
+            catch (InterruptedException e) {
+                return com.facebook.swift.service.scribe.ResultCode.TRY_LATER;
+            }
+            return com.facebook.swift.service.scribe.ResultCode.OK;
+        }
+    }
+
+    private class TestServerInfo
+    {
+        public TServer server;
+        public int port;
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/unframed/UnframedTestSuite.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/unframed/UnframedTestSuite.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.facebook.swift.service.unframed;
 
 import com.facebook.nifty.client.NiftyClient;


### PR DESCRIPTION
This is the swift part of the changes, see https://github.com/facebook/nifty/pull/21 for the nifty part.

This restores the ability to make client connections using unframed/http transports. Previously this was done by creating a client from a plain thrift TSocket and used plain thrift tranpsorts, now this is done by passing the appropriate NiftyClientChannel.Factory, and uses NiftyClient to make connections.
