### PR TITLE
Fix SyncClientHelper

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/SyncClientHelpers.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/SyncClientHelpers.java
@@ -44,7 +44,7 @@ class SyncClientHelpers
             throws TException, InterruptedException
     {
         final ChannelBuffer[] responseHolder = new ChannelBuffer[1];
-        final TException[] exceptionHolder = new TTransportException[1];
+        final TException[] exceptionHolder = new TException[1];
         final CountDownLatch latch = new CountDownLatch(1);
 
         responseHolder[0] = null;

--- a/swift-service/src/main/java/com/facebook/swift/service/SyncClientHelpers.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/SyncClientHelpers.java
@@ -98,7 +98,7 @@ class SyncClientHelpers
             throws TException, InterruptedException
     {
 
-        final TException[] exceptionHolder = new TTransportException[1];
+        final TException[] exceptionHolder = new TException[1];
         final CountDownLatch latch = new CountDownLatch(1);
 
         exceptionHolder[0] = null;


### PR DESCRIPTION
exceptionHolder variable is an array of TException but is created with an array of type TTransportException. Therefore at runtime, when it is trying to hold a object of type TException, the jvm throws an ArrayStoreException and kills the system thread. Therefore the exception is not propagated back to the client code.
