### PR TITLE
Add @ThriftEnum annotation

### DIFF
--- a/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftEnum.java
+++ b/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftEnum.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE})
+public @interface ThriftEnum
+{
+    String value() default "";
+}

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
@@ -331,7 +331,7 @@ public class ThriftCatalog
     {
         ThriftEnumMetadata<?> enumMetadata = enums.get(enumClass);
         if (enumMetadata == null) {
-            enumMetadata = new ThriftEnumMetadata<>((Class<T>) enumClass);
+            enumMetadata = new ThriftEnumMetadataBuilder<>((Class<T>) enumClass).build();
 
             ThriftEnumMetadata<?> current = enums.putIfAbsent(enumClass, enumMetadata);
             if (current != null) {

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadata.java
@@ -33,11 +33,17 @@ public class ThriftEnumMetadata<T extends Enum<T>>
     private final Class<T> enumClass;
     private final Map<Integer, T> byEnumValue;
     private final Map<T, Integer> byEnumConstant;
+    private final String enumName;
 
-    public ThriftEnumMetadata(Class<T> enumClass)
+    public ThriftEnumMetadata(
+            String enumName,
+            Class<T> enumClass)
             throws RuntimeException
     {
+        Preconditions.checkNotNull(enumName, "enumName must not be null");
         Preconditions.checkNotNull(enumClass, "enumClass must not be null");
+
+        this.enumName = enumName;
         this.enumClass = enumClass;
 
         Method enumValueMethod = null;
@@ -96,6 +102,11 @@ public class ThriftEnumMetadata<T extends Enum<T>>
             byEnumValue = null;
             byEnumConstant = null;
         }
+    }
+
+    public String getEnumName()
+    {
+        return enumName;
     }
 
     public Class<T> getEnumClass()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadataBuilder.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.metadata;
+
+import com.facebook.swift.codec.ThriftEnum;
+import com.facebook.swift.codec.ThriftStruct;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class ThriftEnumMetadataBuilder<T extends Enum<T>>
+{
+    private final Class<T> enumClass;
+    private final String enumName;
+
+    public ThriftEnumMetadataBuilder(Class<T> enumClass)
+    {
+        this.enumClass = enumClass;
+        this.enumName = extractEnumName(enumClass);
+    }
+
+    public ThriftEnumMetadata<T> build()
+    {
+        return new ThriftEnumMetadata<>(enumName, enumClass);
+    }
+
+    private String extractEnumName(Class<T> enumClass)
+    {
+        ThriftEnum annotation = enumClass.getAnnotation(ThriftEnum.class);
+        if (annotation == null) {
+            return enumClass.getSimpleName();
+        }
+        else if (!annotation.value().isEmpty()) {
+            return annotation.value();
+        }
+        else {
+            return enumClass.getSimpleName();
+        }
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/TestThriftCodecManager.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/TestThriftCodecManager.java
@@ -18,6 +18,7 @@ package com.facebook.swift.codec;
 import com.facebook.swift.codec.internal.ThriftCodecFactory;
 import com.facebook.swift.codec.internal.coercion.DefaultJavaCoercions;
 import com.facebook.swift.codec.metadata.ThriftEnumMetadata;
+import com.facebook.swift.codec.metadata.ThriftEnumMetadataBuilder;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata;
 import com.facebook.swift.codec.metadata.ThriftType;
 import com.google.common.collect.ImmutableList;
@@ -98,8 +99,8 @@ public class TestThriftCodecManager
     public void testEnum()
             throws Exception
     {
-        ThriftEnumMetadata<Fruit> fruitEnumMetadata = new ThriftEnumMetadata<>(Fruit.class);
-        ThriftEnumMetadata<Letter> letterEnumMetadata = new ThriftEnumMetadata<>(Letter.class);
+        ThriftEnumMetadata<Fruit> fruitEnumMetadata = new ThriftEnumMetadataBuilder<>(Fruit.class).build();
+        ThriftEnumMetadata<Letter> letterEnumMetadata = new ThriftEnumMetadataBuilder<>(Letter.class).build();
         testRoundTripSerialize(Fruit.CHERRY);
         testRoundTripSerialize(Letter.C);
         testRoundTripSerialize(enumType(fruitEnumMetadata), Fruit.CHERRY);

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/template/ThriftTypeRenderer.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/template/ThriftTypeRenderer.java
@@ -46,7 +46,7 @@ public class ThriftTypeRenderer implements AttributeRenderer
             case I16:       return "i16";
             case I32:       return "i32";
             case I64:       return "i64";
-            case ENUM:      return prefix(t) + t.getEnumMetadata().getEnumClass().getSimpleName();
+            case ENUM:      return prefix(t) + t.getEnumMetadata().getEnumName();
             case MAP:       return "map<" + toString(t.getKeyType()) + ", " + toString(t.getValueType()) + ">";
             case SET:       return "set<" + toString(t.getValueType()) + ">";
             case LIST:      return "list<" + toString(t.getValueType()) + ">";

--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -18,7 +18,7 @@ namespace java.swift <context.namespace>
 >>
 
 _enum(enum) ::= <<
-enum <enum.enumClass.simpleName> {
+enum <enum.enumName> {
 <if(enum.explicitThriftValue)><_enumWithValues(enum)><else><_enumWithoutValues(enum)><endif>
 }
 >>


### PR DESCRIPTION
This allows a java enum corresponding to a thrift enum to be annotated with an indication of what the corresponding name for the enum should be in the .thrift file
