### PR TITLE
Updates to generator namespace functionality

### DIFF
--- a/swift-generator-cli/src/main/java/com/facebook/swift/generator/Main.java
+++ b/swift-generator-cli/src/main/java/com/facebook/swift/generator/Main.java
@@ -56,7 +56,8 @@ public class Main
                 .overridePackage(cliConfig.overridePackage)
                 .defaultPackage(cliConfig.defaultPackage)
                 .generateIncludedCode(cliConfig.generateIncludedCode)
-                .codeFlavor(cliConfig.generateBeans ? "java-regular" : "java-immutable");
+                .codeFlavor(cliConfig.generateBeans ? "java-regular" : "java-immutable")
+                .usePlainJavaNamespace(cliConfig.usePlainJavaNamespace);
 
         for (SwiftGeneratorTweak tweak : cliConfig.tweaks) {
             configBuilder.addTweak(tweak);

--- a/swift-generator-cli/src/main/java/com/facebook/swift/generator/SwiftGeneratorCommandLineConfig.java
+++ b/swift-generator-cli/src/main/java/com/facebook/swift/generator/SwiftGeneratorCommandLineConfig.java
@@ -59,4 +59,10 @@ public class SwiftGeneratorCommandLineConfig
             description = "Enable specific code generation tweaks"
     )
     public Set<SwiftGeneratorTweak> tweaks = Sets.newHashSet();
+
+    @Parameter(
+            names = "-use_java_namespace",
+            description = "Use 'java' namespace instead of 'java.swift' namespace"
+    )
+    public boolean usePlainJavaNamespace;
 }

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -136,14 +136,16 @@ public class SwiftGenerator
         final Document document = context.getDocument();
         final Header header = document.getHeader();
 
+        String effectiveJavaNamespace = "java.swift";
+        if (swiftGeneratorConfig.usePlainJavaNamespace()) {
+            effectiveJavaNamespace = "java";
+        }
+
         // Override takes precedence
         String javaPackage = swiftGeneratorConfig.getOverridePackage();
         // Otherwise fallback on package specified in .thrift file
         if (javaPackage == null) {
-            javaPackage = header.getNamespace("java.swift");
-        }
-        if (javaPackage == null) {
-            javaPackage = header.getNamespace("java");
+            javaPackage = header.getNamespace(effectiveJavaNamespace);
         }
         // Or the default if we don't have an override package or a package in the .thrift file
         if (javaPackage == null) {
@@ -151,7 +153,7 @@ public class SwiftGenerator
         }
 
         // If none of the above options get us a package to use, fail
-        Preconditions.checkState(javaPackage != null, "thrift uri %s does not declare a swift namespace!", thriftUri);
+        Preconditions.checkState(javaPackage != null, "thrift uri %s does not declare a '%s' namespace!", thriftUri, effectiveJavaNamespace);
 
         // Make a note that this document is a parent of all the documents included, directly or recursively
         parentDocuments.push(thriftUri);

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -140,7 +140,7 @@ public class SwiftGenerator
         String javaPackage = swiftGeneratorConfig.getOverridePackage();
         // Otherwise fallback on package specified in .thrift file
         if (javaPackage == null) {
-            javaPackage = header.getNamespace("swift");
+            javaPackage = header.getNamespace("java.swift");
         }
         if (javaPackage == null) {
             javaPackage = header.getNamespace("java");

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGeneratorConfig.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGeneratorConfig.java
@@ -31,14 +31,17 @@ public class SwiftGeneratorConfig
     private final Set<SwiftGeneratorTweak> generatorTweaks;
     private final boolean generateIncludedCode;
     private final String codeFlavor;
+    private boolean usePlainJavaNamespace;
 
-    private SwiftGeneratorConfig(final URI inputBase,
-                                 final File outputFolder,
-                                 final String overridePackage,
-                                 final String defaultPackage,
-                                 final Set<SwiftGeneratorTweak> generatorTweaks,
-                                 final boolean generateIncludedCode,
-                                 final String codeFlavor)
+    private SwiftGeneratorConfig(
+            final URI inputBase,
+            final File outputFolder,
+            final String overridePackage,
+            final String defaultPackage,
+            final Set<SwiftGeneratorTweak> generatorTweaks,
+            final boolean generateIncludedCode,
+            final String codeFlavor,
+            boolean usePlainJavaNamespace)
     {
         this.inputBase = inputBase;
         this.outputFolder = outputFolder;
@@ -47,6 +50,7 @@ public class SwiftGeneratorConfig
         this.generatorTweaks = generatorTweaks;
         this.generateIncludedCode = generateIncludedCode;
         this.codeFlavor = codeFlavor;
+        this.usePlainJavaNamespace = usePlainJavaNamespace;
     }
 
     public static Builder builder()
@@ -111,6 +115,14 @@ public class SwiftGeneratorConfig
         return codeFlavor;
     }
 
+    /**
+     * Use namespace from 'namespace java ...' directive instead of from 'namespace java.swift ...'
+     */
+    public boolean usePlainJavaNamespace()
+    {
+        return usePlainJavaNamespace;
+    }
+
     public static class Builder
     {
         private URI inputBase = null;
@@ -120,6 +132,7 @@ public class SwiftGeneratorConfig
         private Set<SwiftGeneratorTweak> generatorTweaks = EnumSet.noneOf(SwiftGeneratorTweak.class);
         private boolean generateIncludedCode = false;
         private String codeFlavor = null;
+        private boolean usePlainJavaNamespace = false;
 
         private Builder()
         {
@@ -139,7 +152,8 @@ public class SwiftGeneratorConfig
                 defaultPackage,
                 generatorTweaks,
                 generateIncludedCode,
-                codeFlavor);
+                codeFlavor,
+                usePlainJavaNamespace);
         }
 
         public Builder inputBase(final URI inputBase)
@@ -181,6 +195,12 @@ public class SwiftGeneratorConfig
         public Builder codeFlavor(final String codeFlavor)
         {
             this.codeFlavor = codeFlavor;
+            return this;
+        }
+
+        public Builder usePlainJavaNamespace(final boolean usePlainJavaNamespace)
+        {
+            this.usePlainJavaNamespace = usePlainJavaNamespace;
             return this;
         }
     }

--- a/swift-maven-plugin/src/main/java/com/facebook/mojo/SwiftMojo.java
+++ b/swift-maven-plugin/src/main/java/com/facebook/mojo/SwiftMojo.java
@@ -135,6 +135,13 @@ public class SwiftMojo extends AbstractMojo
     private String codeFlavor = "java-regular";
 
     /**
+     * Use the 'java' namespace instead of the 'java.swift' namespace.
+     *
+     * @parameter default-value="false"
+     */
+    private boolean usePlainJavaNamespace = false;
+
+    /**
      * @parameter expression="${project}"
      * @required
      * @readonly
@@ -163,7 +170,8 @@ public class SwiftMojo extends AbstractMojo
                     .overridePackage(overridePackage)
                     .defaultPackage(defaultPackage)
                     .generateIncludedCode(generateIncludedCode)
-                    .codeFlavor(codeFlavor);
+                    .codeFlavor(codeFlavor)
+                    .usePlainJavaNamespace(usePlainJavaNamespace);
 
                 if (addThriftExceptions) {
                     configBuilder.addTweak(SwiftGeneratorTweak.ADD_THRIFT_EXCEPTION);


### PR DESCRIPTION
- Change the namespace from just 'swift' to 'java.swift' to clarify what this namespace is for
- Add a switch that triggers usage of the plain 'java' namespace instead of 'java.swift' namespace (off by default)
- Connect the namespace selection to the maven swift generator plugin
