### PR TITLE
POM updates to better fit with nifty, swift-smc, etc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,22 @@
       </dependency>
 
       <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>bootstrap</artifactId>
+        <version>${dep.airlift.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
         <version>3.5.2.Final</version>
@@ -276,29 +292,6 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>2.6</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.proofpoint.platform</groupId>
-        <artifactId>bootstrap</artifactId>
-        <version>0.51</version>
-        <exclusions>
-          <exclusion>
-            <!-- Swift uses a newer version named io.netty:netty -->
-            <groupId>org.jboss.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
-          <exclusion>
-            <!-- Swift uses a newer version named org.ow2.asm:asm-all -->
-            <groupId>asm</groupId>
-            <artifactId>asm</artifactId>
-          </exclusion>
-          <exclusion>
-            <!-- Swift doesn't use this and it causes META-INF content conflicts with jsr-303 -->
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -123,12 +123,6 @@
         <groupId>com.facebook.nifty</groupId>
         <artifactId>nifty-client</artifactId>
         <version>${dep.nifty.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -144,6 +138,10 @@
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -222,14 +220,8 @@
 
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
+        <artifactId>annotations</artifactId>
         <version>2.0.1</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.nesscomputing.testing</groupId>
-        <artifactId>findbugs-annotations</artifactId>
-        <version>2.0.0</version>
       </dependency>
 
       <dependency>

--- a/swift-codec/pom.xml
+++ b/swift-codec/pom.xml
@@ -39,14 +39,9 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <artifactId>annotations</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.nesscomputing.testing</groupId>
-      <artifactId>findbugs-annotations</artifactId>
-    </dependency>
-    
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>

--- a/swift-idl-parser/pom.xml
+++ b/swift-idl-parser/pom.xml
@@ -24,14 +24,9 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <artifactId>annotations</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.nesscomputing.testing</groupId>
-      <artifactId>findbugs-annotations</artifactId>
-    </dependency>
-    
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr-runtime</artifactId>

--- a/swift-load-generator/pom.xml
+++ b/swift-load-generator/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.proofpoint.platform</groupId>
+      <groupId>io.airlift</groupId>
       <artifactId>bootstrap</artifactId>
     </dependency>
 

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
@@ -28,8 +28,8 @@ import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
-import com.proofpoint.bootstrap.LifeCycleManager;
-import com.proofpoint.bootstrap.LifeCycleModule;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.bootstrap.LifeCycleModule;
 import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.configuration.ConfigurationModule;
 

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -94,7 +94,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <artifactId>annotations</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Replaces findbugs "jsr305" dependencies with "annotations" and replaces usage of "proofpoint" with usage of the equivalent "airlift" artifacts. 
