### PR TITLE
Add support for annotations on service declarations

### DIFF
--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
@@ -119,7 +119,7 @@ exception returns [ThriftException value]
     ;
 
 service returns [Service value]
-    : ^(SERVICE k=IDENTIFIER ^(EXTENDS e=IDENTIFIER?) f=functions) { $value = new Service($k.text, $e.text, $f.value); }
+    : ^(SERVICE k=IDENTIFIER ^(EXTENDS e=IDENTIFIER?) f=functions t=type_annotations) { $value = new Service($k.text, $e.text, $f.value, $t.value); }
     ;
 
 

--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
@@ -126,7 +126,7 @@ exception
     ;
 
 service
-    : 'service' s=IDENTIFIER ('extends' e=IDENTIFIER)? '{' f=function* '}' -> ^(SERVICE $s ^(EXTENDS $e?) function*)
+    : 'service' s=IDENTIFIER ('extends' e=IDENTIFIER)? '{' f=function* '}' type_annotations? -> ^(SERVICE $s ^(EXTENDS $e?) function* type_annotations?)
     ;
 
 

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/Service.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/Service.java
@@ -33,7 +33,7 @@ public class Service
     private final Optional<String> parent;
     private final List<ThriftMethod> methods;
 
-    public Service(String name, String parent, List<ThriftMethod> methods)
+    public Service(String name, String parent, List<ThriftMethod> methods, List<TypeAnnotation> annotations)
     {
         this.name = checkNotNull(name, "name");
         this.parent = Optional.fromNullable(parent);

--- a/swift-idl-parser/src/test/resources/share/fb303/if/fb303.thrift
+++ b/swift-idl-parser/src/test/resources/share/fb303/if/fb303.thrift
@@ -22,6 +22,7 @@
  */
 
 namespace java com.facebook.fb303
+namespace java.swift com.facebook.swift.fb303
 namespace cpp facebook.fb303
 namespace perl Facebook.FB303
 
@@ -109,4 +110,4 @@ service FacebookService {
    */
   oneway void shutdown(),
 
-}
+} (priority = 'IMPORTANT')


### PR DESCRIPTION
FB C++ thrift added a priority annotation, which influences execution order of requests. In addition to annotating methods with priorities, it supports annotating services with priorities.

This change doesn't add support for priorities, just adds support for reading annotations attached to a service so that .thrift files using this syntax will still parse in the swift generator.
