### PR TITLE
[swift2thrift] Pass javadoc comments through

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <module>swift-annotations</module>
     <module>swift-codec</module>
     <module>swift-idl-parser</module>
+    <module>swift-javadoc</module>
     <module>swift-service</module>
     <module>swift-generator</module>
     <module>swift-generator-cli</module>

--- a/swift-codec/src/main/java/com/facebook/swift/codec/ThriftDocumentation.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/ThriftDocumentation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD})
+public @interface ThriftDocumentation
+{
+    String[] value() default {};
+}

--- a/swift-codec/src/main/java/com/facebook/swift/codec/ThriftOrder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/ThriftOrder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD})
+public @interface ThriftOrder
+{
+    int value();
+}

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
@@ -16,6 +16,7 @@
 package com.facebook.swift.codec.metadata;
 
 import com.facebook.swift.codec.ThriftDocumentation;
+import com.facebook.swift.codec.ThriftOrder;
 import com.facebook.swift.codec.ThriftStruct;
 import com.facebook.swift.codec.internal.coercion.DefaultJavaCoercions;
 import com.facebook.swift.codec.internal.coercion.FromThrift;
@@ -439,6 +440,26 @@ public class ThriftCatalog
             // ignore
         }
         return ImmutableList.<String>of();
+    }
+
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public static Integer getMethodOrder(Method method)
+    {
+        ThriftOrder order = method.getAnnotation(ThriftOrder.class);
+
+        if (order == null) {
+            try {
+                Class<?> objectClass = method.getDeclaringClass();
+                Class<?> swiftDocsClass = getClassLoaderOf(objectClass).loadClass(objectClass.getName() + "$swift_docs");
+
+                order = swiftDocsClass.getDeclaredMethod(method.getName()).getAnnotation(ThriftOrder.class);
+            }
+            catch (ReflectiveOperationException e) {
+                // ignored
+            }
+        }
+
+        return order == null ? null : order.value();
     }
 
     private <T> ThriftStructMetadata<T> extractThriftStructMetadata(Class<T> structClass)

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.swift.codec.metadata;
 
+import com.facebook.swift.codec.ThriftDocumentation;
 import com.facebook.swift.codec.ThriftStruct;
 import com.facebook.swift.codec.internal.coercion.DefaultJavaCoercions;
 import com.facebook.swift.codec.internal.coercion.FromThrift;
@@ -29,6 +30,7 @@ import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
@@ -359,6 +361,86 @@ public class ThriftCatalog
         return (ThriftStructMetadata<T>) structMetadata;
     }
 
+    private static ClassLoader getClassLoaderOf(Class<?> cls) throws ClassNotFoundException
+    {
+        ClassLoader loader = cls.getClassLoader();
+        if (loader == null) {
+            throw new ClassNotFoundException("null class loader");
+        }
+        return loader;
+    }
+
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public static ImmutableList<String> getThriftDocumentation(Class<?> objectClass)
+    {
+        ThriftDocumentation documentation = objectClass.getAnnotation(ThriftDocumentation.class);
+
+        if (documentation == null) {
+            try {
+                Class<?> swiftDocsClass = getClassLoaderOf(objectClass).loadClass(objectClass.getName() + "$swift_docs");
+
+                documentation = swiftDocsClass.getAnnotation(ThriftDocumentation.class);
+            }
+            catch (ClassNotFoundException e) {
+                // ignored
+            }
+        }
+
+        return documentation == null ? ImmutableList.<String>of() : ImmutableList.copyOf(documentation.value());
+    }
+
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public static ImmutableList<String> getThriftDocumentation(Method method)
+    {
+        ThriftDocumentation documentation = method.getAnnotation(ThriftDocumentation.class);
+
+        if (documentation == null) {
+            try {
+                Class<?> objectClass = method.getDeclaringClass();
+                Class<?> swiftDocsClass = getClassLoaderOf(objectClass).loadClass(objectClass.getName() + "$swift_docs");
+
+                documentation = swiftDocsClass.getDeclaredMethod(method.getName()).getAnnotation(ThriftDocumentation.class);
+            }
+            catch (ReflectiveOperationException e) {
+                // ignored
+            }
+        }
+
+        return documentation == null ? ImmutableList.<String>of() : ImmutableList.copyOf(documentation.value());
+    }
+
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public static ImmutableList<String> getThriftDocumentation(Field field)
+    {
+        ThriftDocumentation documentation = field.getAnnotation(ThriftDocumentation.class);
+
+        if (documentation == null) {
+            try {
+                Class<?> objectClass = field.getDeclaringClass();
+                Class<?> swiftDocsClass = getClassLoaderOf(objectClass).loadClass(objectClass.getName() + "$swift_docs");
+
+                documentation = swiftDocsClass.getDeclaredField(field.getName()).getAnnotation(ThriftDocumentation.class);
+            }
+            catch (ReflectiveOperationException e) {
+                // ignored
+            }
+        }
+
+        return documentation == null ? ImmutableList.<String>of() : ImmutableList.copyOf(documentation.value());
+    }
+
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    public static <T extends Enum<T>> ImmutableList<String> getThriftDocumentation(Enum<T> enumConstant)
+    {
+        try {
+            Field f = enumConstant.getDeclaringClass().getField(enumConstant.name());
+            return getThriftDocumentation(f);
+        } catch (ReflectiveOperationException e) {
+            // ignore
+        }
+        return ImmutableList.<String>of();
+    }
+
     private <T> ThriftStructMetadata<T> extractThriftStructMetadata(Class<T> structClass)
     {
         Preconditions.checkNotNull(structClass, "structClass is null");
@@ -390,4 +472,5 @@ public class ThriftCatalog
                     top);
         }
     }
+
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadata.java
@@ -17,10 +17,12 @@ package com.facebook.swift.codec.metadata;
 
 import com.facebook.swift.codec.ThriftEnumValue;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.concurrent.Immutable;
@@ -34,6 +36,8 @@ public class ThriftEnumMetadata<T extends Enum<T>>
     private final Map<Integer, T> byEnumValue;
     private final Map<T, Integer> byEnumConstant;
     private final String enumName;
+    private final ImmutableList<String> documentation;
+    private final ImmutableMap<T, ImmutableList<String>> elementDocs;
 
     public ThriftEnumMetadata(
             String enumName,
@@ -74,6 +78,7 @@ public class ThriftEnumMetadata<T extends Enum<T>>
             }
         }
 
+        ImmutableMap.Builder<T, ImmutableList<String>> elementDocs = ImmutableMap.builder();
         if (enumValueMethod != null) {
             ImmutableMap.Builder<Integer, T> byEnumValue = ImmutableMap.builder();
             ImmutableMap.Builder<T, Integer> byEnumConstant = ImmutableMap.builder();
@@ -94,6 +99,7 @@ public class ThriftEnumMetadata<T extends Enum<T>>
 
                 byEnumValue.put(value, enumConstant);
                 byEnumConstant.put(enumConstant, value);
+                elementDocs.put(enumConstant, ThriftCatalog.getThriftDocumentation(enumConstant));
             }
             this.byEnumValue = byEnumValue.build();
             this.byEnumConstant = byEnumConstant.build();
@@ -101,7 +107,12 @@ public class ThriftEnumMetadata<T extends Enum<T>>
         else {
             byEnumValue = null;
             byEnumConstant = null;
+            for (T enumConstant : enumClass.getEnumConstants()) {
+                elementDocs.put(enumConstant, ThriftCatalog.getThriftDocumentation(enumConstant));
+            }
         }
+        this.elementDocs = elementDocs.build();
+        this.documentation = ThriftCatalog.getThriftDocumentation(enumClass);
     }
 
     public String getEnumName()
@@ -127,6 +138,16 @@ public class ThriftEnumMetadata<T extends Enum<T>>
     public Map<T, Integer> getByEnumConstant()
     {
         return byEnumConstant;
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
+    }
+
+    public Map<T, ImmutableList<String>> getElementsDocumentation()
+    {
+        return elementDocs;
     }
 
     @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
@@ -37,6 +37,7 @@ public class ThriftFieldMetadata
     private final List<ThriftInjection> injections;
     private final ThriftExtraction extraction;
     private final TypeCoercion coercion;
+    private final ImmutableList<String> documentation;
 
     public ThriftFieldMetadata(
             short id,
@@ -59,6 +60,17 @@ public class ThriftFieldMetadata
         this.injections = ImmutableList.copyOf(injections);
         this.extraction = extraction;
         this.coercion = coercion;
+
+        if (extraction instanceof ThriftFieldExtractor) {
+            ThriftFieldExtractor e = (ThriftFieldExtractor)extraction;
+            this.documentation = ThriftCatalog.getThriftDocumentation(e.getField());
+        } else if (extraction instanceof ThriftMethodExtractor) {
+            ThriftMethodExtractor e = (ThriftMethodExtractor)extraction;
+            this.documentation = ThriftCatalog.getThriftDocumentation(e.getMethod());
+        } else {
+            // no extraction = no documentation
+            this.documentation = ImmutableList.of();
+        }
     }
 
     public short getId()
@@ -109,6 +121,11 @@ public class ThriftFieldMetadata
     public TypeCoercion getCoercion()
     {
         return coercion;
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
     }
 
     @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
@@ -37,6 +37,7 @@ public class ThriftStructMetadata<T>
     private final Class<?> builderClass;
     private final ThriftMethodInjection builderMethod;
 
+    private final ImmutableList<String> documentation;
     private final SortedMap<Short, ThriftFieldMetadata> fields;
     private final List<ThriftFieldMetadata> unsortedFields;
 
@@ -48,6 +49,7 @@ public class ThriftStructMetadata<T>
             Class<T> structClass,
             Class<?> builderClass,
             ThriftMethodInjection builderMethod,
+            List<String> documentation,
             List<ThriftFieldMetadata> fields,
             ThriftConstructorInjection constructor,
             List<ThriftMethodInjection> methodInjections)
@@ -58,6 +60,7 @@ public class ThriftStructMetadata<T>
         this.structClass = checkNotNull(structClass, "structClass is null");
         this.constructor = checkNotNull(constructor, "constructor is null");
         this.unsortedFields = ImmutableList.copyOf(fields);
+        this.documentation = ImmutableList.copyOf(checkNotNull(documentation, "documentation is null"));
         this.fields = ImmutableSortedMap.copyOf(uniqueIndex(checkNotNull(fields, "fields is null"), new Function<ThriftFieldMetadata, Short>()
         {
             @Override
@@ -92,6 +95,11 @@ public class ThriftStructMetadata<T>
     public ThriftFieldMetadata getField(int id)
     {
         return fields.get((short) id);
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
     }
 
     public Collection<ThriftFieldMetadata> getFields()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
@@ -69,6 +69,7 @@ public class ThriftStructMetadataBuilder<T>
     private final Class<T> structClass;
     private final Class<?> builderClass;
 
+    private final List<String> documentation;
     private final List<FieldMetadata> fields = newArrayList();
 
     // readers
@@ -96,6 +97,8 @@ public class ThriftStructMetadataBuilder<T>
         structName = extractStructName();
         // get the builder class from the annotation or from the Java class
         builderClass = extractBuilderClass();
+        // grab any documentation from the annotation or saved JavaDocs
+        documentation = ThriftCatalog.getThriftDocumentation(structClass);
         // extract all of the annotated constructor and report an error if
         // there is more than one or none
         // also extract thrift fields from the annotated parameters and verify
@@ -403,7 +406,12 @@ public class ThriftStructMetadataBuilder<T>
     private static String extractFieldName(Method method)
     {
         checkNotNull(method, "method is null");
-        String methodName = method.getName();
+        return extractFieldName(method.getName());
+    }
+
+    public static String extractFieldName(String methodName)
+    {
+        checkNotNull(methodName, "methodName is null");
         if ((methodName.startsWith("get") || methodName.startsWith("set")) && methodName.length() > 3) {
             String name = Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
             return name;
@@ -415,7 +423,6 @@ public class ThriftStructMetadataBuilder<T>
         else {
             return methodName;
         }
-
     }
 
     private boolean isValidateGetter(Method method)
@@ -619,6 +626,7 @@ public class ThriftStructMetadataBuilder<T>
                 structClass,
                 builderClass,
                 builderMethodInjection,
+                ImmutableList.copyOf(documentation),
                 ImmutableList.copyOf(fieldsMetadata),
                 constructorInjection,
                 methodInjections

--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -10,44 +10,47 @@ namespace java.swift <context.namespace>
 
 <context.includes : {inc | include "<inc>"}; separator="\n">
 
-<context.enums : {e | <_enum(e)>}; separator="\n">
+<context.enums : {e | <_enum(e)>}; separator="\n\n">
 
-<context.structs : {s | <_struct(s)>}; separator="\n">
+<context.structs : {s | <_struct(s)>}; separator="\n\n">
 
-<context.services : {s | <_service(s)>}; separator="\n">
+<context.services : {s | <_service(s)>}; separator="\n\n">
+
 >>
 
 _enum(enum) ::= <<
+<_doc(enum.documentation)><\\\>
 enum <enum.enumName> {
-<if(enum.explicitThriftValue)><_enumWithValues(enum)><else><_enumWithoutValues(enum)><endif>
+  <enum.elementsDocumentation : {enumElem | <_doc(enum.elementsDocumentation.(enumElem))><\\\>
+  <enumElem><_maybeEnumValue(enum, enumElem)>}; separator=", ">
 }
 >>
 
-_enumWithValues(enum) ::= <<
-  <enum.byEnumConstant : {enumElem | <enumElem>=<enum.byEnumConstant.(enumElem)>}; separator=", ">
->>
-
-_enumWithoutValues(enum) ::= <<
-  <enum.enumClass.enumConstants; separator=", ">
+_maybeEnumValue(enum, enumElem) ::= <<
+<if(enum.byEnumConstant)>=<enum.byEnumConstant.(enumElem)><endif>
 >>
 
 _struct(struct) ::= <<
+<_doc(struct.documentation)><\\\>
 <if(struct.exception)>exception<else>struct<endif> <struct.structName> {
   <struct.unsortedFields : {f | <_field(f)>;}; separator="\n">
 }
 >>
 
 _field(field) ::= <<
+<_doc(field.documentation)><\\\>
 <field.id>: <field.type> <field.name>
 >>
 
 _service(service) ::= <<
+<_doc(service.documentation)><\\\>
 service <service> <if(service.parentService)>extends <service.parentService> <endif>{
   <service.declaredMethods : {method | <_method(service.declaredMethods.(method))>}; separator="\n">
 }
 >>
 
 _method(method) ::= <<
+<_doc(method.documentation)><\\\>
 <if(method.oneway)>oneway <endif><\\\>
 <method.returnType> <method.name><\\\>
 (<_methodParameters(method.parameters)>)<\\\>
@@ -61,4 +64,12 @@ _methodParameters(params) ::= <<
 
 _methodExceptions(exceptions) ::= <<
 <if(exceptions)> throws (<exceptions : {e | <e>: <exceptions.(e)> ex<e>}; separator=", ">)<endif>
+>>
+
+_doc(documentation) ::= <<
+<if(documentation)>
+/**
+<documentation : {line |  * <line>}; separator="\n">
+ */
+<endif>
 >>

--- a/swift-javadoc/pom.xml
+++ b/swift-javadoc/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.swift</groupId>
+        <artifactId>swift-root</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>swift-javadoc</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <description>Java 6 annotator for saving JavaDocs</description>
+
+    <properties>
+        <fb.main.basedir>${project.parent.basedir}</fb.main.basedir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- need to disable annotation processors, or it will try to run the one we're building while we build it... -->
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/swift-javadoc/src/main/java/com/facebook/swift/javadoc/JavaDocProcessor.java
+++ b/swift-javadoc/src/main/java/com/facebook/swift/javadoc/JavaDocProcessor.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.javadoc;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.*;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@SupportedAnnotationTypes({"com.facebook.swift.service.ThriftService",
+                           "com.facebook.swift.codec.ThriftStruct",
+                           "com.facebook.swift.codec.ThriftEnum"
+})
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
+public class JavaDocProcessor extends AbstractProcessor
+{
+    private Messager messager;
+    private Elements elementUtils;
+    private Filer filer;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv)
+    {
+        super.init(processingEnv);
+        messager = processingEnv.getMessager();
+        elementUtils = processingEnv.getElementUtils();
+        filer = processingEnv.getFiler();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)
+    {
+        for (TypeElement annotation : annotations) {
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                if (element instanceof TypeElement) {
+                    note("Processing compile-time metadata of %s", element);
+                    export((TypeElement) element);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static class FieldOrMethodDoc
+    {
+        public enum FieldOrMethod
+        {
+            FIELD, METHOD
+        }
+
+        private FieldOrMethod fOrM;
+        private List<String> doc;
+
+        public FieldOrMethod getFieldOrMethod() { return fOrM; }
+        private List<String> getDoc() { return doc; }
+
+        public FieldOrMethodDoc(FieldOrMethod fieldOrMethod, List<String> doc) {
+            this.fOrM = fieldOrMethod;
+            this.doc = doc;
+        }
+    }
+
+    @SuppressWarnings("PMD.UselessParentheses")
+    private void export(TypeElement typeElement)
+    {
+        if (typeElement.getQualifiedName().toString().contains("$swift_docs")) {
+            return;
+        }
+
+        switch (typeElement.getKind()) {
+            case CLASS:
+            case INTERFACE:
+            case ENUM:
+                break;
+            default:
+                warn("Non-class was annotated: %s %s", typeElement.getKind(), typeElement);
+
+                return;
+        }
+
+        FileObject file;
+
+        try {
+            file = filer.createSourceFile(typeElement.getQualifiedName() + "$swift_docs", typeElement);
+        }
+        catch (IOException e) {
+            error("Failed to create %s$swift_docs file", typeElement);
+
+            return;
+        }
+
+        List<String> serviceDocumentation = getComment(typeElement);
+        Map<String, FieldOrMethodDoc> documentation = new LinkedHashMap<>();
+
+        for (Element member : elementUtils.getAllMembers(typeElement)) {
+            if (member instanceof ExecutableElement &&
+                (isAnnotatedWith(member, "com.facebook.swift.service.ThriftMethod") ||
+                 isAnnotatedWith(member, "com.facebook.swift.codec.ThriftField"))) {
+                    // service method or method accessor for a struct field
+                    String methodName = member.getSimpleName().toString();
+                documentation.put(methodName, new FieldOrMethodDoc(FieldOrMethodDoc.FieldOrMethod.METHOD, getComment(member)));
+            } else if ((member instanceof VariableElement &&
+                        isAnnotatedWith(member, "com.facebook.swift.codec.ThriftField")) ||
+                       member.getKind() == ElementKind.ENUM_CONSTANT) {
+                // field or enum constant
+                String fieldName = member.getSimpleName().toString();
+                documentation.put(fieldName, new FieldOrMethodDoc(FieldOrMethodDoc.FieldOrMethod.FIELD, getComment(member)));
+            }
+        }
+
+        try (PrintStream out = new PrintStream(file.openOutputStream())) {
+            // need to do the indexOf() stuff in order to handle nested classes properly
+            String binaryName = elementUtils.getBinaryName(typeElement).toString();
+            String className = binaryName.substring(binaryName.lastIndexOf('.') + 1);
+
+            out.printf("package %s;%n", elementUtils.getPackageOf(typeElement).getQualifiedName());
+            out.println();
+            out.println("import com.facebook.swift.codec.ThriftDocumentation;");
+            out.println();
+
+            printDoc(out, serviceDocumentation, 0);
+
+            out.printf("class %s$swift_docs%n", className);
+            out.println("{");
+
+            for (Map.Entry<String, FieldOrMethodDoc> entry : documentation.entrySet()) {
+                String name = entry.getKey();
+                FieldOrMethodDoc docs = entry.getValue();
+
+                printDoc(out, docs.getDoc(), 1);
+                if (docs.getFieldOrMethod() == FieldOrMethodDoc.FieldOrMethod.METHOD) {
+                    out.printf("    private void %s() {}%n", name);
+                } else if (docs.getFieldOrMethod() == FieldOrMethodDoc.FieldOrMethod.FIELD) {
+                    out.printf("    private int %s;%n", name);
+                }
+                out.println();
+            }
+
+            out.println("}");
+        }
+        catch (IOException e) {
+            error("Failed to write to %s$swift_docs file", typeElement);
+        }
+    }
+
+    // Derived from Apache Commons org.apache.commons.lang.StringEscapeUtils.escapeJava,
+    // to be replaced by
+    // com.google.common.escape.SourceCodeEscapers.javaCharEscaper().escape
+    // in Guava 15 when released
+    private static String escapeJavaString(String input)
+    {
+        int len = input.length();
+        // assume (for performance, not for correctness) that string will not expand by more than 10 chars
+        StringBuilder out = new StringBuilder(len + 10);
+        for (int i = 0; i < len; i++) {
+            char c = input.charAt(i);
+            if (c >= 32 && c <= 0x7f) {
+                if (c == '"') {
+                    out.append('\\');
+                    out.append('"');
+                } else if (c == '\\') {
+                    out.append('\\');
+                    out.append('\\');
+                } else {
+                    out.append(c);
+                }
+            } else {
+                out.append('\\');
+                out.append('u');
+                // one liner hack to have the hex string of length exactly 4
+                out.append(Integer.toHexString(c | 0x10000).substring(1));
+            }
+        }
+        return out.toString();
+    }
+
+    private void printDoc(PrintStream out, List<String> docs, int indentLevel)
+    {
+        String indent = indentLevel > 0 ? String.format("%" + indentLevel*4 + "s", "") : "";
+        if (!docs.isEmpty()) {
+            out.println(indent + "@ThriftDocumentation({");
+
+            for (String doc : docs) {
+                out.printf("%s    \"%s\",%n", indent, escapeJavaString(doc));
+            }
+
+            out.println(indent + "})");
+        }
+    }
+
+    private boolean isAnnotatedWith(Element element, String annotation)
+    {
+        for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+            if (annotation.equals(annotationMirror.getAnnotationType().toString())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private List<String> getComment(Element element)
+    {
+        String docComment = elementUtils.getDocComment(element);
+
+        if (docComment == null) {
+            return Collections.emptyList();
+        }
+
+        if (docComment.startsWith(" ")) {
+            docComment = docComment.substring(1);
+        }
+
+        return Arrays.asList(docComment.split("\n ?"));
+    }
+
+    private void note(String format, Object... args)
+    {
+        log(Diagnostic.Kind.NOTE, format, args);
+    }
+
+    private void warn(String format, Object... args)
+    {
+        log(Diagnostic.Kind.WARNING, format, args);
+    }
+
+    private void error(String format, Object... args)
+    {
+        log(Diagnostic.Kind.ERROR, format, args);
+    }
+
+    private void log(Diagnostic.Kind kind, String format, Object... args)
+    {
+        String message = format;
+
+        if (args.length > 0) {
+            try {
+                message = String.format(format, args);
+            }
+            catch (Exception e) {
+                message = format + ": " + Arrays.asList(args) + " (" + e.getMessage() + ")";
+            }
+        }
+
+        messager.printMessage(kind, message);
+    }
+}

--- a/swift-javadoc/src/main/java/com/facebook/swift/javadoc/JavaDocProcessor.java
+++ b/swift-javadoc/src/main/java/com/facebook/swift/javadoc/JavaDocProcessor.java
@@ -122,13 +122,21 @@ public class JavaDocProcessor extends AbstractProcessor
         List<String> serviceDocumentation = getComment(typeElement);
         Map<String, FieldOrMethodDoc> documentation = new LinkedHashMap<>();
 
+        // offset auto-generated order numbers so they don't collide with hand-written ones
+        int orderCounter = 10000;
+        Map<String, Integer> orderMap = new LinkedHashMap<>();
         for (Element member : elementUtils.getAllMembers(typeElement)) {
-            if (member instanceof ExecutableElement &&
-                (isAnnotatedWith(member, "com.facebook.swift.service.ThriftMethod") ||
-                 isAnnotatedWith(member, "com.facebook.swift.codec.ThriftField"))) {
+            if (member instanceof ExecutableElement) {
+                boolean isMethod = isAnnotatedWith(member, "com.facebook.swift.service.ThriftMethod");
+                boolean isField = isAnnotatedWith(member, "com.facebook.swift.codec.ThriftField");
+                if (isMethod || isField) {
                     // service method or method accessor for a struct field
                     String methodName = member.getSimpleName().toString();
-                documentation.put(methodName, new FieldOrMethodDoc(FieldOrMethodDoc.FieldOrMethod.METHOD, getComment(member)));
+                    documentation.put(methodName, new FieldOrMethodDoc(FieldOrMethodDoc.FieldOrMethod.METHOD, getComment(member)));
+                    if (isMethod) {
+                        orderMap.put(methodName, orderCounter++);
+                    }
+                }
             } else if ((member instanceof VariableElement &&
                         isAnnotatedWith(member, "com.facebook.swift.codec.ThriftField")) ||
                        member.getKind() == ElementKind.ENUM_CONSTANT) {
@@ -146,6 +154,7 @@ public class JavaDocProcessor extends AbstractProcessor
             out.printf("package %s;%n", elementUtils.getPackageOf(typeElement).getQualifiedName());
             out.println();
             out.println("import com.facebook.swift.codec.ThriftDocumentation;");
+            out.println("import com.facebook.swift.codec.ThriftOrder;");
             out.println();
 
             printDoc(out, serviceDocumentation, 0);
@@ -158,6 +167,10 @@ public class JavaDocProcessor extends AbstractProcessor
                 FieldOrMethodDoc docs = entry.getValue();
 
                 printDoc(out, docs.getDoc(), 1);
+                Integer order = orderMap.get(name);
+                if (order != null) {
+                    out.printf("    @ThriftOrder(%d)%n", order);
+                }
                 if (docs.getFieldOrMethod() == FieldOrMethodDoc.FieldOrMethod.METHOD) {
                     out.printf("    private void %s() {}%n", name);
                 } else if (docs.getFieldOrMethod() == FieldOrMethodDoc.FieldOrMethod.FIELD) {

--- a/swift-javadoc/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/swift-javadoc/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.facebook.swift.javadoc.JavaDocProcessor

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -50,6 +50,7 @@ public class ThriftMethodMetadata
     private final List<ThriftFieldMetadata> parameters;
     private final Method method;
     private final ImmutableMap<Short, ThriftType> exceptions;
+    private final ImmutableList<String> documentation;
     private final boolean oneway;
 
     public ThriftMethodMetadata(String serviceName, Method method, ThriftCatalog catalog)
@@ -72,6 +73,7 @@ public class ThriftMethodMetadata
         }
         this.qualifiedName = serviceName + "." + name;
 
+        documentation = ThriftCatalog.getThriftDocumentation(method);
         returnType = catalog.getThriftType(method.getGenericReturnType());
 
         ImmutableList.Builder<ThriftFieldMetadata> builder = ImmutableList.builder();
@@ -146,6 +148,11 @@ public class ThriftMethodMetadata
     public ThriftType getException(short id)
     {
         return exceptions.get(id);
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
     }
 
     public Method getMethod()

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftServiceMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftServiceMetadata.java
@@ -19,6 +19,7 @@ import com.facebook.swift.codec.metadata.ThriftCatalog;
 import com.facebook.swift.service.ThriftMethod;
 import com.facebook.swift.service.ThriftService;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
@@ -38,6 +39,7 @@ public class ThriftServiceMetadata
     private final Map<String, ThriftMethodMetadata> methods;
     private final Map<String, ThriftMethodMetadata> declaredMethods;
     private final ThriftServiceMetadata parentService;
+    private final ImmutableList<String> documentation;
 
     public ThriftServiceMetadata(Class<?> serviceClass, ThriftCatalog catalog)
     {
@@ -50,6 +52,8 @@ public class ThriftServiceMetadata
         else {
             name = thriftService.value();
         }
+
+        documentation = ThriftCatalog.getThriftDocumentation(serviceClass);
 
         ImmutableMap.Builder<String, ThriftMethodMetadata> builder = ImmutableMap.builder();
         ImmutableMap.Builder<String, ThriftMethodMetadata> declaredBuilder = ImmutableMap.builder();
@@ -86,6 +90,7 @@ public class ThriftServiceMetadata
         this.methods = builder.build();
         this.declaredMethods = this.methods;
         this.parentService = null;
+        this.documentation = ImmutableList.of();
     }
 
     public String getName()
@@ -106,6 +111,11 @@ public class ThriftServiceMetadata
     public Map<String, ThriftMethodMetadata> getDeclaredMethods()
     {
         return declaredMethods;
+    }
+
+    public ImmutableList<String> getDocumentation()
+    {
+        return documentation;
     }
 
     public static ThriftService getThriftServiceAnnotation(Class<?> serviceClass)


### PR DESCRIPTION
Adds a ThriftDocumentation annotation that can be applied to services,
structs, methods, fields and enums.
Also introduces a JavaDocProcessor annotation processor that will save
javadocs on ThriftService-, ThriftStruct- and ThriftEnum-annotated classes
to specially-named mirror classes with ThriftDocumentation annotations,
e.g., the javadocs for Foo are saved to Foo$swift_docs.

Original code by tim twilliamson@gmail.com, modified, bugfixed and
extended by me.
