### PR TITLE
[swift-idl-parser] Parse and accept default namespace

### DIFF
--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
@@ -44,20 +44,26 @@ document returns [Document value]
 header returns [Header value]
 @init {
     List<String> includes = new ArrayList<>();
-    Map<String, String> namespaces = new HashMap<>();
     List<String> cppIncludes = new ArrayList<>();
+    String defaultNamespace = null;
+    Map<String, String> namespaces = new HashMap<>();
 }
 @after {
-    $value = new Header(includes, namespaces, cppIncludes);
+    $value = new Header(includes, cppIncludes, defaultNamespace, namespaces);
 }
-    : ( include     { includes.add($include.value); }
-      | namespace   { namespaces.put($namespace.language, $namespace.value); }
-      | cpp_include { cppIncludes.add($cpp_include.value); }
+    : ( include           { includes.add($include.value); }
+      | cpp_include       { cppIncludes.add($cpp_include.value); }
+      | default_namespace { defaultNamespace = $default_namespace.value; }
+      | namespace         { namespaces.put($namespace.language, $namespace.value); }
       )*
     ;
 
 include returns [String value]
     : ^(INCLUDE LITERAL) { $value = $LITERAL.text; }
+    ;
+
+default_namespace returns [String value]
+    : ^(DEFAULT_NAMESPACE (v=IDENTIFIER | v=LITERAL)) { $value = $v.text; }
     ;
 
 namespace returns [String language, String value]

--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
@@ -26,6 +26,7 @@ tokens {
     INCLUDE;
     TYPEDEF;
     NAMESPACE;
+    DEFAULT_NAMESPACE;
     CPP_INCLUDE;
     ENUM;
     SENUM;
@@ -76,7 +77,8 @@ include
     ;
 
 namespace
-    : 'namespace' k=IDENTIFIER (v=IDENTIFIER | v=LITERAL) -> ^(NAMESPACE $k $v)
+    : 'namespace' '*' (v=IDENTIFIER | v=LITERAL) -> ^(DEFAULT_NAMESPACE $v)
+    | 'namespace' k=IDENTIFIER (v=IDENTIFIER | v=LITERAL) -> ^(NAMESPACE $k $v)
     | 'cpp_namespace' IDENTIFIER -> ^(NAMESPACE IDENTIFIER["cpp"] IDENTIFIER)
     | 'php_namespace' IDENTIFIER -> ^(NAMESPACE IDENTIFIER["php"] IDENTIFIER)
     ;

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/Document.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/Document.java
@@ -73,9 +73,10 @@ public class Document
     public static Document emptyDocument()
     {
         List<String> includes = emptyList();
-        Map<String, String> namespaces = Collections.emptyMap();
         List<String> cppIncludes = emptyList();
-        Header header = new Header(includes, namespaces, cppIncludes);
+        String defaultNamespace = null;
+        Map<String, String> namespaces = Collections.emptyMap();
+        Header header = new Header(includes, cppIncludes, defaultNamespace, namespaces);
         List<Definition> definitions = emptyList();
         return new Document(header, definitions);
     }

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/Header.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/Header.java
@@ -28,13 +28,15 @@ public class Header
 {
     private final List<String> includes;
     private final Map<String, String> namespaces;
+    private final String defaultNamespace;
     private final List<String> cppIncludes;
 
-    public Header(List<String> includes, Map<String, String> namespaces, List<String> cppIncludes)
+    public Header(List<String> includes, List<String> cppIncludes, String defaultNamespace, Map<String, String> namespaces)
     {
         this.includes = ImmutableList.copyOf(checkNotNull(includes, "includes"));
-        this.namespaces = ImmutableMap.copyOf(checkNotNull(namespaces, "namespaces"));
         this.cppIncludes = ImmutableList.copyOf(checkNotNull(cppIncludes, "cppIncludes"));
+        this.defaultNamespace = checkNotNull(defaultNamespace, "defaultNamespace");
+        this.namespaces = ImmutableMap.copyOf(checkNotNull(namespaces, "namespaces"));
     }
 
     public List<String> getIncludes()
@@ -44,7 +46,11 @@ public class Header
 
     public String getNamespace(final String nameSpaceName)
     {
-        return namespaces.get(nameSpaceName);
+        String namespace = namespaces.get(nameSpaceName);
+        if (namespace == null) {
+            namespace = defaultNamespace;
+        }
+        return namespace;
     }
 
     public Map<String, String> getNamespaces()
@@ -57,13 +63,19 @@ public class Header
         return cppIncludes;
     }
 
+    public String getDefaultNamespace()
+    {
+        return defaultNamespace;
+    }
+
     @Override
     public String toString()
     {
         return Objects.toStringHelper(this)
                 .add("includes", includes)
-                .add("namespaces", namespaces)
                 .add("cppIncludes", cppIncludes)
+                .add("defaultNamespace", defaultNamespace)
+                .add("namespaces", namespaces)
                 .toString();
     }
 }


### PR DESCRIPTION
While testing the toString() changes for the generator, I found we couldn't parse the ASF version of ThriftTest.thrift, because we were missing this.
