### PR TITLE
Context cleanup

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ClientContextChain.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ClientContextChain.java
@@ -23,60 +23,62 @@ import java.util.List;
 public class ClientContextChain
 {
     private final List<? extends ThriftClientEventHandler> handlers;
+    private final String methodName;
     private final List<Object> contexts;
 
     ClientContextChain(List<? extends ThriftClientEventHandler> handlers, String methodName)
     {
         this.handlers = handlers;
+        this.methodName = methodName;
         this.contexts = new ArrayList<>();
         for (ThriftClientEventHandler h: this.handlers) {
             this.contexts.add(h.getContext(methodName));
         }
     }
 
-    public void preWrite(String methodName, Object[] args)
+    public void preWrite(Object[] args)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preWrite(contexts.get(i), methodName, args);
         }
     }
 
-    public void postWrite(String methodName, Object[] args)
+    public void postWrite(Object[] args)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postWrite(contexts.get(i), methodName, args);
         }
     }
 
-    public void preRead(String methodName)
+    public void preRead()
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preRead(contexts.get(i), methodName);
         }
     }
 
-    public void preReadException(String methodName, Exception e)
+    public void preReadException(Exception e)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preReadException(contexts.get(i), methodName, e);
         }
     }
 
-    public void postRead(String methodName, Object result)
+    public void postRead(Object result)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postRead(contexts.get(i), methodName, result);
         }
     }
 
-    public void postReadException(String methodName, Exception e)
+    public void postReadException(Exception e)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postReadException(contexts.get(i), methodName, e);
         }
     }
 
-    public void done(String methodName)
+    public void done()
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).done(contexts.get(i), methodName);

--- a/swift-service/src/main/java/com/facebook/swift/service/ClientContextChain.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ClientContextChain.java
@@ -57,10 +57,10 @@ public class ClientContextChain
         }
     }
 
-    public void preReadException(Exception e)
+    public void preReadException(Throwable t)
     {
         for (int i = 0; i < handlers.size(); i++) {
-            handlers.get(i).preReadException(contexts.get(i), methodName, e);
+            handlers.get(i).preReadException(contexts.get(i), methodName, t);
         }
     }
 
@@ -71,10 +71,10 @@ public class ClientContextChain
         }
     }
 
-    public void postReadException(Exception e)
+    public void postReadException(Throwable t)
     {
         for (int i = 0; i < handlers.size(); i++) {
-            handlers.get(i).postReadException(contexts.get(i), methodName, e);
+            handlers.get(i).postReadException(contexts.get(i), methodName, t);
         }
     }
 

--- a/swift-service/src/main/java/com/facebook/swift/service/ContextChain.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ContextChain.java
@@ -23,60 +23,62 @@ import java.util.List;
 public class ContextChain
 {
     private final List<ThriftEventHandler> handlers;
+    private final String methodName;
     private final List<Object> contexts;
 
     ContextChain(List<ThriftEventHandler> handlers, String methodName, RequestContext requestContext)
     {
         this.handlers = handlers;
+        this.methodName = methodName;
         this.contexts = new ArrayList<>();
         for (ThriftEventHandler h: this.handlers) {
             this.contexts.add(h.getContext(methodName, requestContext));
         }
     }
 
-    public void preRead(String methodName)
+    public void preRead()
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preRead(contexts.get(i), methodName);
         }
     }
 
-    public void postRead(String methodName, Object[] args)
+    public void postRead(Object[] args)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postRead(contexts.get(i), methodName, args);
         }
     }
 
-    public void preWrite(String methodName, Object result)
+    public void preWrite(Object result)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preWrite(contexts.get(i), methodName, result);
         }
     }
 
-    public void preWriteException(String methodName, Exception e)
+    public void preWriteException(Exception e)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preWriteException(contexts.get(i), methodName, e);
         }
     }
 
-    public void postWrite(String methodName, Object result)
+    public void postWrite(Object result)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postWrite(contexts.get(i), methodName, result);
         }
     }
 
-    public void postWriteException(String methodName, Exception e)
+    public void postWriteException(Exception e)
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postWriteException(contexts.get(i), methodName, e);
         }
     }
 
-    public void done(String methodName)
+    public void done()
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).done(contexts.get(i), methodName);

--- a/swift-service/src/main/java/com/facebook/swift/service/ContextChain.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ContextChain.java
@@ -57,10 +57,10 @@ public class ContextChain
         }
     }
 
-    public void preWriteException(Exception e)
+    public void preWriteException(Throwable t)
     {
         for (int i = 0; i < handlers.size(); i++) {
-            handlers.get(i).preWriteException(contexts.get(i), methodName, e);
+            handlers.get(i).preWriteException(contexts.get(i), methodName, t);
         }
     }
 
@@ -71,10 +71,10 @@ public class ContextChain
         }
     }
 
-    public void postWriteException(Exception e)
+    public void postWriteException(Throwable t)
     {
         for (int i = 0; i < handlers.size(); i++) {
-            handlers.get(i).postWriteException(contexts.get(i), methodName, e);
+            handlers.get(i).postWriteException(contexts.get(i), methodName, t);
         }
     }
 

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientEventHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientEventHandler.java
@@ -15,7 +15,7 @@
  */
 package com.facebook.swift.service;
 
-public class ThriftClientEventHandler
+public abstract class ThriftClientEventHandler
 {
     public Object getContext(String methodName)
     {

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientEventHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientEventHandler.java
@@ -25,8 +25,8 @@ public abstract class ThriftClientEventHandler
     public void preWrite(Object context, String methodName, Object[] args) {}
     public void postWrite(Object context, String methodName, Object[] args) {}
     public void preRead(Object context, String methodName) {}
-    public void preReadException(Object context, String methodName, Exception e) {}
+    public void preReadException(Object context, String methodName, Throwable t) {}
     public void postRead(Object context, String methodName, Object result) {}
-    public void postReadException(Object context, String methodName, Exception e) {}
+    public void postReadException(Object context, String methodName, Throwable t) {}
     public void done(Object context, String methodName) {}
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -376,25 +376,24 @@ public class ThriftClientManager implements Closeable
 
             ThriftMethodHandler methodHandler = methods.get(method);
 
-            String methodName = methodHandler.getQualifiedName();
             try {
                 if (methodHandler == null) {
                     throw new TApplicationException(UNKNOWN_METHOD, "Unknown method : '" + method + "'");
                 }
-                ClientContextChain context = new ClientContextChain(eventHandlers, methodName);
-                try {
-                    return methodHandler.invoke(channel,
-                                                inputTransport,
-                                                outputTransport,
-                                                inputProtocol,
-                                                outputProtocol,
-                                                sequenceId.getAndIncrement(),
-                                                context,
-                                                args);
+
+                if (channel.hasError()) {
+                    throw new TTransportException(channel.getError());
                 }
-                finally {
-                    context.done();
-                }
+
+                ClientContextChain context = new ClientContextChain(eventHandlers, methodHandler.getQualifiedName());
+                return methodHandler.invoke(channel,
+                                            inputTransport,
+                                            outputTransport,
+                                            inputProtocol,
+                                            outputProtocol,
+                                            sequenceId.getAndIncrement(),
+                                            context,
+                                            args);
             }
             catch (TException e) {
                 Class<? extends TException> thrownType = e.getClass();

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -376,11 +376,12 @@ public class ThriftClientManager implements Closeable
 
             ThriftMethodHandler methodHandler = methods.get(method);
 
+            String methodName = methodHandler.getQualifiedName();
             try {
                 if (methodHandler == null) {
                     throw new TApplicationException(UNKNOWN_METHOD, "Unknown method : '" + method + "'");
                 }
-                ClientContextChain context = new ClientContextChain(eventHandlers, methodHandler.getQualifiedName());
+                ClientContextChain context = new ClientContextChain(eventHandlers, methodName);
                 try {
                     return methodHandler.invoke(channel,
                                                 inputTransport,
@@ -390,8 +391,9 @@ public class ThriftClientManager implements Closeable
                                                 sequenceId.getAndIncrement(),
                                                 context,
                                                 args);
-                } finally {
-                    context.done(methodHandler.getQualifiedName());
+                }
+                finally {
+                    context.done();
                 }
             }
             catch (TException e) {

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientStatsHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientStatsHandler.java
@@ -47,17 +47,20 @@ public class ThriftClientStatsHandler extends ThriftClientEventHandler
         return stats;
     }
 
+    @Override
     public Object getContext(String methodName)
     {
         stats.putIfAbsent(methodName, new ThriftMethodStats());
         return new PerCallMethodStats();
     }
 
+    @Override
     public void preWrite(Object context, String methodName, Object[] args)
     {
         ((PerCallMethodStats)context).preWriteTime = nanoTime();
     }
 
+    @Override
     public void postWrite(Object context, String methodName, Object[] args)
     {
         long now = nanoTime();
@@ -66,6 +69,7 @@ public class ThriftClientStatsHandler extends ThriftClientEventHandler
         stats.get(methodName).addWriteTime(nanosBetween(ctx.preWriteTime, now));
     }
 
+    @Override
     public void preRead(Object context, String methodName)
     {
         long now = nanoTime();
@@ -74,23 +78,27 @@ public class ThriftClientStatsHandler extends ThriftClientEventHandler
         stats.get(methodName).addInvokeTime(nanosBetween(ctx.postWriteTime, now));
     }
 
+    @Override
     public void preReadException(Object context, String methodName, Exception e)
     {
         preRead(context, methodName);
         ((PerCallMethodStats)context).success = false;
     }
 
+    @Override
     public void postRead(Object context, String methodName, Object result)
     {
         stats.get(methodName).addReadTime(nanosSince(((PerCallMethodStats) context).preReadTime));
     }
 
+    @Override
     public void postReadException(Object context, String methodName, Exception e)
     {
         postRead(context, methodName, null);
         ((PerCallMethodStats)context).success = false;
     }
 
+    @Override
     public void done(Object context, String methodName)
     {
         PerCallMethodStats ctx = (PerCallMethodStats)context;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientStatsHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientStatsHandler.java
@@ -79,7 +79,7 @@ public class ThriftClientStatsHandler extends ThriftClientEventHandler
     }
 
     @Override
-    public void preReadException(Object context, String methodName, Exception e)
+    public void preReadException(Object context, String methodName, Throwable t)
     {
         preRead(context, methodName);
         ((PerCallMethodStats)context).success = false;
@@ -92,7 +92,7 @@ public class ThriftClientStatsHandler extends ThriftClientEventHandler
     }
 
     @Override
-    public void postReadException(Object context, String methodName, Exception e)
+    public void postReadException(Object context, String methodName, Throwable t)
     {
         postRead(context, methodName, null);
         ((PerCallMethodStats)context).success = false;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftEventHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftEventHandler.java
@@ -17,7 +17,7 @@ package com.facebook.swift.service;
 
 import com.facebook.nifty.core.RequestContext;
 
-public class ThriftEventHandler
+public abstract class ThriftEventHandler
 {
     public Object getContext(String methodName, RequestContext requestContext)
     {

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftEventHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftEventHandler.java
@@ -27,8 +27,8 @@ public abstract class ThriftEventHandler
     public void preRead(Object context, String methodName) {}
     public void postRead(Object context, String methodName, Object[] args) {}
     public void preWrite(Object context, String methodName, Object result) {}
-    public void preWriteException(Object context, String methodName, Exception e) {}
+    public void preWriteException(Object context, String methodName, Throwable t) {}
     public void postWrite(Object context, String methodName, Object result) {}
-    public void postWriteException(Object context, String methodName, Exception e) {}
+    public void postWriteException(Object context, String methodName, Throwable t) {}
     public void done(Object context, String methodName) {}
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
@@ -132,15 +132,15 @@ public class ThriftMethodProcessor
     {
         String methodName = serviceName + "." + name;
         // read args
-        contextChain.preRead(methodName);
+        contextChain.preRead();
         Object[] args = readArguments(in);
-        contextChain.postRead(methodName, args);
+        contextChain.postRead(args);
 
         // invoke method
         Object result;
         try {
             result = invokeMethod(args);
-            contextChain.preWrite(methodName, result);
+            contextChain.preWrite(result);
 
             if (!oneway) {
                 // write success reply
@@ -151,11 +151,11 @@ public class ThriftMethodProcessor
                               (short) 0,
                               successCodec,
                               result);
-                contextChain.postWrite(methodName, result);
+                contextChain.postWrite(result);
             }
         }
         catch (Exception e) {
-            contextChain.preWriteException(methodName, e);
+            contextChain.preWriteException(e);
             if (!oneway) {
                 ExceptionProcessor exceptionCodec = exceptionCodecs.get(e.getClass());
                 if (exceptionCodec != null) {
@@ -167,7 +167,7 @@ public class ThriftMethodProcessor
                                   exceptionCodec.getId(),
                                   exceptionCodec.getCodec(),
                                   e);
-                    contextChain.postWriteException(methodName, e);
+                    contextChain.postWriteException(e);
                 } else {
                     // unexpected exception
                     TApplicationException applicationException =
@@ -182,7 +182,7 @@ public class ThriftMethodProcessor
                     out.writeMessageEnd();
                     out.getTransport().flush();
 
-                    contextChain.postWriteException(methodName, applicationException);
+                    contextChain.postWriteException(applicationException);
                 }
             }
         }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceProcessor.java
@@ -125,8 +125,9 @@ public class ThriftServiceProcessor implements NiftyProcessor
             ContextChain context = new ContextChain(eventHandlers, qualifiedMethodName, requestContext);
             try {
                 method.process(in, out, sequenceId, context);
-            } finally {
-                context.done(qualifiedMethodName);
+            }
+            finally {
+                context.done();
             }
 
             return true;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceStatsHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceStatsHandler.java
@@ -80,7 +80,7 @@ public class ThriftServiceStatsHandler extends ThriftEventHandler
     }
 
     @Override
-    public void preWriteException(Object context, String methodName, Exception e)
+    public void preWriteException(Object context, String methodName, Throwable t)
     {
         preWrite(context, methodName, null);
         ((PerCallMethodStats)context).success = false;
@@ -93,7 +93,7 @@ public class ThriftServiceStatsHandler extends ThriftEventHandler
     }
 
     @Override
-    public void postWriteException(Object context, String methodName, Exception e)
+    public void postWriteException(Object context, String methodName, Throwable t)
     {
         postWrite(context, methodName, null);
     }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceStatsHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceStatsHandler.java
@@ -48,17 +48,20 @@ public class ThriftServiceStatsHandler extends ThriftEventHandler
         return stats;
     }
 
+    @Override
     public Object getContext(String methodName, RequestContext requestContext)
     {
         stats.putIfAbsent(methodName, new ThriftMethodStats());
         return new PerCallMethodStats();
     }
 
+    @Override
     public void preRead(Object context, String methodName)
     {
         ((PerCallMethodStats)context).preReadTime = nanoTime();
     }
 
+    @Override
     public void postRead(Object context, String methodName, Object[] args)
     {
         long now = nanoTime();
@@ -67,6 +70,7 @@ public class ThriftServiceStatsHandler extends ThriftEventHandler
         stats.get(methodName).addReadTime(nanosBetween(ctx.preReadTime, now));
     }
 
+    @Override
     public void preWrite(Object context, String methodName, Object result)
     {
         long now = nanoTime();
@@ -75,22 +79,26 @@ public class ThriftServiceStatsHandler extends ThriftEventHandler
         stats.get(methodName).addInvokeTime(nanosBetween(ctx.postReadTime, now));
     }
 
+    @Override
     public void preWriteException(Object context, String methodName, Exception e)
     {
         preWrite(context, methodName, null);
         ((PerCallMethodStats)context).success = false;
     }
 
+    @Override
     public void postWrite(Object context, String methodName, Object result)
     {
         stats.get(methodName).addWriteTime(nanosSince(((PerCallMethodStats) context).preWriteTime));
     }
 
+    @Override
     public void postWriteException(Object context, String methodName, Exception e)
     {
         postWrite(context, methodName, null);
     }
 
+    @Override
     public void done(Object context, String methodName)
     {
         PerCallMethodStats ctx = (PerCallMethodStats)context;


### PR DESCRIPTION
- Get rid of unnecessary methodName arguments for ContextChain
- Change Exception arguments for handlers to Throwable (since this is the type received for failed futures)
- Fix a bug that would cause contextChain.done() to be called early for async client calls
- Make async client call futures non-cancellable. There are some problems with allowing cancellation of client call futures:
  1) i want to ensure that context.done() is called after any other context calls, but before any future callbacks (so that time spent running a future callback is not counted as context time for stats collection) and having cancellable futures complicates this a lot
  2) cancellable client call futures introduces requirements for synchronization because the future's set() and setException() are always called on the client's IO thread, but cancel() can be caused from anywhere
  3) and in return, it doesn't really offer much benefit because once the thrift async call request is dispatched, it's usually executing in another process on another server, and you can't recall that request
