### PR TITLE
Allow handler methods to declare a return type of ListenableFuture

### DIFF
--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftService.java
@@ -223,14 +223,7 @@ public class TestThriftService
         final ThriftServiceProcessor processor = new ThriftServiceProcessor(new ThriftCodecManager(), handlers, scribeService);
 
         List<LogEntry> messages = niftyProcessor ?
-                testProcessor(processor) : testProcessor(new TProcessor()
-        {
-            @Override
-            public boolean process(TProtocol in, TProtocol out) throws TException
-            {
-                return processor.process(in, out, null);
-            }
-        });
+                testProcessor(processor) : testProcessor(NiftyProcessorAdapters.processorToTProcessor(processor));
         assertEquals(scribeService.getMessages(), newArrayList(concat(toSwiftLogEntry(messages), toSwiftLogEntry(messages))));
         assertTrue(eventHandler.validate(2));
         assertTrue(secondHandler.validate(2));

--- a/swift-service/src/test/java/com/facebook/swift/service/async/AsyncService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/AsyncService.java
@@ -19,39 +19,72 @@ import com.facebook.swift.codec.ThriftCodecManager;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftServer;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.thrift.TException;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
 import static org.testng.Assert.assertEquals;
 
 public class AsyncService extends AsyncTestBase
 {
 
+    private static final int TARGET_SERVER_THREAD_COUNT = 30;
+    private static final int PROXY_SERVER_THREAD_COUNT = 1;
+
     private ThriftServer asyncServer;
+    private ThriftServer syncServer;
 
     @Test(timeOut = 1000)
     public void testAsyncService()
             throws Exception
     {
-        try (DelayedMap.Client client = createClient(DelayedMap.Client.class, asyncServer).get()) {
-            List<String> keys = Lists.newArrayList("testKey");
-            List<String> values = client.getMultipleValues(0, TimeUnit.SECONDS, keys);
-            assertEquals(values, Lists.newArrayList("default"));
+        try (DelayedMap.AsyncClient client = createClient(DelayedMap.AsyncClient.class, asyncServer).get()) {
+            List<String> keys = newArrayList();
+            Set<String> expectedValues = newHashSet();
+
+            List<ListenableFuture<Void>> putFutures = newArrayList();
+
+            // Proxy server has only one worker threads, so if it executes these requests
+            // sequentially, it should timeout. The handler is async though, and proxies the requests
+            // to a server with many threads, so all these requests should be handled near-simultaneously
+            for (int i = 0; i < TARGET_SERVER_THREAD_COUNT; i++) {
+                String key = "key" + Integer.toString(i);
+                String value = "value" + Integer.toString(i);
+                keys.add(key);
+                expectedValues.add(value);
+                putFutures.add(i, client.putValueSlowly(200, TimeUnit.MILLISECONDS, key, value));
+            }
+
+            // Wait for all puts to finish
+            for (int i = 0; i < TARGET_SERVER_THREAD_COUNT; i++) {
+                putFutures.get(i).get();
+            }
+
+            List<String> values = client.getMultipleValues(100, TimeUnit.MILLISECONDS, keys).get();
+            assertEquals(newHashSet(values), expectedValues);
         }
     }
 
     @BeforeMethod(alwaysRun = true)
-    private void setup()
-            throws IllegalAccessException, InstantiationException, TException
+    private void setup() throws Exception
     {
+        InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
+
         codecManager = new ThriftCodecManager();
         clientManager = new ThriftClientManager(codecManager);
-        asyncServer = createAsyncServer();
+        syncServer = createTargetServer(TARGET_SERVER_THREAD_COUNT);
+        asyncServer = createAsyncServer(PROXY_SERVER_THREAD_COUNT, clientManager, syncServer);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMap.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMap.java
@@ -47,16 +47,13 @@ public class DelayedMap
     public static interface AsyncService
     {
         @ThriftMethod
-        public ListenableFuture<String> getValueSlowly(long timeout, TimeUnit unit, String key)
-                throws TException;
+        public ListenableFuture<String> getValueSlowly(long timeout, TimeUnit unit, String key);
 
         @ThriftMethod
-        public ListenableFuture<Void> putValueSlowly(long timeout, TimeUnit unit, String key, String value)
-                throws TException;
+        public ListenableFuture<Void> putValueSlowly(long timeout, TimeUnit unit, String key, String value);
 
         @ThriftMethod
-        public ListenableFuture<List<String>> getMultipleValues(long timeout, TimeUnit unit, List<String> keys)
-                throws TException;
+        public ListenableFuture<List<String>> getMultipleValues(long timeout, TimeUnit unit, List<String> keys);
     }
 
 
@@ -80,15 +77,12 @@ public class DelayedMap
     public interface AsyncClient extends Closeable
     {
         @ThriftMethod
-        public ListenableFuture<String> getValueSlowly(long timeout, TimeUnit unit, String key)
-                throws TException;
+        public ListenableFuture<String> getValueSlowly(long timeout, TimeUnit unit, String key);
 
         @ThriftMethod
-        public ListenableFuture<Void> putValueSlowly(long timeout, TimeUnit unit, String key, String value)
-                throws TException;
+        public ListenableFuture<Void> putValueSlowly(long timeout, TimeUnit unit, String key, String value);
 
         @ThriftMethod
-        public ListenableFuture<List<String>> getMultipleValues(long timeout, TimeUnit unit, List<String> keys)
-                throws TException;
+        public ListenableFuture<List<String>> getMultipleValues(long timeout, TimeUnit unit, List<String> keys);
     }
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
@@ -16,6 +16,8 @@
 package com.facebook.swift.service.async;
 
 import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,9 +25,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.Maps.newConcurrentMap;
+
 public class DelayedMapSyncHandler implements DelayedMap.Service
 {
-    private Map<String, String> store = new HashMap<>();
+    private static final Logger LOGGER =LoggerFactory.getLogger(DelayedMapSyncHandler.class);
+
+    private Map<String, String> store = newConcurrentMap();
 
     @Override
     public void putValueSlowly(long timeout,
@@ -34,8 +40,10 @@ public class DelayedMapSyncHandler implements DelayedMap.Service
                                String value)
             throws TException
     {
+        LOGGER.info("put started");
         checkedSleep(timeout, unit);
         store.put(key, value);
+        LOGGER.info("put finished");
     }
 
     @Override


### PR DESCRIPTION
This combined with a prerequisite change to nifty (https://github.com/facebook/nifty/pull/80) allows for writing asynchronous handler methods that return a future.
