### PR TITLE
Prune the subtree from search for @ThriftService annotations when one is...

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ReflectionHelper.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ReflectionHelper.java
@@ -91,7 +91,7 @@ public final class ReflectionHelper
         return TypeToken.of(type).resolveType(FUTURE_RETURN_TYPE).getType();
     }
 
-    public static <T extends Annotation> Set<T> getAllClassAnnotations(Class<?> type, Class<T> annotation)
+    public static <T extends Annotation> Set<T> getEffectiveClassAnnotations(Class<?> type, Class<T> annotation)
     {
         // if the class is directly annotated, it is considered the only annotation
         if (type.isAnnotationPresent(annotation)) {
@@ -100,20 +100,21 @@ public final class ReflectionHelper
 
         // otherwise find all annotations from all super classes and interfaces
         ImmutableSet.Builder<T> builder = ImmutableSet.builder();
-        addAllClassAnnotations(type, annotation, builder);
+        addEffectiveClassAnnotations(type, annotation, builder);
         return builder.build();
     }
 
-    private static <T extends Annotation> void addAllClassAnnotations(Class<?> type, Class<T> annotation, ImmutableSet.Builder<T> builder)
+    private static <T extends Annotation> void addEffectiveClassAnnotations(Class<?> type, Class<T> annotation, ImmutableSet.Builder<T> builder)
     {
         if (type.isAnnotationPresent(annotation)) {
             builder.add(type.getAnnotation(annotation));
+            return;
         }
         if (type.getSuperclass() != null) {
-            addAllClassAnnotations(type.getSuperclass(), annotation, builder);
+            addEffectiveClassAnnotations(type.getSuperclass(), annotation, builder);
         }
         for (Class<?> anInterface : type.getInterfaces()) {
-            addAllClassAnnotations(anInterface, annotation, builder);
+            addEffectiveClassAnnotations(anInterface, annotation, builder);
         }
     }
 

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftServiceMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftServiceMetadata.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.swift.codec.metadata.ReflectionHelper.findAnnotatedMethods;
-import static com.facebook.swift.codec.metadata.ReflectionHelper.getAllClassAnnotations;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.getEffectiveClassAnnotations;
 
 @Immutable
 public class ThriftServiceMetadata
@@ -86,7 +86,7 @@ public class ThriftServiceMetadata
 
     public static ThriftService getThriftServiceAnnotation(Class<?> serviceClass)
     {
-        Set<ThriftService> serviceAnnotations = getAllClassAnnotations(serviceClass, ThriftService.class);
+        Set<ThriftService> serviceAnnotations = getEffectiveClassAnnotations(serviceClass, ThriftService.class);
         Preconditions.checkArgument(!serviceAnnotations.isEmpty(), "Service class %s is not annotated with @ThriftService", serviceClass.getName());
         Preconditions.checkArgument(serviceAnnotations.size() == 1,
                 "Service class %s has multiple conflicting @ThriftService annotations: %s",

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/BaseService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/BaseService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+
+@ThriftService("BaseService")
+public interface BaseService
+{
+    @ThriftMethod
+    public void fooBase();
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/BaseServiceImplementation.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/BaseServiceImplementation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+public class BaseServiceImplementation implements BaseService
+{
+    @Override
+    public void fooBase()
+    {
+        throw new IllegalStateException("NYI");
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/CombinedService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/CombinedService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+
+@ThriftService("CombinedService")
+public interface CombinedService extends DerivedServiceOne, DerivedServiceTwo
+{
+    @ThriftMethod
+    public void fooCombined();
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/CombinedServiceImplementation.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/CombinedServiceImplementation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+public class CombinedServiceImplementation implements CombinedService
+{
+    @Override
+    public void fooCombined()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooOne()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooTwo()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooBase()
+    {
+        throw new IllegalStateException("NYI");
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/DerivedServiceOne.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/DerivedServiceOne.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+
+@ThriftService("DerivedServiceOne")
+public interface DerivedServiceOne extends BaseService
+{
+    @ThriftMethod
+    public void fooOne();
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/DerivedServiceTwo.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/DerivedServiceTwo.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+
+@ThriftService("DerivedServiceTwo")
+public interface DerivedServiceTwo extends BaseService
+{
+    @ThriftMethod
+    public void fooTwo();
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/MultipleDerivedServiceImplementation.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/MultipleDerivedServiceImplementation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+public class MultipleDerivedServiceImplementation implements DerivedServiceOne, DerivedServiceTwo
+{
+    @Override
+    public void fooOne()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooTwo()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooBase()
+    {
+        throw new IllegalStateException("NYI");
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/MultipleDerivedServiceImplementationWithExplicitAnnotation.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/MultipleDerivedServiceImplementationWithExplicitAnnotation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+import com.facebook.swift.service.ThriftService;
+
+@ThriftService("MultipleDerivedServiceImplementation")
+public class MultipleDerivedServiceImplementationWithExplicitAnnotation implements DerivedServiceOne, DerivedServiceTwo
+{
+    @Override
+    public void fooOne()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooTwo()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooBase()
+    {
+        throw new IllegalStateException("NYI");
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/SingleDerivedServiceImplementation.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/SingleDerivedServiceImplementation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+public class SingleDerivedServiceImplementation implements DerivedServiceOne
+{
+    @Override
+    public void fooOne()
+    {
+        throw new IllegalStateException("NYI");
+    }
+
+    @Override
+    public void fooBase()
+    {
+        throw new IllegalStateException("NYI");
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/annotations/TestThriftServiceAnnotationConflicts.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/annotations/TestThriftServiceAnnotationConflicts.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.annotations;
+
+import com.facebook.swift.service.metadata.ThriftServiceMetadata;
+import org.testng.annotations.Test;
+
+// Tests that verify we correctly identify conflicts between inherited interfaces
+// annotated with @ThriftService
+public class TestThriftServiceAnnotationConflicts
+{
+    // Passes because only a single ancestor class/interface declares @ThriftService (BaseService)
+    //
+    // Implementation -- @ThriftService BaseService
+    //
+    @Test
+    public void testInheritBaseInterface()
+    {
+        ThriftServiceMetadata.getThriftServiceAnnotation(BaseServiceImplementation.class);
+    }
+
+    // Passes because even though multiple ancestor class/interfaces declare @ThriftService
+    // (BaseService and DerivedServiceOne), BaseService is inherited indirectly through
+    // DerivedServiceOne, so DerivedServiceOne's annotation takes precedence.
+    //
+    // Implementation -- @ThriftService DerivedServiceOne -- @ThriftService BaseService
+    //
+    @Test
+    public void testInheritSingleDerivedInterface()
+    {
+        ThriftServiceMetadata.getThriftServiceAnnotation(SingleDerivedServiceImplementation.class);
+    }
+
+    // Fails because multiple ancestors declare @ThriftService, and there is a conflict between
+    // the @ThriftService annotations on DerviceServiceOne and DerivceServiceTwo which cannot
+    // be resolved because neither takes precedence over the other
+    //
+    //                  / @ThriftService DerivedServiceOne \
+    // Implementation --                                      -- @ThriftService BaseService
+    //                  \ @ThriftService DerivedServiceTwo /
+    //
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testInheritMultipleDerivedInterfaces()
+    {
+        ThriftServiceMetadata.getThriftServiceAnnotation(MultipleDerivedServiceImplementation.class);
+    }
+
+    // Passes because even though the there would be a conflict, the implementation class explicitly
+    // declares it's own @ThriftService, overriding all those from ancestors and resolving the conflict
+    //
+    //                                 / @ThriftService DerivedServiceOne \
+    // @ThriftService Implementation --                                    -- @ThriftService BaseService
+    //                                 \ @ThriftService DerivedServiceTwo /
+    //
+    @Test
+    public void testInheritMultipleDerviedInterfacesWithExplicitAnnotation()
+    {
+        ThriftServiceMetadata.getThriftServiceAnnotation(MultipleDerivedServiceImplementationWithExplicitAnnotation.class);
+    }
+
+    // Passes because even though multiple ancestors declare @ThriftService, they are all inherited
+    // through CombinedService, so it's @ThriftService annotation takes precedence.
+    //
+    //                                                    / @ThriftService DerivedServiceOne \
+    // Implementation -- @ThriftService CombinedService --                                    -- @ThriftService BaseService
+    //                                                    \ @ThriftService DerivedServiceTwo /
+    //
+    @Test
+    public void testInheritCombinedInterface()
+    {
+        ThriftServiceMetadata.getThriftServiceAnnotation(CombinedServiceImplementation.class);
+    }
+}


### PR DESCRIPTION
... found

If you have class A implements interface B, which extends from interface C, and class A is NOT annotated with @ThriftService but interface B and C are each annotated with @ThriftService, this should be fine and not produce a conflict, because interface B's @ThriftService should hide the one from interface C.
