### PR TITLE
Add ThriftServerConfig options for transport and protocol type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,12 @@
 
       <dependency>
         <groupId>io.airlift</groupId>
+        <artifactId>testing</artifactId>
+        <version>${dep.airlift.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.airlift</groupId>
         <artifactId>node</artifactId>
         <version>${dep.airlift.version}</version>
       </dependency>

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -192,5 +192,17 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>bootstrap</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.airlift</groupId>
+      <artifactId>testing</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
@@ -50,6 +50,7 @@ import javax.annotation.PreDestroy;
 
 import static com.facebook.nifty.core.ShutdownUtil.shutdownChannelFactory;
 import static com.facebook.nifty.core.ShutdownUtil.shutdownExecutor;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
@@ -108,6 +109,9 @@ public class ThriftServer implements Closeable
             Map<String, ThriftFrameCodecFactory> availableFrameCodecFactories,
             Map<String, TDuplexProtocolFactory> availableProtocolFactories)
     {
+        checkNotNull(availableFrameCodecFactories, "availableFrameCodecFactories cannot be null");
+        checkNotNull(availableProtocolFactories, "availableProtocolFactories cannot be null");
+
         NiftyProcessorFactory processorFactory = new NiftyProcessorFactory()
         {
             @Override

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
@@ -146,7 +146,7 @@ public class ThriftServer implements Closeable
                                                          .withProcessorFactory(processorFactory)
                                                          .limitConnectionsTo(config.getConnectionLimit())
                                                          .thriftFrameCodecFactory(availableFrameCodecFactories.get(transportName))
-                                                         .speaks(availableProtocolFactories.get(protocolName))
+                                                         .protocol(availableProtocolFactories.get(protocolName))
                                                          .using(workerExecutor).build();
 
         NettyServerConfigBuilder nettyServerConfigBuilder = NettyServerConfig.newBuilder();

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
@@ -15,15 +15,20 @@
  */
 package com.facebook.swift.service;
 
+import com.facebook.nifty.codec.DefaultThriftFrameCodecFactory;
+import com.facebook.nifty.codec.ThriftFrameCodecFactory;
 import com.facebook.nifty.core.NettyServerConfig;
 import com.facebook.nifty.core.NettyServerConfigBuilder;
 import com.facebook.nifty.core.NettyServerTransport;
 import com.facebook.nifty.core.ThriftServerDef;
+import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.facebook.nifty.processor.NiftyProcessor;
 import com.facebook.nifty.processor.NiftyProcessorFactory;
-import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.transport.TTransport;
 import org.jboss.netty.channel.ServerChannelFactory;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
@@ -35,6 +40,7 @@ import org.weakref.jmx.Managed;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -44,11 +50,21 @@ import javax.annotation.PreDestroy;
 
 import static com.facebook.nifty.core.ShutdownUtil.shutdownChannelFactory;
 import static com.facebook.nifty.core.ShutdownUtil.shutdownExecutor;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.Executors.newCachedThreadPool;
-import static java.util.concurrent.Executors.newFixedThreadPool;
 
 public class ThriftServer implements Closeable
 {
+
+    public static final ImmutableMap<String,TDuplexProtocolFactory> DEFAULT_PROTOCOL_FACTORIES = ImmutableMap.of(
+            "binary", TDuplexProtocolFactory.fromSingleFactory(new TBinaryProtocol.Factory()),
+            "compact", TDuplexProtocolFactory.fromSingleFactory(new TCompactProtocol.Factory())
+    );
+    public static final ImmutableMap<String,ThriftFrameCodecFactory> DEFAULT_FRAME_CODEC_FACTORIES = ImmutableMap.<String, ThriftFrameCodecFactory>of(
+            "buffered", new DefaultThriftFrameCodecFactory(),
+            "framed", new DefaultThriftFrameCodecFactory()
+    );
+
     private enum State {
         NOT_STARTED,
         RUNNING,
@@ -79,8 +95,18 @@ public class ThriftServer implements Closeable
         this(processor, config, new HashedWheelTimer(new ThreadFactoryBuilder().setDaemon(true).build()));
     }
 
+    public ThriftServer(NiftyProcessor processor, ThriftServerConfig config, Timer timer)
+    {
+        this(processor, config, timer, DEFAULT_FRAME_CODEC_FACTORIES, DEFAULT_PROTOCOL_FACTORIES);
+    }
+
     @Inject
-    public ThriftServer(final NiftyProcessor processor, ThriftServerConfig config, @ThriftServerTimer Timer timer)
+    public ThriftServer(
+            final NiftyProcessor processor,
+            ThriftServerConfig config,
+            @ThriftServerTimer Timer timer,
+            Map<String, ThriftFrameCodecFactory> availableFrameCodecFactories,
+            Map<String, TDuplexProtocolFactory> availableProtocolFactories)
     {
         NiftyProcessorFactory processorFactory = new NiftyProcessorFactory()
         {
@@ -90,6 +116,12 @@ public class ThriftServer implements Closeable
                 return processor;
             }
         };
+
+        String transportName = config.getTransportName();
+        String protocolName = config.getProtocolName();
+
+        checkState(availableFrameCodecFactories.containsKey(transportName), "No available server transport named " + transportName);
+        checkState(availableProtocolFactories.containsKey(protocolName), "No available server protocol named " + protocolName);
 
         configuredPort = config.getPort();
 
@@ -109,6 +141,8 @@ public class ThriftServer implements Closeable
                                                          .clientIdleTimeout(config.getIdleConnectionTimeout())
                                                          .withProcessorFactory(processorFactory)
                                                          .limitConnectionsTo(config.getConnectionLimit())
+                                                         .thriftFrameCodecFactory(availableFrameCodecFactories.get(transportName))
+                                                         .speaks(availableProtocolFactories.get(protocolName))
                                                          .using(workerExecutor).build();
 
         NettyServerConfigBuilder nettyServerConfigBuilder = NettyServerConfig.newBuilder();
@@ -194,7 +228,7 @@ public class ThriftServer implements Closeable
     @PostConstruct
     public synchronized ThriftServer start()
     {
-        Preconditions.checkState(state != State.CLOSED, "Thrift server is closed");
+        checkState(state != State.CLOSED, "Thrift server is closed");
         if (state == State.NOT_STARTED) {
             transport.start(serverChannelFactory);
             state = State.RUNNING;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -16,6 +16,7 @@
 package com.facebook.swift.service;
 
 import com.google.common.base.Optional;
+import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
@@ -36,7 +37,7 @@ public class ThriftServerConfig
     private static final int DEFAULT_IO_WORKER_THREAD_COUNT = 2 * Runtime.getRuntime().availableProcessors();
     private static final int DEFAULT_WORKER_THREAD_COUNT = 200;
 
-    private String bindAddress = "localhost";
+    private String bindAddress;
     private int port;
     private int acceptBacklog = 1024;
     private int connectionLimit;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -247,6 +248,14 @@ public class ThriftServerConfig
         return newFixedThreadPool(getWorkerThreads(), new ThreadFactoryBuilder().setNameFormat("thrift-worker-%s").build());
     }
 
+    /**
+     * Sets the name of the transport (frame codec) that this server will handle. The available
+     * options by default are 'unframed', 'buffered', and 'framed'. Additional modules may install
+     * other options. Server startup will fail if you specify an unavailable transport here.
+     *
+     * @param transportName The name of the transport
+     * @return This {@link ThriftServerConfig} instance
+     */
     @Config("thrift.transport")
     public ThriftServerConfig setTransportName(String transportName)
     {
@@ -254,11 +263,20 @@ public class ThriftServerConfig
         return this;
     }
 
+    @NotNull
     public String getTransportName()
     {
         return transportName;
     }
 
+    /**
+     * Sets the name of the protocol that this server will speak. The available options by default
+     * are 'binary' and 'compact'. Additional modules may install other options. Server startup will
+     * fail if you specify an unavailable protocol here.
+     *
+     * @param protocolName The name of the protocol
+     * @return This {@link ThriftServerConfig} instance
+     */
     @Config("thrift.protocol")
     public ThriftServerConfig setProtocolName(String protocolName)
     {
@@ -266,6 +284,7 @@ public class ThriftServerConfig
         return this;
     }
 
+    @NotNull
     public String getProtocolName()
     {
         return protocolName;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -215,7 +215,7 @@ public class ThriftServerConfig
      * @param connectionLimit The maximum number of concurrent connections
      * @return This {@link ThriftServerConfig} instance
      */
-    @Config("thrift.server")
+    @Config("thrift.connection-limit")
     public ThriftServerConfig setConnectionLimit(int connectionLimit)
     {
         this.connectionLimit = connectionLimit;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -15,15 +15,11 @@
  */
 package com.facebook.swift.service;
 
-import com.facebook.nifty.codec.DefaultThriftFrameCodecFactory;
-import com.facebook.nifty.codec.ThriftFrameCodecFactory;
-import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import org.apache.thrift.protocol.TBinaryProtocol;
 
 import java.util.concurrent.ExecutorService;
 

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -15,11 +15,15 @@
  */
 package com.facebook.swift.service;
 
+import com.facebook.nifty.codec.DefaultThriftFrameCodecFactory;
+import com.facebook.nifty.codec.ThriftFrameCodecFactory;
+import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.apache.thrift.protocol.TBinaryProtocol;
 
 import java.util.concurrent.ExecutorService;
 
@@ -44,7 +48,8 @@ public class ThriftServerConfig
     private Duration idleConnectionTimeout = Duration.valueOf("60s");
     private Optional<Integer> workerThreads = Optional.absent();
     private Optional<ExecutorService> workerExecutor = Optional.absent();
-
+    private String transportName = "framed";
+    private String protocolName = "binary";
     /**
      * The default maximum allowable size for a single incoming thrift request or outgoing thrift
      * response. A server can configure the actual maximum to be much higher (up to 0x7FFFFFFF or
@@ -240,5 +245,29 @@ public class ThriftServerConfig
     private ExecutorService makeDefaultWorkerExecutor()
     {
         return newFixedThreadPool(getWorkerThreads(), new ThreadFactoryBuilder().setNameFormat("thrift-worker-%s").build());
+    }
+
+    @Config("thrift.transport")
+    public ThriftServerConfig setTransportName(String transportName)
+    {
+        this.transportName = transportName;
+        return this;
+    }
+
+    public String getTransportName()
+    {
+        return transportName;
+    }
+
+    @Config("thrift.protocol")
+    public ThriftServerConfig setProtocolName(String protocolName)
+    {
+        this.protocolName = protocolName;
+        return this;
+    }
+
+    public String getProtocolName()
+    {
+        return protocolName;
     }
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
@@ -56,8 +56,9 @@ public class ThriftServerModule implements Module
         // Setup binder for message frame codecs...
         newMapBinder(binder, String.class, ThriftFrameCodecFactory.class).permitDuplicates();
 
-        // ...and bind buffered and framed codecs by default. The default frame codec factory from
-        // Nifty handles both equally well.
+        // ...and bind unframed (aka buffered) and framed codecs by default. The default frame codec
+        // factory from Nifty handles both equally well.
+        bindFrameCodecFactory(binder, "unframed", DefaultThriftFrameCodecFactory.class);
         bindFrameCodecFactory(binder, "buffered", DefaultThriftFrameCodecFactory.class);
         bindFrameCodecFactory(binder, "framed", DefaultThriftFrameCodecFactory.class);
 

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
@@ -15,6 +15,9 @@
  */
 package com.facebook.swift.service.guice;
 
+import com.facebook.nifty.codec.DefaultThriftFrameCodecFactory;
+import com.facebook.nifty.codec.ThriftFrameCodecFactory;
+import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.facebook.nifty.processor.NiftyProcessor;
 import com.facebook.swift.service.*;
 import com.facebook.swift.service.guice.ThriftServiceExporter.ThriftServiceExport;
@@ -24,11 +27,15 @@ import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.binder.ScopedBindingBuilder;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TCompactProtocol;
 import org.jboss.netty.util.HashedWheelTimer;
 import org.jboss.netty.util.Timer;
 
 import javax.annotation.PreDestroy;
 
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 
@@ -46,6 +53,21 @@ public class ThriftServerModule implements Module
                     }
                 });
 
+        // Setup binder for message frame codecs...
+        newMapBinder(binder, String.class, ThriftFrameCodecFactory.class).permitDuplicates();
+
+        // ...and bind buffered and framed codecs by default. The default frame codec factory from
+        // Nifty handles both equally well.
+        bindFrameCodecFactory(binder, "buffered", DefaultThriftFrameCodecFactory.class);
+        bindFrameCodecFactory(binder, "framed", DefaultThriftFrameCodecFactory.class);
+
+        // Setup binder for protocols...
+        newMapBinder(binder, String.class, TDuplexProtocolFactory.class).permitDuplicates();
+
+        // ...and bind binary and compact protocols by default
+        bindProtocolFactory(binder, "binary", TDuplexProtocolFactory.fromSingleFactory(new TBinaryProtocol.Factory()));
+        bindProtocolFactory(binder, "compact", TDuplexProtocolFactory.fromSingleFactory(new TCompactProtocol.Factory()));
+
         newSetBinder(binder, ThriftServiceExport.class).permitDuplicates();
         newSetBinder(binder, ThriftEventHandler.class).permitDuplicates();
         binder.bind(ThriftServiceProcessor.class).toProvider(ThriftServiceProcessorProvider.class).in(Scopes.SINGLETON);
@@ -53,5 +75,25 @@ public class ThriftServerModule implements Module
 
         bindConfig(binder).to(ThriftServerConfig.class);
         binder.bind(ThriftServer.class).in(Scopes.SINGLETON);
+    }
+
+    public static ScopedBindingBuilder bindFrameCodecFactory(Binder binder, String key, Class<? extends ThriftFrameCodecFactory> frameCodecFactoryClass)
+    {
+        return newMapBinder(binder, String.class, ThriftFrameCodecFactory.class).addBinding(key).to(frameCodecFactoryClass);
+    }
+
+    public static void bindFrameCodecFactory(Binder binder, String key, ThriftFrameCodecFactory frameCodecFactory)
+    {
+        newMapBinder(binder, String.class, ThriftFrameCodecFactory.class).addBinding(key).toInstance(frameCodecFactory);
+    }
+
+    public static ScopedBindingBuilder bindProtocolFactory(Binder binder, String key, Class<? extends TDuplexProtocolFactory> protocolFactoryClass)
+    {
+        return newMapBinder(binder, String.class, TDuplexProtocolFactory.class).addBinding(key).to(protocolFactoryClass);
+    }
+
+    public static void bindProtocolFactory(Binder binder, String key, TDuplexProtocolFactory protocolFactory)
+    {
+        newMapBinder(binder, String.class, TDuplexProtocolFactory.class).addBinding(key).toInstance(protocolFactory);
     }
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static org.testng.Assert.assertNotNull;
+
+public class TestThriftServerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(
+                ConfigAssertions.recordDefaults(ThriftServerConfig.class)
+                        .setBindAddress("localhost")
+                        .setAcceptBacklog(1024)
+                        .setMaxFrameSize(DataSize.valueOf("64MB"))
+                        .setPort(0)
+                        .setConnectionLimit(0)
+                        .setWorkerThreads(200)
+                        .setAcceptorThreadCount(1)
+                        .setIoThreadCount(2 * Runtime.getRuntime().availableProcessors())
+                        .setIdleConnectionTimeout(Duration.valueOf("60s"))
+                        .setTransportName("framed")
+                        .setProtocolName("binary")
+        );
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("thrift.port", "12345")
+                .put("thrift.max-frame-size", "333kB")
+                .put("thrift.bind-address", "127.0.0.1")
+                .put("thrift.accept-backlog", "7777")
+                .put("thrift.threads.max", "111")
+                .put("thrift.acceptor-threads.count", "3")
+                .put("thrift.io-threads.count", "27")
+                .put("thrift.idle-connection-timeout", "157ms")
+                .put("thrift.connection-limit", "1111")
+                .put("thrift.transport", "buffered")
+                .put("thrift.protocol", "compact")
+                .build();
+
+        ThriftServerConfig expected = new ThriftServerConfig()
+                .setPort(12345)
+                .setMaxFrameSize(DataSize.valueOf("333kB"))
+                .setBindAddress("127.0.0.1")
+                .setAcceptBacklog(7777)
+                .setWorkerThreads(111)
+                .setAcceptorThreadCount(3)
+                .setIoThreadCount(27)
+                .setIdleConnectionTimeout(Duration.valueOf("157ms"))
+                .setConnectionLimit(1111)
+                .setTransportName("buffered")
+                .setProtocolName("compact");
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testGuiceInjection()
+            throws Exception
+    {
+        Bootstrap bootstrap = new Bootstrap(new AbstractModule() {
+            @Override
+            protected void configure()
+            {
+                bindConfig(binder()).to(ThriftServerConfig.class);
+            }
+        });
+
+        Map<String, String> properties = ImmutableMap.of();
+
+        Injector injector =
+                bootstrap.doNotInitializeLogging()
+                .strictConfig()
+                .setRequiredConfigurationProperties(properties)
+                .initialize();
+
+        ThriftServerConfig config = injector.getInstance(ThriftServerConfig.class);
+        assertNotNull(config);
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/protocol/TestClientProtocols.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/protocol/TestClientProtocols.java
@@ -115,7 +115,7 @@ public class TestClientProtocols
             ThriftServerDef def = ThriftServerDef.newBuilder()
                                                  .listen(0)
                                                  .withProcessor(processor)
-                                                 .speaks(protocolFactory).build();
+                                                 .protocol(protocolFactory).build();
 
             server = new NettyServerTransport(def, NettyServerConfig.newBuilder().build(), new DefaultChannelGroup());
             server.start();


### PR DESCRIPTION
This adds ThriftServerConfig options to choose 'thrift.transport' and 'thrift.protocol' by name, and a map binder that can be extended by guice modules from other packages to add more available options for these configs.
