### PR TITLE
Expose TStruct object when reading Thrift input stream

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/TProtocolReader.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/TProtocolReader.java
@@ -23,9 +23,11 @@ import org.apache.thrift.protocol.TMap;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolUtil;
 import org.apache.thrift.protocol.TSet;
+import org.apache.thrift.protocol.TStruct;
 import org.apache.thrift.protocol.TType;
 
 import javax.annotation.concurrent.NotThreadSafe;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,11 +55,12 @@ public class TProtocolReader
         return protocol;
     }
 
-    public void readStructBegin()
+    public TStruct readStructBegin()
             throws TException
     {
-        protocol.readStructBegin();
+        TStruct struct = protocol.readStructBegin();
         currentField = null;
+        return struct;
     }
 
     public void readStructEnd()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TStruct;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.util.CheckClassAdapter;
@@ -299,7 +300,7 @@ public class ThriftCodecByteCodeGenerator<T>
         read.loadVariable(protocol).invokeVirtual(
                 TProtocolReader.class,
                 "readStructBegin",
-                void.class
+                TStruct.class
         );
 
         // while (protocol.nextField())


### PR DESCRIPTION
To be able to replay an incoming data stream, the TStruct information
must be visible. Change the readStructBegin() method on the
TProtocolReader to expose this information.
