### PR TITLE
Fixed LoadGenerator to export stats to JMX.

### DIFF
--- a/swift-load-generator/pom.xml
+++ b/swift-load-generator/pom.xml
@@ -51,11 +51,6 @@
 
     <dependency>
       <groupId>io.airlift</groupId>
-      <artifactId>units</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.airlift</groupId>
       <artifactId>configuration</artifactId>
     </dependency>
 
@@ -77,6 +72,16 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>bootstrap</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>jmx</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.weakref</groupId>
+      <artifactId>jmxutils</artifactId>
     </dependency>
 
     <dependency>

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AbstractClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AbstractClientWorker.java
@@ -26,7 +26,6 @@ import java.util.Random;
 public abstract class AbstractClientWorker implements Runnable
 {
     protected final LoadGeneratorCommandLineConfig config;
-    protected final ThriftClientManager clientManager;
     protected final HostAndPort serverHostAndPort;
     private final Random randomGenerator = new Random();
     protected AtomicLong requestsProcessed = new AtomicLong(0);
@@ -34,11 +33,8 @@ public abstract class AbstractClientWorker implements Runnable
     protected AtomicLong requestsPending = new AtomicLong(0);
     private final int totalWeight;
 
-    public AbstractClientWorker(
-            ThriftClientManager clientManager,
-            LoadGeneratorCommandLineConfig config)
+    public AbstractClientWorker(LoadGeneratorCommandLineConfig config)
     {
-        this.clientManager = clientManager;
         this.config = config;
         this.serverHostAndPort = HostAndPort.fromParts(config.serverAddress, config.serverPort);
         this.totalWeight =


### PR DESCRIPTION
The bug was that 2 instances of A?SyncClientWorker were created. One was
used to export stats, the other to do actualy thrfit calls. The result
was that the exported counters were always 0.
With this fix, only one instance is created and stats are shown
correctly.
