### PR TITLE
Swift2ThriftGenerator is not quite comprehensive

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -254,6 +254,26 @@ public class Swift2ThriftGenerator {
                     }
                 }
             }
+            for (ThriftType ex : method.getValue().getExceptions().values()) {
+            	if (!verifyField(ex)) {
+                    ok = false;
+                    if (!quiet) {
+                        LOG.error("Unknown exception type {} in {}.{}",
+                                thriftTypeRenderer.toString(ex),
+                                service.getName(),
+                                method.getKey());
+                    }
+                }            	
+            }
+            if (!verifyField(method.getValue().getReturnType())) {
+                ok = false;
+                if (!quiet) {
+                    LOG.error("Unknown return type {} in {}.{}",
+                            thriftTypeRenderer.toString(method.getValue().getReturnType()),
+                            service.getName(),
+                            method.getKey());
+                }
+            }
         }
         knownServices.add(service);
         return ok;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
@@ -165,6 +165,8 @@ public class ThriftMethodProcessor
                       new TApplicationException(INTERNAL_ERROR,
                                                 "Internal error processing " + method.getName());
                     applicationException.initCause(e);
+                    System.err.println("Internal error processing " + method.getName());
+                    e.printStackTrace();
 
                     // Application exceptions are sent to client, and the connection can be reused
                     out.writeMessageBegin(new TMessage(name, TMessageType.EXCEPTION, sequenceId));


### PR DESCRIPTION
I think this feature is great and the addition of it prevents me from having to roll my own, which I was about to do, so thanks for that.

One problem I encountered though is that when types in other packages are references in service definitions as an exception or a return type, the code generator was not pulling in that other package in the same manner as it does for service parameters.  This commit extends that functionality to exceptions and return types as well.

There is a case in ThriftMethodProcessor where server side exceptions seemed to be getting swallowed quietly... I added a printStackTrace() to that method for more clarity.  I don't know if this is best way to handle this case but you can at least see the location to which I'm referring.

Thanks guys
