### PR TITLE
[generator] Implicit enum identifiers & catch missing field / param IDs

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
@@ -131,8 +131,7 @@ public class TemplateContextGenerator
 
     public EnumFieldContext fieldFromThrift(final IntegerEnumField field)
     {
-        Preconditions.checkState(field.getValue().get() != null, "field value for integer field %s is null!", field.getName());
-        return new EnumFieldContext(mangleJavaConstantName(field.getName()), field.getValue().get());
+        return new EnumFieldContext(mangleJavaConstantName(field.getName()), field.getValue());
     }
 
     public EnumFieldContext fieldFromThrift(final String value)

--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
@@ -26,6 +26,7 @@ options {
     package com.facebook.swift.parser.antlr;
 
     import com.facebook.swift.parser.model.*;
+    import com.facebook.swift.parser.util.*;
 
     import java.util.ArrayList;
     import java.util.HashMap;
@@ -133,8 +134,14 @@ const_map returns [Map<ConstValue, ConstValue> value = new HashMap<>()]
     : ^(MAP ( ^(ENTRY k=const_value v=const_value) { $value.put($k.value, $v.value); } )*)
     ;
 
-enum_fields returns [List<IntegerEnumField> value = new ArrayList<>()]
-    : ( ^(k=IDENTIFIER v=integer?) { $value.add(new IntegerEnumField($k.text, $v.value)); } )*
+enum_fields returns [IntegerEnumFieldList value = new IntegerEnumFieldList()]
+    : ( enum_field[$value] { $value.add($enum_field.value); } )*
+    ;
+
+enum_field[IntegerEnumFieldList fieldList] returns [IntegerEnumField value]
+    : ^(k=IDENTIFIER v=integer?) {
+         $value = new IntegerEnumField($k.text, $v.value, $fieldList.getNextImplicitEnumerationValue());
+    }
     ;
 
 senum_values returns [List<String> value = new ArrayList<>()]

--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
@@ -236,7 +236,7 @@ cpp_type returns [String value]
     ;
 
 
-integer returns [long value]
+integer returns [Long value]
     : i=INTEGER     { $value = Long.parseLong($i.text); }
     | h=HEX_INTEGER { $value = Long.decode($h.text); }
     ;

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/IntegerEnumField.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/IntegerEnumField.java
@@ -23,12 +23,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class IntegerEnumField
 {
     private final String name;
-    private final Optional<Long> value;
+    private final Optional<Long> explicitValue;
 
-    public IntegerEnumField(String name, Long value)
+    private final long effectiveValue;
+
+    public IntegerEnumField(String name, Long explicitValue, Long defaultValue)
     {
         this.name = checkNotNull(name, "name");
-        this.value = Optional.fromNullable(value);
+        this.explicitValue = Optional.fromNullable(explicitValue);
+        this.effectiveValue = (this.explicitValue.isPresent()) ? this.explicitValue.get() : defaultValue;
     }
 
     public String getName()
@@ -36,9 +39,14 @@ public class IntegerEnumField
         return name;
     }
 
-    public Optional<Long> getValue()
+    public Optional<Long> getExplicitValue()
     {
-        return value;
+        return explicitValue;
+    }
+
+    public long getValue()
+    {
+        return effectiveValue;
     }
 
     @Override
@@ -46,7 +54,8 @@ public class IntegerEnumField
     {
         return Objects.toStringHelper(this)
                 .add("name", name)
-                .add("value", value)
+                .add("value", getValue())
+                .add("explicitValue", explicitValue)
                 .toString();
     }
 }

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/util/IntegerEnumFieldList.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/util/IntegerEnumFieldList.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.parser.util;
+
+import com.facebook.swift.parser.model.IntegerEnumField;
+
+import java.util.ArrayList;
+
+public class IntegerEnumFieldList extends ArrayList<IntegerEnumField>
+{
+    public long getNextImplicitEnumerationValue()
+    {
+        int lastFieldInex = size() - 1;
+        if (lastFieldInex < 0) {
+            // No previous values to derive from, and thrift enumerations start at zero by default
+            return 0;
+        }
+        IntegerEnumField lastField = get(lastFieldInex);
+        return lastField.getValue() + 1;
+    }
+}


### PR DESCRIPTION
This fixes two things:

If field IDs were missing from the thrift file, the generator was filling them in, but doing it wrong. Generator was supposed to be looking for null for field IDs to indicate missing ids, but the parser was never giving it null because the type was "long" instead of "Long". After this fix, the generator will correctly complain if there are missing field / param identifiers. Another option would be to try to synthesize them "correctly" the way the thrift compiler does, but it does it by synthesizing _negative_ ids and warns that it may not be compatible, so I don't think its worth carrying this over... Seems better to just throw an error and require the .thrift to be explicit.

The other fix is to correctly synthesize integer enumeration values. In this case, there are a number of fbcode .thrift files that take advantage of this (and are being generated incorrectly as of now), and the fbcode & apache thrift compilers don't complain about this and have consistent behavior (count up from last explicit enum value, or from 0 if there hasn't been an explicit value yet), so I made the swift generator do the same thing.
