### PR TITLE
Support for @ThriftField-annotated fields that have generic types

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/ThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/ThriftCodecFactory.java
@@ -24,5 +24,5 @@ import com.facebook.swift.codec.metadata.ThriftStructMetadata;
  */
 public interface ThriftCodecFactory
 {
-    <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata);
+    ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata);
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
@@ -51,9 +51,9 @@ public class CompilerThriftCodecFactory implements ThriftCodecFactory
     }
 
     @Override
-    public <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata)
+    public ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata)
     {
-        ThriftCodecByteCodeGenerator<T> generator = new ThriftCodecByteCodeGenerator<>(
+        ThriftCodecByteCodeGenerator<?> generator = new ThriftCodecByteCodeGenerator<>(
                 codecManager,
                 metadata,
                 classLoader,

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
@@ -93,7 +93,7 @@ public class ThriftCodecByteCodeGenerator<T>
     private static final Map<ThriftProtocolType, Method> WRITE_METHODS;
 
     private final ThriftCodecManager codecManager;
-    private final ThriftStructMetadata<T> metadata;
+    private final ThriftStructMetadata metadata;
     private final ParameterizedType structType;
     private final ParameterizedType codecType;
 
@@ -109,7 +109,7 @@ public class ThriftCodecByteCodeGenerator<T>
     @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     public ThriftCodecByteCodeGenerator(
             ThriftCodecManager codecManager,
-            ThriftStructMetadata<T> metadata,
+            ThriftStructMetadata metadata,
             DynamicClassLoader classLoader,
             boolean debug
     )
@@ -628,10 +628,16 @@ public class ThriftCodecByteCodeGenerator<T>
         if (extraction instanceof ThriftFieldExtractor) {
             ThriftFieldExtractor fieldExtractor = (ThriftFieldExtractor) extraction;
             write.getField(fieldExtractor.getField());
+            if (fieldExtractor.isGeneric()) {
+                write.checkCast(type(fieldExtractor.getType()));
+            }
         }
         else if (extraction instanceof ThriftMethodExtractor) {
             ThriftMethodExtractor methodExtractor = (ThriftMethodExtractor) extraction;
             write.invokeVirtual(methodExtractor.getMethod());
+            if (methodExtractor.isGeneric()) {
+                write.checkCast(type(methodExtractor.getType()));
+            }
         }
     }
 
@@ -723,7 +729,7 @@ public class ThriftCodecByteCodeGenerator<T>
                 protocolType == MAP;
     }
 
-    private ParameterizedType toCodecType(ThriftStructMetadata<?> metadata)
+    private ParameterizedType toCodecType(ThriftStructMetadata metadata)
     {
         return type(PACKAGE + "/" + type(metadata.getStructClass()).getClassName() + "Codec");
     }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftCodec.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftCodec.java
@@ -45,10 +45,10 @@ import static java.lang.String.format;
 @Immutable
 public class ReflectionThriftCodec<T> implements ThriftCodec<T>
 {
-    private final ThriftStructMetadata<T> metadata;
+    private final ThriftStructMetadata metadata;
     private final SortedMap<Short, ThriftCodec<?>> fields;
 
-    public ReflectionThriftCodec(ThriftCodecManager manager, ThriftStructMetadata<T> metadata)
+    public ReflectionThriftCodec(ThriftCodecManager manager, ThriftStructMetadata metadata)
     {
         this.metadata = metadata;
         ImmutableSortedMap.Builder<Short, ThriftCodec<?>> fields = ImmutableSortedMap.naturalOrder();

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftCodecFactory.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.Immutable;
 public class ReflectionThriftCodecFactory implements ThriftCodecFactory
 {
     @Override
-    public <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata)
+    public ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata)
     {
         return new ReflectionThriftCodec<>(codecManager, metadata);
     }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldExtractor.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldExtractor.java
@@ -16,9 +16,11 @@
 package com.facebook.swift.codec.metadata;
 
 import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
 
 import javax.annotation.concurrent.Immutable;
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 @Immutable
 public class ThriftFieldExtractor implements ThriftExtraction
@@ -26,16 +28,19 @@ public class ThriftFieldExtractor implements ThriftExtraction
     private final short id;
     private final String name;
     private final Field field;
+    private final Class<?> type;
 
-    public ThriftFieldExtractor(short id, String name, Field field)
+    public ThriftFieldExtractor(short id, String name, Field field, Type type)
     {
         Preconditions.checkArgument(id >= 0, "fieldId is negative");
         Preconditions.checkNotNull(name, "name is null");
         Preconditions.checkNotNull(field, "field is null");
+        Preconditions.checkNotNull(type, "type is null");
 
         this.id = id;
         this.name = name;
         this.field = field;
+        this.type = TypeToken.of(type).getRawType();
     }
 
     @Override
@@ -55,6 +60,16 @@ public class ThriftFieldExtractor implements ThriftExtraction
         return field;
     }
 
+    public Class<?> getType()
+    {
+        return type;
+    }
+
+    public boolean isGeneric()
+    {
+        return field.getType() != field.getGenericType();
+    }
+
     @Override
     public String toString()
     {
@@ -63,6 +78,7 @@ public class ThriftFieldExtractor implements ThriftExtraction
         sb.append("{id=").append(id);
         sb.append(", name=").append(name);
         sb.append(", field=").append(field.getDeclaringClass().getSimpleName()).append(".").append(field.getName());
+        sb.append(", type=").append(type);
         sb.append('}');
         return sb.toString();
     }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftMethodExtractor.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftMethodExtractor.java
@@ -15,8 +15,11 @@
  */
 package com.facebook.swift.codec.metadata;
 
+import com.google.common.reflect.TypeToken;
+
 import javax.annotation.concurrent.Immutable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -27,8 +30,9 @@ public class ThriftMethodExtractor implements ThriftExtraction
     private final short id;
     private final String name;
     private final Method method;
+    private final Class<?> type;
 
-    public ThriftMethodExtractor(short id, String name, Method method)
+    public ThriftMethodExtractor(short id, String name, Method method, Type type)
     {
         checkArgument(id >= 0, "fieldId is negative");
         checkNotNull(name, "name is null");
@@ -37,6 +41,7 @@ public class ThriftMethodExtractor implements ThriftExtraction
         this.id = id;
         this.name = name;
         this.method = method;
+        this.type = TypeToken.of(type).getRawType();
     }
 
     @Override
@@ -56,6 +61,16 @@ public class ThriftMethodExtractor implements ThriftExtraction
         return method;
     }
 
+    public Class<?> getType()
+    {
+        return type;
+    }
+
+    public boolean isGeneric()
+    {
+        return getMethod().getReturnType() != getMethod().getGenericReturnType();
+    }
+
     @Override
     public String toString()
     {
@@ -64,6 +79,7 @@ public class ThriftMethodExtractor implements ThriftExtraction
         sb.append("{id=").append(id);
         sb.append(", name='").append(name).append('\'');
         sb.append(", method=").append(method);
+        sb.append(", type=").append(type);
         sb.append('}');
         return sb.toString();
     }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
@@ -18,7 +18,9 @@ package com.facebook.swift.codec.metadata;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.reflect.TypeToken;
 
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 import java.util.SortedMap;
@@ -29,10 +31,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.uniqueIndex;
 
 @Immutable
-public class ThriftStructMetadata<T>
+public class ThriftStructMetadata
 {
     private final String structName;
-    private final Class<T> structClass;
 
     private final Class<?> builderClass;
     private final ThriftMethodInjection builderMethod;
@@ -43,10 +44,11 @@ public class ThriftStructMetadata<T>
 
     private final ThriftConstructorInjection constructor;
     private final List<ThriftMethodInjection> methodInjections;
+    private final Type structType;
 
     public ThriftStructMetadata(
             String structName,
-            Class<T> structClass,
+            Type structType,
             Class<?> builderClass,
             ThriftMethodInjection builderMethod,
             List<String> documentation,
@@ -57,7 +59,7 @@ public class ThriftStructMetadata<T>
         this.builderClass = builderClass;
         this.builderMethod = builderMethod;
         this.structName = checkNotNull(structName, "structName is null");
-        this.structClass = checkNotNull(structClass, "structClass is null");
+        this.structType = checkNotNull(structType, "structType is null");
         this.constructor = checkNotNull(constructor, "constructor is null");
         this.unsortedFields = ImmutableList.copyOf(fields);
         this.documentation = ImmutableList.copyOf(checkNotNull(documentation, "documentation is null"));
@@ -77,9 +79,14 @@ public class ThriftStructMetadata<T>
         return structName;
     }
 
-    public Class<T> getStructClass()
+    public Class<?> getStructClass()
     {
-        return structClass;
+        return TypeToken.of(structType).getRawType();
+    }
+
+    public Type getStructType()
+    {
+        return structType;
     }
 
     public Class<?> getBuilderClass()
@@ -124,7 +131,7 @@ public class ThriftStructMetadata<T>
 
     public boolean isException()
     {
-        return Exception.class.isAssignableFrom(structClass);
+        return Exception.class.isAssignableFrom(getStructClass());
     }
 
     @Override
@@ -133,7 +140,7 @@ public class ThriftStructMetadata<T>
         final StringBuilder sb = new StringBuilder();
         sb.append("ThriftStructMetadata");
         sb.append("{structName='").append(structName).append('\'');
-        sb.append(", structClass=").append(structClass);
+        sb.append(", structType=").append(structType);
         sb.append(", builderClass=").append(builderClass);
         sb.append(", builderMethod=").append(builderMethod);
         sb.append(", fields=").append(fields);

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
@@ -47,7 +47,7 @@ public class ThriftType
     public static final ThriftType STRING = new ThriftType(ThriftProtocolType.STRING, ByteBuffer.class);
     public static final ThriftType VOID = new ThriftType(ThriftProtocolType.STRUCT, void.class);
 
-    public static ThriftType struct(ThriftStructMetadata<?> structMetadata)
+    public static ThriftType struct(ThriftStructMetadata structMetadata)
     {
         return new ThriftType(structMetadata);
     }
@@ -97,7 +97,7 @@ public class ThriftType
     private final Type javaType;
     private final ThriftType keyType;
     private final ThriftType valueType;
-    private final ThriftStructMetadata<?> structMetadata;
+    private final ThriftStructMetadata structMetadata;
     private final ThriftEnumMetadata<?> enumMetadata;
     private final ThriftType uncoercedType;
 
@@ -130,7 +130,7 @@ public class ThriftType
         this.uncoercedType = null;
     }
 
-    private ThriftType(ThriftStructMetadata<?> structMetadata)
+    private ThriftType(ThriftStructMetadata structMetadata)
     {
         Preconditions.checkNotNull(structMetadata, "structMetadata is null");
 
@@ -190,7 +190,7 @@ public class ThriftType
         return valueType;
     }
 
-    public ThriftStructMetadata<?> getStructMetadata()
+    public ThriftStructMetadata getStructMetadata()
     {
         checkState(structMetadata != null, "%s does not have struct metadata", protocolType);
         return structMetadata;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/TestThriftCodecManager.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/TestThriftCodecManager.java
@@ -59,7 +59,7 @@ public class TestThriftCodecManager
         codecManager = new ThriftCodecManager(new ThriftCodecFactory()
         {
             @Override
-            public <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata)
+            public ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata)
             {
                 throw new UnsupportedOperationException();
             }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGeneric.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGeneric.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class ConcreteDerivedFromGeneric extends GenericThriftStructBase<Double>
+{
+    private final Double concreteProperty;
+
+    @ThriftConstructor
+    public ConcreteDerivedFromGeneric(
+            @ThriftField(1) Double genericProperty,
+            @ThriftField(2) Double concreteProperty)
+    {
+        super(genericProperty);
+        this.concreteProperty = concreteProperty;
+    }
+
+    @ThriftField(2)
+    public Double getConcreteProperty()
+    {
+        return concreteProperty;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConcreteDerivedFromGeneric other = (ConcreteDerivedFromGeneric) obj;
+        return Objects.equals(this.concreteProperty, other.concreteProperty) && super.equals(obj);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGenericBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGenericBean.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class ConcreteDerivedFromGenericBean extends GenericThriftStructBeanBase<String>
+{
+    private String concreteField;
+
+    @ThriftField(2)
+    public String getConcreteField()
+    {
+        return concreteField;
+    }
+
+    @ThriftField(2)
+    public void setConcreteField(String concreteField)
+    {
+        this.concreteField = concreteField;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConcreteDerivedFromGenericBean other = (ConcreteDerivedFromGenericBean) obj;
+        return Objects.equals(this.concreteField, other.concreteField) && super.equals(obj);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteThriftStructDerivedFromGenericField.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteThriftStructDerivedFromGenericField.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class ConcreteThriftStructDerivedFromGenericField extends GenericThriftStructFieldBase<String>
+{
+    @ThriftField(2)
+    public String concreteField;
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConcreteThriftStructDerivedFromGenericField other = (ConcreteThriftStructDerivedFromGenericField) obj;
+        return Objects.equals(concreteField, other.concreteField) && super.equals(obj);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBase.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBase.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericThriftStructBase<T>
+{
+    private T genericProperty;
+
+    @ThriftConstructor
+    public GenericThriftStructBase(@ThriftField(1) T genericProperty)
+    {
+        this.genericProperty = genericProperty;
+    }
+
+    @ThriftField(1)
+    public T getGenericProperty()
+    {
+        return genericProperty;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructBase<?> other = (GenericThriftStructBase<?>) obj;
+        return Objects.equals(this.genericProperty, other.genericProperty);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBaseFromBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBaseFromBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct(builder = GenericThriftStructBaseFromBuilder.Builder.class)
+public class GenericThriftStructBaseFromBuilder<S, T>
+{
+    private final S firstGenericProperty;
+    private final T secondGenericProperty;
+
+    private GenericThriftStructBaseFromBuilder(S firstGenericProperty, T secondGenericProperty)
+    {
+        this.firstGenericProperty = firstGenericProperty;
+        this.secondGenericProperty = secondGenericProperty;
+    }
+
+    @ThriftField(1)
+    public S getFirstGenericProperty()
+    {
+        return firstGenericProperty;
+    }
+
+    @ThriftField(2)
+    public T getSecondGenericProperty()
+    {
+        return secondGenericProperty;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructBaseFromBuilder<?, ?> other = (GenericThriftStructBaseFromBuilder<?, ?>) obj;
+        return
+                Objects.equals(firstGenericProperty, other.firstGenericProperty) &&
+                Objects.equals(secondGenericProperty, other.secondGenericProperty);
+    }
+
+    public static class Builder<X, Y>
+    {
+        private X firstGenericProperty;
+        private Y secondGenericProperty;
+
+        @ThriftField(1)
+        public Builder<X, Y> setFirstGenericProperty(X firstGenericProperty)
+        {
+            this.firstGenericProperty = firstGenericProperty;
+            return this;
+        }
+
+        @ThriftField(2)
+        public Builder<X, Y> setSecondGenericProperty(Y secondGenericProperty)
+        {
+            this.secondGenericProperty = secondGenericProperty;
+            return this;
+        }
+
+        @ThriftConstructor
+        public GenericThriftStructBaseFromBuilder<X, Y> build()
+        {
+            return new GenericThriftStructBaseFromBuilder<>(firstGenericProperty, secondGenericProperty);
+        }
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBeanBase.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBeanBase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.TypeLiteral;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericThriftStructBeanBase<T>
+{
+    private T genericProperty;
+
+    @ThriftField(1)
+    public T getGenericProperty()
+    {
+        return genericProperty;
+    }
+
+    @ThriftField(1)
+    public void setGenericProperty(T value)
+    {
+        this.genericProperty = value;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructBeanBase<?> other = (GenericThriftStructBeanBase<?>) obj;
+        return Objects.equals(this.genericProperty, other.genericProperty);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructFieldBase.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructFieldBase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericThriftStructFieldBase<T>
+{
+    @ThriftField(1)
+    public T genericField;
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructFieldBase<?> other = (GenericThriftStructFieldBase<?>) obj;
+        return Objects.equals(genericField, other.genericField);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
@@ -33,7 +33,7 @@ public class TestThriftStructMetadata
     @Test
     public void testField()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkField.class, 0, 0);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkField.class, 0, 0);
 
         verifyFieldInjection(metadata, 1, "message");
         verifyFieldExtraction(metadata, 1, "message");
@@ -41,7 +41,7 @@ public class TestThriftStructMetadata
         verifyFieldExtraction(metadata, 2, "type");
     }
 
-    private void verifyFieldInjection(ThriftStructMetadata<?> metadata, int id, String name)
+    private void verifyFieldInjection(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftInjection injection = metadata.getField(id).getInjections().get(0);
         assertThat(injection).isNotNull().isInstanceOf(ThriftFieldInjection.class);
@@ -49,7 +49,7 @@ public class TestThriftStructMetadata
         assertEquals(fieldInjection.getField().getName(), name);
     }
 
-    private void verifyFieldExtraction(ThriftStructMetadata<?> metadata, int id, String name)
+    private void verifyFieldExtraction(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftExtraction extraction = metadata.getField(id).getExtraction();
         assertThat(extraction).isNotNull().isInstanceOf(ThriftFieldExtractor.class);
@@ -60,14 +60,14 @@ public class TestThriftStructMetadata
     @Test
     public void testBean()
     {
-        ThriftStructMetadata<BonkBean> metadata = testMetadataBuild(BonkBean.class, 0, 2);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkBean.class, 0, 2);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 0);
         verifyMethodExtraction(metadata, 2, "type", "getType");
     }
 
-    private void verifyParameterInjection(ThriftStructMetadata<?> metadata, int id, String name, int parameterIndex)
+    private void verifyParameterInjection(ThriftStructMetadata metadata, int id, String name, int parameterIndex)
     {
         ThriftInjection injection = metadata.getField(id).getInjections().get(0);
         assertThat(injection).isNotNull().isInstanceOf(ThriftParameterInjection.class);
@@ -77,7 +77,7 @@ public class TestThriftStructMetadata
         assertEquals(parameterInjection.getParameterIndex(), parameterIndex);
     }
 
-    private void verifyMethodExtraction(ThriftStructMetadata<?> metadata, int id, String name, String methodName)
+    private void verifyMethodExtraction(ThriftStructMetadata metadata, int id, String name, String methodName)
     {
         ThriftExtraction extraction = metadata.getField(id).getExtraction();
         assertThat(extraction).isNotNull().isInstanceOf(ThriftMethodExtractor.class);
@@ -89,7 +89,7 @@ public class TestThriftStructMetadata
     @Test
     public void testConstructor()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkConstructor.class, 2, 0);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkConstructor.class, 2, 0);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 1);
@@ -99,7 +99,7 @@ public class TestThriftStructMetadata
     @Test
     public void testMethod()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkMethod.class, 0, 1);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkMethod.class, 0, 1);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 1);
@@ -109,24 +109,24 @@ public class TestThriftStructMetadata
     @Test
     public void testBuilder()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkBuilder.class, 0, 2);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkBuilder.class, 0, 2);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 0);
         verifyMethodExtraction(metadata, 2, "type", "getType");
     }
 
-    private <T> ThriftStructMetadata<T> testMetadataBuild(Class<T> structClass, int expectedConstructorParameters, int expectedMethodInjections)
+    private ThriftStructMetadata testMetadataBuild(Class<?> structClass, int expectedConstructorParameters, int expectedMethodInjections)
     {
         ThriftCatalog catalog = new ThriftCatalog();
-        ThriftStructMetadataBuilder<T> builder = new ThriftStructMetadataBuilder<>(catalog, structClass);
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(catalog, structClass);
         assertNotNull(builder);
 
         assertNotNull(builder.getMetadataErrors());
         builder.getMetadataErrors().throwIfHasErrors();
         assertEquals(builder.getMetadataErrors().getWarnings().size(), 0);
 
-        ThriftStructMetadata<T> metadata = builder.build();
+        ThriftStructMetadata metadata = builder.build();
         assertNotNull(metadata);
 
         verifyField(metadata, 1, "message");
@@ -138,7 +138,7 @@ public class TestThriftStructMetadata
         return metadata;
     }
 
-    private <T> void verifyField(ThriftStructMetadata<T> metadata, int id, String name)
+    private <T> void verifyField(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftFieldMetadata messageField = metadata.getField(id);
         assertNotNull(messageField, "messageField is null");

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -29,7 +29,7 @@ public class TestThriftStructMetadataBuilder
     public void testNoId()
             throws Exception
     {
-        ThriftStructMetadataBuilder<NoId> builder = new ThriftStructMetadataBuilder<>(new ThriftCatalog(), NoId.class);
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), NoId.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -65,7 +65,7 @@ public class TestThriftStructMetadataBuilder
     public void testMultipleIds()
             throws Exception
     {
-        ThriftStructMetadataBuilder<MultipleIds> builder = new ThriftStructMetadataBuilder<>(new ThriftCatalog(), MultipleIds.class);
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), MultipleIds.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -112,7 +112,7 @@ public class TestThriftStructMetadataBuilder
     public void testMultipleNames()
             throws Exception
     {
-        ThriftStructMetadataBuilder<MultipleNames> builder = new ThriftStructMetadataBuilder<>(new ThriftCatalog(), MultipleNames.class);
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), MultipleNames.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -148,7 +148,7 @@ public class TestThriftStructMetadataBuilder
     public void testUnsupportedType()
             throws Exception
     {
-        ThriftStructMetadataBuilder<UnsupportedJavaType> builder = new ThriftStructMetadataBuilder<>(new ThriftCatalog(), UnsupportedJavaType.class);
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), UnsupportedJavaType.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -176,7 +176,7 @@ public class TestThriftStructMetadataBuilder
     public void testMultipleTypes()
             throws Exception
     {
-        ThriftStructMetadataBuilder<MultipleTypes> builder = new ThriftStructMetadataBuilder<>(new ThriftCatalog(), MultipleTypes.class);
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), MultipleTypes.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -304,7 +304,7 @@ public class Swift2ThriftGenerator {
 
     private boolean verifyStruct(ThriftType t, boolean quiet)
     {
-        ThriftStructMetadata<?> metadata = t.getStructMetadata();
+        ThriftStructMetadata metadata = t.getStructMetadata();
         boolean ok = true;
         for (ThriftFieldMetadata fieldMetadata: metadata.getFields()) {
             boolean fieldOk = verifyField(fieldMetadata.getType());

--- a/swift-service/src/test/java/com/facebook/swift/generics/GenericInterface.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/GenericInterface.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+
+@ThriftService
+public interface GenericInterface
+{
+    @ThriftMethod
+    GenericStruct<String> echo(GenericStruct<String> gen);
+
+    public static interface Client extends GenericInterface, AutoCloseable
+    {
+        @Override
+        public void close();
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/generics/GenericService.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/GenericService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.swift.service.ThriftMethod;
+
+public class GenericService implements GenericInterface
+{
+    @Override
+    @ThriftMethod
+    public GenericStruct<String> echo(GenericStruct<String> genericObject)
+    {
+        return genericObject;
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/generics/GenericStruct.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/GenericStruct.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericStruct<T>
+{
+    @ThriftField(1)
+    public T genericField;
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this || getClass() != obj.getClass()) {
+            return true;
+        }
+        GenericStruct<?> other = (GenericStruct<?>) obj;
+        return Objects.equals(genericField, other.genericField);
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/generics/TestGenericProcessor.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/TestGenericProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.nifty.client.FramedClientConnector;
+import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.service.ThriftClient;
+import com.facebook.swift.service.ThriftClientManager;
+import com.facebook.swift.service.ThriftEventHandler;
+import com.facebook.swift.service.ThriftServer;
+import com.facebook.swift.service.ThriftServerConfig;
+import com.facebook.swift.service.ThriftServiceProcessor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+public class TestGenericProcessor
+{
+    @Test
+    public void testGenericProcessor()
+            throws ExecutionException, InterruptedException
+    {
+        ThriftCodecManager codecManager = new ThriftCodecManager();
+        ThriftServiceProcessor processor = new ThriftServiceProcessor(codecManager, ImmutableList.<ThriftEventHandler>of(), new GenericService());
+
+        try (ThriftServer server = new ThriftServer(processor, new ThriftServerConfig()).start();
+             ThriftClientManager clientManager = new ThriftClientManager(codecManager)) {
+            ThriftClient<GenericInterface.Client> clientOpener = new ThriftClient<>(clientManager, GenericInterface.Client.class);
+            try (GenericInterface.Client client = clientOpener.open(new FramedClientConnector(HostAndPort.fromParts("localhost", server.getPort()))).get()) {
+                GenericStruct<String> original = new GenericStruct<>();
+                original.genericField = "original.genericField";
+                GenericStruct<String> copy = client.echo(original);
+                assertEquals(original, copy);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for generically-typed @ThriftFields.

With tests for generic @ThriftStruct classes using all types of extractions (ctor+getters, builder+getters, setters+getters, public fields)
