### PR TITLE
Add new generator type, ctor

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -59,7 +59,8 @@ public class SwiftGenerator
     private static final Map<String, ImmutableList<String>> TEMPLATES =
             ImmutableMap.of(
                     "java-regular", ImmutableList.of("java/common.st", "java/regular.st"),
-                    "java-immutable", ImmutableList.of("java/common.st", "java/immutable.st")
+                    "java-immutable", ImmutableList.of("java/common.st", "java/immutable.st"),
+                    "java-ctor", ImmutableList.of("java/common.st", "java/ctor.st")
             );
 
     private final File outputFolder;

--- a/swift-generator/src/main/resources/templates/java/ctor.st
+++ b/swift-generator/src/main/resources/templates/java/ctor.st
@@ -10,11 +10,19 @@ private <field.javaType> <field.javaName>;
 <_annotation(field)>
 public <field.javaType> <field.javaGetterName>() { return <field.javaName>; }
 
-@ThriftField
 public void <field.javaSetterName>(final <field.javaType> <field.javaName>) { this.<field.javaName> = <field.javaName>; }
 >>
 
 _constructor(element) ::= <<
+@ThriftConstructor
+public <element.javaName><_params(element.fields)> {
+    <element.fields: {field|<_ctorAssignment(field)>}; separator="\n">
+}
+
 public <element.javaName>() {
 }
+>>
+
+_ctorAssignment(field) ::= <<
+this.<field.javaName> = <field.javaName>;
 >>


### PR DESCRIPTION
generates mutable beans with an args and a no-args c'tor. This is
useful to emulate legacy code, e.g. the hive metastore.

Also fix a build problem in the service pom.
