### PR TITLE
Generator include fixes

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -88,6 +88,8 @@ public class SwiftGenerator
         final Map<String, SwiftDocumentContext> contexts = Maps.newHashMap();
         for (final URI inputUri : swiftGeneratorConfig.getInputs()) {
 
+            parsedDocuments.clear();
+
             parseDocument(inputUri.isAbsolute() ? inputUri
                                                 : swiftGeneratorConfig.getInputBase().resolve(inputUri),
                           contexts,


### PR DESCRIPTION
If we've already fully parsed an included IDL file, and we see the same file included again, just ignore it.

If we are currently parsing an IDL file, and we see it included again throw an exception detailing the include path that led to recursive inclusion.
