### PR TITLE
[swift-generator] Plain JDK implementation of toString() for thrift structs

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/FieldContext.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/FieldContext.java
@@ -69,6 +69,11 @@ public class FieldContext
         return javaSetterName;
     }
 
+    public boolean isStringType()
+    {
+        return getJavaType().equals("String");
+    }
+
     @Override
     public int hashCode()
     {

--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -33,8 +33,6 @@ package <context.javaPackage>;
 import com.facebook.swift.codec.*;
 import java.util.*;
 
-import static com.google.common.base.Objects.toStringHelper;
-
 @ThriftStruct("<context.name>")
 public class <context.javaName>
 {
@@ -157,12 +155,14 @@ _toString(context) ::= <<
 @Override
 public String toString()
 {
-    return toStringHelper(this)
-        <context.fields : { field |<_toStringField(field)>}; separator="\n">
-        .toString();
+    final StringBuilder sb = new StringBuilder();
+    sb.append("<context.javaName>{");
+    <context.fields : { field |<_toStringField(field)>}; separator=".append(\", \");\n">;
+    sb.append('}');
+    return sb.toString();
 }
 >>
 
 _toStringField(field) ::= <<
-.add("<field.javaName>", <field.javaName>)
+sb.append("<field.javaName>=<if(field.stringType)>'<endif>").append(<field.javaName>)<if(field.stringType)>.append('\'')<endif>
 >>


### PR DESCRIPTION
Currently, types generated by the generator depend on swift-codec (to handle the swift annotations), which means they indirectly depend on guava anyway. So this doesn't really buy us much right now.

It is part of my plan, though, to separate out the swift annotations so that a single version of a stub library containing just swift-generated interfaces and types could be usable across multiple versions of swift... and this version of toString() is easy enough, in case it would be useful to someone someday.
