### PR TITLE
Upgrade from airlift 0.66 to airlift 0.68

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <fb.check.fail-findbugs>false</fb.check.fail-findbugs>
 
     <dep.guice.version>3.0</dep.guice.version>
-    <dep.airlift.version>0.66</dep.airlift.version>
+    <dep.airlift.version>0.68</dep.airlift.version>
     <dep.maven-api.version>2.2.1</dep.maven-api.version>
     <dep.slf4j.version>1.7.2</dep.slf4j.version>
     <dep.logback.version>1.0.7</dep.logback.version>
@@ -378,6 +378,28 @@
           <artifactId>maven-shade-plugin</artifactId>
 	  <version>2.0</version>
 	</plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <configuration>
+            <rules>
+              <bannedDependencies>
+                <!--
+                    Ban io.airlift:log except in tests, since it bridges from
+                    jul and log4j back to slf4j, which would prevent consumers
+                    of swift from choosing those logging implementations
+                -->
+                <excludes combine.children="append">
+                  <exclude>io.airlift:log:*:*:*</exclude>
+                </excludes>
+                <includes combine.children="append">
+                  <exclude>io.airlift:log:*:*:test</exclude>
+                </includes>
+              </bannedDependencies>
+            </rules>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/swift-load-generator/pom.xml
+++ b/swift-load-generator/pom.xml
@@ -96,6 +96,25 @@
           </transformers>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <bannedDependencies>
+              <!--
+                  This module uses io.airlift:bootstrap, which does depends on io.airlift:log,
+                  and it's fine to include io.airlift:log here because this is a standalone app,
+                  not a library, and it doesn't use log4j as its logger.
+              -->
+              <includes combine.children="append">
+                <exclude>io.airlift:log:*:*:compile</exclude>
+              </includes>
+            </bannedDependencies>
+          </rules>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
With this new version of airlift, the 'log' artifact isn't an indirect dep of swift-service or swift-codec (except for at test scope). Added checks to make sure it doesn't happen again.
