### PR TITLE
Fix generator bug with using primitive types as type parameters

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
@@ -152,7 +152,7 @@ public class TypeToJavaConverter
             return type.getClass() == IdentifierType.class;
         }
 
-        public String convert(final ThriftType type, final boolean ignored)
+        public String convert(final ThriftType type, final boolean primitive)
         {
             final String name = ((IdentifierType) type).getName();
             // the name is [<thrift-namespace>.]<thrift type>
@@ -174,7 +174,7 @@ public class TypeToJavaConverter
                 return (javaType == null) ? null : javaType.getSimpleName();
             }
             else {
-                return convertType(thriftType);
+                return TypeToJavaConverter.this.convert(thriftType, primitive);
             }
         }
     }


### PR DESCRIPTION
For thrift type:

 list<seq_t>

where "seq_t" is a typedef to "int64", the generator generates the illegal type:

 List<long>

this fixes it to generate:

 List<Long>
