### PR TITLE
Set thread names all the time correctly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty</artifactId>
-        <version>3.6.2.Final</version>
+        <version>3.7.0.Final</version>
       </dependency>
 
       <dependency>

--- a/swift-load-generator/pom.xml
+++ b/swift-load-generator/pom.xml
@@ -155,7 +155,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/swift-service/pom.xml
+++ b/swift-service/pom.xml
@@ -190,7 +190,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/swift2thrift-generator-cli/pom.xml
+++ b/swift2thrift-generator-cli/pom.xml
@@ -42,7 +42,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This requires a newer version of Netty as the timer renaming code appeared post-3.6.2.
