### PR TITLE
Make it possible to use full netty configuration options in Swift

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Inject;
 import io.airlift.units.Duration;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
@@ -83,8 +84,14 @@ public class ThriftClientManager implements Closeable
 
     public ThriftClientManager(ThriftCodecManager codecManager)
     {
+        this(codecManager, new NiftyClient());
+    }
+
+    @Inject
+    public ThriftClientManager(ThriftCodecManager codecManager, NiftyClient niftyClient)
+    {
         this.codecManager = codecManager;
-        this.niftyClient = new NiftyClient();
+        this.niftyClient = niftyClient;
     }
 
     public <T, C extends NiftyClientChannel> ListenableFuture<T> createClient(

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
@@ -15,9 +15,11 @@
  */
 package com.facebook.swift.service;
 
-import com.facebook.nifty.core.NettyConfigBuilder;
+import com.facebook.nifty.core.NettyServerConfig;
+import com.facebook.nifty.core.NettyServerConfigBuilder;
 import com.facebook.nifty.core.NettyServerTransport;
 import com.facebook.nifty.core.ThriftServerDef;
+import com.facebook.nifty.core.ThriftServerDefBuilder;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
@@ -31,11 +33,11 @@ import org.jboss.netty.util.Timer;
 import org.weakref.jmx.Managed;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.net.SocketAddress;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -54,13 +56,15 @@ public class ThriftServer implements Closeable
     }
 
     private final NettyServerTransport transport;
-    private final int workerThreads;
     private final int configuredPort;
     private final DefaultChannelGroup allChannels = new DefaultChannelGroup();
 
+    private final Executor workerExecutor;
     private final ExecutorService acceptorExecutor;
     private final ExecutorService ioExecutor;
-    private final ExecutorService workerExecutor;
+    private final Integer workerThreads;
+    private final int acceptorThreads;
+    private final int ioThreads;
 
     private final ServerChannelFactory serverChannelFactory;
 
@@ -83,14 +87,17 @@ public class ThriftServer implements Closeable
 
         configuredPort = config.getPort();
 
-        workerThreads = config.getWorkerThreads();
-
-        workerExecutor = newFixedThreadPool(workerThreads, new ThreadFactoryBuilder().setNameFormat("thrift-worker-%s").build());
-
         acceptorExecutor = newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("thrift-acceptor-%s").build());
+        acceptorThreads = config.getAcceptorThreadCount();
         ioExecutor = newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("thrift-io-%s").build());
+        ioThreads = config.getIoThreadCount();
 
-        serverChannelFactory = new NioServerSocketChannelFactory(acceptorExecutor, ioExecutor);
+        serverChannelFactory = new NioServerSocketChannelFactory(acceptorExecutor, acceptorThreads, ioExecutor, ioThreads);
+
+        workerThreads = config.getWorkerThreads();
+        workerExecutor = newFixedThreadPool(
+                getWorkerThreads(),
+                new ThreadFactoryBuilder().setNameFormat("thrift-worker-%s").build());
 
         ThriftServerDef thriftServerDef = ThriftServerDef.newBuilder()
                                                          .name("thrift")
@@ -100,21 +107,50 @@ public class ThriftServer implements Closeable
                                                          .withProcessorFactory(processorFactory)
                                                          .using(workerExecutor).build();
 
-        transport = new NettyServerTransport(thriftServerDef, new NettyConfigBuilder(), allChannels, timer);
+        NettyServerConfigBuilder nettyServerConfigBuilder = NettyServerConfig.newBuilder();
+
+        nettyServerConfigBuilder.setBossThreadCount(config.getAcceptorThreadCount());
+        nettyServerConfigBuilder.setWorkerThreadCount(config.getIoThreadCount());
+        nettyServerConfigBuilder.setTimer(timer);
+
+        NettyServerConfig nettyServerConfig = nettyServerConfigBuilder.build();
+
+        transport = new NettyServerTransport(thriftServerDef, nettyServerConfig, allChannels);
+    }
+
+    /**
+     * A ThriftServer constructor that takes raw Netty configuration parameters
+     */
+    public ThriftServer(NettyServerConfig nettyServerConfig, ThriftServerDef thriftServerDef)
+    {
+        configuredPort = thriftServerDef.getServerPort();
+        workerExecutor = thriftServerDef.getExecutor();
+        acceptorExecutor = nettyServerConfig.getBossExecutor();
+        acceptorThreads = nettyServerConfig.getBossThreadCount();
+        ioExecutor = nettyServerConfig.getWorkerExecutor();
+        ioThreads = nettyServerConfig.getWorkerThreadCount();
+        serverChannelFactory = new NioServerSocketChannelFactory(acceptorExecutor, acceptorThreads, ioExecutor, ioThreads);
+
+        if (workerExecutor instanceof ThreadPoolExecutor) {
+            workerThreads = ((ThreadPoolExecutor) workerExecutor).getPoolSize();
+        }
+        else {
+            // No way to ask a generic Executor for the number of threads it is running
+            workerThreads = null;
+        }
+
+        transport = new NettyServerTransport(thriftServerDef, nettyServerConfig, allChannels);
     }
 
     @Managed
-    public int getPort()
+    public Integer getPort()
     {
         if (configuredPort != 0) {
             return configuredPort;
         }
-
-        if (transport.getServerChannel() == null) {
-            throw new IllegalStateException("Cannot determine the randomly port before the server is started");
+        else {
+            return getBoundPort();
         }
-
-        return getBoundPort();
     }
 
     private int getBoundPort()
@@ -126,13 +162,26 @@ public class ThriftServer implements Closeable
             return inetSocketAddress.getPort();
         }
 
-        throw new IllegalStateException("Unable to determine the bound port");
+        // Cannot determine the randomly assigned port until the server is started
+        return 0;
     }
 
     @Managed
     public int getWorkerThreads()
     {
         return workerThreads;
+    }
+
+    @Managed
+    public int getAcceptorThreads()
+    {
+        return acceptorThreads;
+    }
+
+    @Managed
+    public int getIoThreads()
+    {
+        return ioThreads;
     }
 
     public synchronized boolean isRunning() {
@@ -162,7 +211,9 @@ public class ThriftServer implements Closeable
             try {
                 transport.stop();
 
-                shutdownExecutor(workerExecutor, "workerExecutor");
+                if (workerExecutor instanceof ExecutorService) {
+                    shutdownExecutor((ExecutorService) workerExecutor, "workerExecutor");
+                }
                 shutdownChannelFactory(serverChannelFactory, acceptorExecutor, ioExecutor, allChannels);
             }
             catch (InterruptedException e) {

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -26,8 +26,13 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class ThriftServerConfig
 {
+    private static final int DEFAULT_BOSS_THREAD_COUNT = 1;
+    private static final int DEFAULT_IO_WORKER_THREAD_COUNT = 2 * Runtime.getRuntime().availableProcessors();
+
     private int port;
     private int workerThreads = 200;
+    private int acceptorThreadCount = DEFAULT_BOSS_THREAD_COUNT;
+    private int ioThreadCount = DEFAULT_IO_WORKER_THREAD_COUNT;
     private Duration clientIdleTimeout;
 
     /**
@@ -87,6 +92,30 @@ public class ThriftServerConfig
     public ThriftServerConfig setClientIdleTimeout(Duration clientIdleTimeout)
     {
         this.clientIdleTimeout = clientIdleTimeout;
+        return this;
+    }
+
+    public int getAcceptorThreadCount()
+    {
+        return acceptorThreadCount;
+    }
+
+    @Config("thrift.acceptor-threads.count")
+    public ThriftServerConfig setAcceptorThreadCount(int acceptorThreadCount)
+    {
+        this.acceptorThreadCount = acceptorThreadCount;
+        return this;
+    }
+
+    public int getIoThreadCount()
+    {
+        return ioThreadCount;
+    }
+
+    @Config("thrift.io-threads.count")
+    public ThriftServerConfig setIoThreadCount(int ioThreadCount)
+    {
+        this.ioThreadCount = ioThreadCount;
         return this;
     }
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.swift.service.guice;
 
+import com.facebook.nifty.client.NiftyClient;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftClientManager.ThriftClientMetadata;
 import com.facebook.swift.service.ThriftMethodHandler;
@@ -42,6 +43,8 @@ public class ThriftClientModule implements Module
     @Override
     public void configure(Binder binder)
     {
+        binder.bind(NiftyClient.class).in(Scopes.SINGLETON);
+
         // Bind single shared ThriftClientManager
         binder.bind(ThriftClientManager.class).in(Scopes.SINGLETON);
 

--- a/swift-service/src/test/java/com/facebook/swift/service/protocol/TestClientProtocols.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/protocol/TestClientProtocols.java
@@ -16,7 +16,7 @@
 package com.facebook.swift.service.protocol;
 
 import com.facebook.nifty.client.FramedClientConnector;
-import com.facebook.nifty.core.NettyConfigBuilder;
+import com.facebook.nifty.core.NettyServerConfig;
 import com.facebook.nifty.core.NettyServerTransport;
 import com.facebook.nifty.core.ThriftServerDef;
 import com.facebook.nifty.duplex.TDuplexProtocolFactory;
@@ -39,7 +39,6 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TTransportException;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
-import org.jboss.netty.util.HashedWheelTimer;
 import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
@@ -125,7 +124,7 @@ public class TestClientProtocols
                                                  .withProcessor(processor)
                                                  .speaks(protocolFactory).build();
 
-            server = new NettyServerTransport(def, new NettyConfigBuilder(), new DefaultChannelGroup(), new HashedWheelTimer());
+            server = new NettyServerTransport(def, NettyServerConfig.newBuilder().build(), new DefaultChannelGroup());
             server.start();
         }
 


### PR DESCRIPTION
This diff makes it possible to pass a NiftyClient to construct a ThriftClientManager, and to pass a ThriftServerDef and NettyServerConfig to construct a ThriftServer.
