### PR TITLE
Generator package fixes

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -136,24 +136,7 @@ public class SwiftGenerator
         final Document document = context.getDocument();
         final Header header = document.getHeader();
 
-        String effectiveJavaNamespace = "java.swift";
-        if (swiftGeneratorConfig.usePlainJavaNamespace()) {
-            effectiveJavaNamespace = "java";
-        }
-
-        // Override takes precedence
-        String javaPackage = swiftGeneratorConfig.getOverridePackage();
-        // Otherwise fallback on package specified in .thrift file
-        if (javaPackage == null) {
-            javaPackage = header.getNamespace(effectiveJavaNamespace);
-        }
-        // Or the default if we don't have an override package or a package in the .thrift file
-        if (javaPackage == null) {
-            javaPackage = swiftGeneratorConfig.getDefaultPackage();
-        }
-
-        // If none of the above options get us a package to use, fail
-        Preconditions.checkState(javaPackage != null, "thrift uri %s does not declare a '%s' namespace!", thriftUri, effectiveJavaNamespace);
+        String javaPackage = context.getJavaPackage();
 
         // Make a note that this document is a parent of all the documents included, directly or recursively
         parentDocuments.push(thriftUri);

--- a/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
@@ -100,7 +100,7 @@ public class TypeToJavaConverter
 
         public String convert(final ThriftType type, boolean primitive)
         {
-            return primitive ? "void" : "VOID";
+            return primitive ? "void" : "Void";
         }
     }
 

--- a/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
@@ -39,10 +39,13 @@ public class TypeToJavaConverter
     private final TypedefRegistry typedefRegistry;
 
     private final List<Converter> converters;
+    private final String javaPackage;
 
-    public TypeToJavaConverter(final TypeRegistry typeRegistry,
-                               final TypedefRegistry typedefRegistry,
-                               final String namespace)
+    public TypeToJavaConverter(
+            final TypeRegistry typeRegistry,
+            final TypedefRegistry typedefRegistry,
+            final String namespace,
+            final String javaPackage)
     {
         Preconditions.checkNotNull(typeRegistry);
         Preconditions.checkNotNull(typedefRegistry);
@@ -50,6 +53,7 @@ public class TypeToJavaConverter
         this.typeRegistry = typeRegistry;
         this.typedefRegistry = typedefRegistry;
         this.namespace = namespace;
+        this.javaPackage = javaPackage;
 
         final ImmutableList.Builder<Converter> builder = ImmutableList.builder();
         builder.add(new VoidConverter());
@@ -171,11 +175,21 @@ public class TypeToJavaConverter
             final ThriftType thriftType = typedefRegistry.findType(javatypeName);
             if (thriftType == null) {
                 final SwiftJavaType javaType = typeRegistry.findType(javatypeName);
-                return (javaType == null) ? null : javaType.getSimpleName();
+                return (javaType == null) ? null : shortenClassName(javaType.getClassName());
             }
             else {
                 return TypeToJavaConverter.this.convert(thriftType, primitive);
             }
+        }
+
+        private String shortenClassName(String className)
+        {
+            // If the class is in the package we are currently generating code for, generate
+            // only the simple name, otherwise generate the fully qualified class name.
+            if (className.startsWith(javaPackage) && className.lastIndexOf(".") == javaPackage.length()) {
+                className = className.substring(javaPackage.length() + 1);
+            }
+            return className;
         }
     }
 

--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
@@ -198,7 +198,7 @@ public class TemplateContextGenerator
 
     private String getterName(final ThriftField field)
     {
-        final String type = typeConverter.convertType(field.getType());
+        final String type = typeConverter.convertType(field.getType()).toLowerCase();
         return ("boolean".equals(type) ? "is" : "get") + mangleJavatypeName(field.getName());
     }
 


### PR DESCRIPTION
Generated references to types in #include'd .thrift files from other namespaces are not qualified, and there is no "using" statement to bring them in, so they don't compile.

This attempts to fix that by qualifying references to types from other generated packages.
