### PR TITLE
Add boxed variants of the primitive types to the Codec Manager

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/ThriftCodecManager.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/ThriftCodecManager.java
@@ -123,12 +123,12 @@ public class ThriftCodecManager
             }
         });
 
-        addBuiltinCodec(new BooleanThriftCodec());
-        addBuiltinCodec(new ByteThriftCodec());
-        addBuiltinCodec(new ShortThriftCodec());
-        addBuiltinCodec(new IntegerThriftCodec());
-        addBuiltinCodec(new LongThriftCodec());
-        addBuiltinCodec(new DoubleThriftCodec());
+        addBuiltinCodec(new BooleanThriftCodec(), ThriftType.BOOL_OBJ);
+        addBuiltinCodec(new ByteThriftCodec(), ThriftType.BYTE_OBJ);
+        addBuiltinCodec(new ShortThriftCodec(), ThriftType.I16_OBJ);
+        addBuiltinCodec(new IntegerThriftCodec(), ThriftType.I32_OBJ);
+        addBuiltinCodec(new LongThriftCodec(), ThriftType.I64_OBJ);
+        addBuiltinCodec(new DoubleThriftCodec(), ThriftType.DOUBLE_OBJ);
         addBuiltinCodec(new ByteBufferThriftCodec());
         addBuiltinCodec(new VoidThriftCodec());
 
@@ -181,9 +181,12 @@ public class ThriftCodecManager
      * Adds a ThriftCodec to the codec map, but does not register it with the catalog since builtins
      * should already be registered
      */
-    private void addBuiltinCodec(ThriftCodec<?> codec)
+    private void addBuiltinCodec(ThriftCodec<?> codec, ThriftType ... additionalThriftTypes)
     {
         typeCodecs.put(codec.getType(), codec);
+        for (ThriftType thriftType : additionalThriftTypes) {
+            typeCodecs.put(thriftType, codec);
+        }
     }
 
     public ThriftCatalog getCatalog()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
@@ -47,6 +47,13 @@ public class ThriftType
     public static final ThriftType STRING = new ThriftType(ThriftProtocolType.STRING, ByteBuffer.class);
     public static final ThriftType VOID = new ThriftType(ThriftProtocolType.STRUCT, void.class);
 
+    public static final ThriftType BOOL_OBJ = new ThriftType(ThriftProtocolType.BOOL, Boolean.class);
+    public static final ThriftType BYTE_OBJ = new ThriftType(ThriftProtocolType.BYTE, Byte.class);
+    public static final ThriftType DOUBLE_OBJ = new ThriftType(ThriftProtocolType.DOUBLE, Double.class);
+    public static final ThriftType I16_OBJ = new ThriftType(ThriftProtocolType.I16, Short.class);
+    public static final ThriftType I32_OBJ = new ThriftType(ThriftProtocolType.I32, Integer.class);
+    public static final ThriftType I64_OBJ = new ThriftType(ThriftProtocolType.I64, Long.class);
+
     public static ThriftType struct(ThriftStructMetadata<?> structMetadata)
     {
         return new ThriftType(structMetadata);


### PR DESCRIPTION
When doing reverse lookup of codecs for types and trying to resolve
container types (e.g. List<Long>), the codec manager needs to be able
to correctly return the codec for a java.lang.Long object. So these
types must be registered with the ThriftCodecManager, too.
