### PR TITLE
Allow binding custom thrift codecs by class

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecBinder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecBinder.java
@@ -47,16 +47,49 @@ public class ThriftCodecBinder
         this.binder = binder;
     }
 
-    public void bindThriftCodec(ThriftCodec<?> thriftCodec)
+    public void bindCustomThriftCodec(ThriftCodec<?> thriftCodec)
     {
         Preconditions.checkNotNull(thriftCodec, "thriftCodec is null");
 
-        // bind the instance to the internal thrift codec set
+        // bind the custom codec instance to the internal thrift codec set
         newSetBinder(binder, new TypeLiteral<ThriftCodec<?>>() {}, InternalThriftCodec.class).addBinding().toInstance(thriftCodec);
 
-        // make the codec available to user code for binding
+        // make the custom codec available to user code for binding
         Type type = thriftCodec.getType().getJavaType();
         binder.bind(getThriftCodecKey(type)).toProvider(new ThriftCodecProvider(type)).in(Scopes.SINGLETON);
+    }
+
+    public void bindCustomThriftCodec(Class<? extends ThriftCodec<?>> thriftCodecType)
+    {
+        Preconditions.checkNotNull(thriftCodecType, "thriftCodecType is null");
+
+        // bind the custom codec type to the internal thrift codec set
+        newSetBinder(binder, new TypeLiteral<ThriftCodec<?>>() {}, InternalThriftCodec.class).addBinding().to(thriftCodecType);
+
+        // make the custom codec available to user code for binding
+        binder.bind(thriftCodecType).in(Scopes.SINGLETON);
+    }
+
+    public void bindCustomThriftCodec(TypeLiteral<? extends ThriftCodec<?>> thriftCodecType)
+    {
+        Preconditions.checkNotNull(thriftCodecType, "thriftCodecType is null");
+
+        // bind the custom codec type to the internal thrift codec set
+        newSetBinder(binder, new TypeLiteral<ThriftCodec<?>>() {}, InternalThriftCodec.class).addBinding().to(thriftCodecType);
+
+        // make the custom codec available to user code for binding
+        binder.bind(thriftCodecType).in(Scopes.SINGLETON);
+    }
+
+    public void bindCustomThriftCodec(Key<? extends ThriftCodec<?>> thriftCodecKey)
+    {
+        Preconditions.checkNotNull(thriftCodecKey, "thriftCodecKey is null");
+
+        // bind the custom codec type to the internal thrift codec set
+        newSetBinder(binder, new TypeLiteral<ThriftCodec<?>>() {}, InternalThriftCodec.class).addBinding().to(thriftCodecKey);
+
+        // make the custom codec available to user code for binding
+        binder.bind(thriftCodecKey).in(Scopes.SINGLETON);
     }
 
     public void bindThriftCodec(Class<?> type)

--- a/swift-codec/src/test/java/com/facebook/swift/codec/guice/TestThriftCodecModule.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/guice/TestThriftCodecModule.java
@@ -59,7 +59,7 @@ public class TestThriftCodecModule
 
                         thriftCodecBinder(binder).bindThriftCodec(new TypeLiteral<Map<Integer, List<String>>>() {});
 
-                        thriftCodecBinder(binder).bindThriftCodec(new ThriftCodec<ValueClass>()
+                        thriftCodecBinder(binder).bindCustomThriftCodec(new ThriftCodec<ValueClass>()
                         {
                             @Override
                             public ThriftType getType()


### PR DESCRIPTION
All overloads of bindThriftCodec() actually assumed the class you were referring to was a thrift type, and created a binding for the codec using a provider that would ask the codec manager for an appropriate codec. Only one overload let you install a custom codec, and it required an instance, which is problematic because sometimes you want to create a custom codec that depends on an injected ThriftCatalog or ThriftCodecManager.

I renamed this overload bindThriftCustomCodec() to help reduce confusion between overloads that take a thrift type argument, and overloads that take a codec argument, and then added more overloads of this bindThriftCustomCodec() that will take class, typeliteral, and key.
