### PR TITLE
Updates to ThriftClientManager helper methods

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -39,12 +39,14 @@ import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocolException;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TTransportException;
+import org.jboss.netty.channel.Channel;
 
 import java.io.Closeable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -189,12 +191,12 @@ public class ThriftClientManager implements Closeable
         ));
     }
 
-    private InetSocketAddress toInetSocketAddress(HostAndPort hostAndPort)
+    private static InetSocketAddress toInetSocketAddress(HostAndPort hostAndPort)
     {
         return new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort());
     }
 
-    private InetSocketAddress toSocksProxyAddress(HostAndPort socksProxy)
+    private static InetSocketAddress toSocksProxyAddress(HostAndPort socksProxy)
     {
         if (socksProxy == null) {
             return null;
@@ -213,7 +215,7 @@ public class ThriftClientManager implements Closeable
         niftyClient.close();
     }
 
-    public NiftyClientChannel getNiftyChannel(Object client)
+    public static NiftyClientChannel getNiftyChannel(Object client)
     {
         try {
             InvocationHandler genericHandler = Proxy.getInvocationHandler(client);
@@ -223,6 +225,22 @@ public class ThriftClientManager implements Closeable
         catch (ClassCastException e) {
             throw new IllegalArgumentException("Not a swift client object", e);
         }
+    }
+
+    public static HostAndPort getRemoteAddress(Object client) {
+        Channel nettyChannel = getNiftyChannel(client).getNettyChannel();
+        if (nettyChannel == null || nettyChannel.getRemoteAddress() == null) {
+            throw new IllegalStateException("Client is not connected");
+        }
+
+        SocketAddress address = nettyChannel.getRemoteAddress();
+        if (!(address instanceof InetSocketAddress)) {
+            throw new IllegalStateException("Client is not connected via TCP socket");
+        }
+
+        InetSocketAddress inetAddress = (InetSocketAddress) address;
+        return HostAndPort.fromParts(inetAddress.getHostName(),
+                                     inetAddress.getPort());
     }
 
     @Immutable


### PR DESCRIPTION
Add getRemoteAddress() to get the remote address of a connected swift client, and fix the helper methods so they return null instead of throwing if passed a non-swift client object (to facilitate testing using mock clients)
