### PR TITLE
Fixed swift2thrift bug caused by the addition of unions

### DIFF
--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -40,7 +40,7 @@ _struct(struct) ::= <<
 
 _field(field) ::= <<
 <_doc(field.documentation)><\\\>
-<field.id>: <field.type> <field.name>
+<field.id>: <field.thriftType> <field.name>
 >>
 
 _service(service) ::= <<


### PR DESCRIPTION
ThriftFieldMetadata.getType() was renamed to getThriftType(), and an
unrelated getType() function was added. Update the template to call
getThriftType.
