### PR TITLE
Add bindings for ThriftCatalog and ThriftCodecFactory

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/ThriftCodecManager.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/ThriftCodecManager.java
@@ -64,12 +64,6 @@ public class ThriftCodecManager
         this(new CompilerThriftCodecFactory(), codecs);
     }
 
-    @Inject
-    public ThriftCodecManager(@InternalThriftCodec Set<ThriftCodec<?>> codecs)
-    {
-        this(new CompilerThriftCodecFactory(), codecs);
-    }
-
     public ThriftCodecManager(ThriftCodecFactory factory, ThriftCodec<?>... codecs)
     {
         this(factory, new ThriftCatalog(), ImmutableSet.copyOf(codecs));
@@ -80,7 +74,8 @@ public class ThriftCodecManager
         this(factory, new ThriftCatalog(), codecs);
     }
 
-    public ThriftCodecManager(final ThriftCodecFactory factory, final ThriftCatalog catalog, Set<ThriftCodec<?>> codecs)
+    @Inject
+    public ThriftCodecManager(final ThriftCodecFactory factory, final ThriftCatalog catalog, @InternalThriftCodec Set<ThriftCodec<?>> codecs)
     {
         Preconditions.checkNotNull(factory, "factory is null");
         Preconditions.checkNotNull(catalog, "catalog is null");

--- a/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecModule.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecModule.java
@@ -18,6 +18,9 @@ package com.facebook.swift.codec.guice;
 import com.facebook.swift.codec.InternalThriftCodec;
 import com.facebook.swift.codec.ThriftCodec;
 import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.codec.internal.ThriftCodecFactory;
+import com.facebook.swift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.swift.codec.metadata.ThriftCatalog;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -33,6 +36,8 @@ public class ThriftCodecModule implements Module
         binder.disableCircularProxies();
         binder.requireExplicitBindings();
 
+        binder.bind(ThriftCodecFactory.class).to(CompilerThriftCodecFactory.class).in(Scopes.SINGLETON);
+        binder.bind(ThriftCatalog.class).in(Scopes.SINGLETON);
         binder.bind(ThriftCodecManager.class).in(Scopes.SINGLETON);
         newSetBinder(binder, new TypeLiteral<ThriftCodec<?>>() {}, InternalThriftCodec.class).permitDuplicates();
     }


### PR DESCRIPTION
This is mainly to allow binding of custom codecs that need a ThriftCatalog injected. Was trying to get this catalog via injecting a ThriftCodecManager and using codecManager.getCatalog(), but this doesn't work if you want your bound custom codec to be in the internal codec set used to create the ThriftCodecManager (because it creates a dependency loop).
