### PR TITLE
Make all @ThriftStruct classes final

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -166,12 +166,12 @@ public abstract class AbstractThriftMetadataBuilder
 
     protected final void verifyClass(Class<? extends Annotation> annotation)
     {
-        // Verify struct class is public and not abstract
-        if (Modifier.isAbstract(getStructClass().getModifiers())) {
-            metadataErrors.addError("%s class [%s] is abstract", annotation.getSimpleName(), getStructClass().getName());
-        }
+        // Verify struct class is public and final
         if (!Modifier.isPublic(getStructClass().getModifiers())) {
             metadataErrors.addError("%s class [%s] is not public", annotation.getSimpleName(), getStructClass().getName());
+        }
+        if (!Modifier.isFinal(structClass.getModifiers())) {
+            metadataErrors.addError("%s class [%s] is not final (thrift does not support polymorphism)", annotation.getSimpleName(), structClas
         }
 
         if (!getStructClass().isAnnotationPresent(annotation)) {

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -166,16 +166,19 @@ public abstract class AbstractThriftMetadataBuilder
 
     protected final void verifyClass(Class<? extends Annotation> annotation)
     {
+        String annotationName = annotation.getSimpleName();
+        String structClassName = getStructClass().getName();
+
         // Verify struct class is public and final
         if (!Modifier.isPublic(getStructClass().getModifiers())) {
-            metadataErrors.addError("%s class [%s] is not public", annotation.getSimpleName(), getStructClass().getName());
+            metadataErrors.addError("%s class [%s] is not public", annotationName, structClassName);
         }
-        if (!Modifier.isFinal(structClass.getModifiers())) {
-            metadataErrors.addError("%s class [%s] is not final (thrift does not support polymorphism)", annotation.getSimpleName(), structClas
+        if (!Modifier.isFinal(getStructClass().getModifiers())) {
+            metadataErrors.addError("%s class [%s] is not final (thrift does not support polymorphism)", annotationName, structClassName);
         }
 
         if (!getStructClass().isAnnotationPresent(annotation)) {
-            metadataErrors.addError("%s class [%s] does not have a @%s annotation", getStructClass().getName(), annotation.getSimpleName());
+            metadataErrors.addError("%s class [%s] does not have a @%s annotation", annotationName, structClassName, annotationName);
         }
     }
 

--- a/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
@@ -15,14 +15,14 @@
  */
 package com.facebook.swift.codec;
 
+import com.facebook.swift.codec.generics.GenericThriftStruct;
+import com.facebook.swift.codec.generics.GenericThriftStructFromBuilder;
 import com.facebook.swift.codec.internal.EnumThriftCodec;
 import com.facebook.swift.codec.generics.ConcreteDerivedFromGeneric;
 import com.facebook.swift.codec.generics.ConcreteDerivedFromGenericBean;
 import com.facebook.swift.codec.generics.ConcreteThriftStructDerivedFromGenericField;
-import com.facebook.swift.codec.generics.GenericThriftStructBase;
-import com.facebook.swift.codec.generics.GenericThriftStructBaseFromBuilder;
-import com.facebook.swift.codec.generics.GenericThriftStructBeanBase;
-import com.facebook.swift.codec.generics.GenericThriftStructFieldBase;
+import com.facebook.swift.codec.generics.GenericThriftStructBean;
+import com.facebook.swift.codec.generics.GenericThriftStructField;
 import com.facebook.swift.codec.internal.coercion.DefaultJavaCoercions;
 import com.facebook.swift.codec.metadata.ThriftCatalog;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata;
@@ -308,10 +308,10 @@ public abstract class AbstractThriftCodecManagerTest
     public void testBeanGeneric()
             throws Exception
     {
-        GenericThriftStructBeanBase<String> bean = new GenericThriftStructBeanBase<>();
+        GenericThriftStructBean<String> bean = new GenericThriftStructBean<>();
         bean.setGenericProperty("genericValue");
 
-        testRoundTripSerialize(new TypeToken<GenericThriftStructBeanBase<String>>() {}, bean);
+        testRoundTripSerialize(new TypeToken<GenericThriftStructBean<String>>() {}, bean);
     }
 
     @Test
@@ -329,9 +329,9 @@ public abstract class AbstractThriftCodecManagerTest
     public void testImmutableGeneric()
             throws Exception
     {
-        GenericThriftStructBase<Double> immutable = new GenericThriftStructBase<>(Math.PI);
+        GenericThriftStruct<Double> immutable = new GenericThriftStruct<>(Math.PI);
 
-        testRoundTripSerialize(new TypeToken<GenericThriftStructBase<Double>>() {}, immutable);
+        testRoundTripSerialize(new TypeToken<GenericThriftStruct<Double>>() {}, immutable);
     }
 
     @Test
@@ -347,14 +347,14 @@ public abstract class AbstractThriftCodecManagerTest
     public void testGenericFromBuilder()
             throws Exception
     {
-        GenericThriftStructBaseFromBuilder<Integer, Double> builderObject =
-                new GenericThriftStructBaseFromBuilder.Builder<Integer, Double>()
+        GenericThriftStructFromBuilder<Integer, Double> builderObject =
+                new GenericThriftStructFromBuilder.Builder<Integer, Double>()
                         .setFirstGenericProperty(12345)
                         .setSecondGenericProperty(1.2345)
                         .build();
 
         testRoundTripSerialize(
-                new TypeToken<GenericThriftStructBaseFromBuilder<Integer, Double>>() {},
+                new TypeToken<GenericThriftStructFromBuilder<Integer, Double>>() {},
                 builderObject);
     }
 
@@ -362,11 +362,11 @@ public abstract class AbstractThriftCodecManagerTest
     public void testFieldGeneric()
             throws Exception
     {
-        GenericThriftStructFieldBase<Integer> fieldObject = new GenericThriftStructFieldBase<>();
+        GenericThriftStructField<Integer> fieldObject = new GenericThriftStructField<>();
         fieldObject.genericField = 5757;
 
         testRoundTripSerialize(
-                new TypeToken<GenericThriftStructFieldBase<Integer>>() {},
+                new TypeToken<GenericThriftStructField<Integer>>() {},
                 fieldObject);
     }
 

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkBean.java
@@ -16,7 +16,7 @@
 package com.facebook.swift.codec;
 
 @ThriftStruct("Bonk")
-public class BonkBean
+public final class BonkBean
 {
     private String message;
     private int type;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkBuilder.java
@@ -21,7 +21,7 @@ import javax.annotation.concurrent.Immutable;
 
 @Immutable
 @ThriftStruct(value = "Bonk", builder = Builder.class)
-public class BonkBuilder
+public final class BonkBuilder
 {
     private final String message;
     private final int type;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkConstructor.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkConstructor.java
@@ -19,7 +19,7 @@ import javax.annotation.concurrent.Immutable;
 
 @Immutable
 @ThriftStruct("Bonk")
-public class BonkConstructor
+public final class BonkConstructor
 {
     private final String message;
     private final int type;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkConstructorNameOverride.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkConstructorNameOverride.java
@@ -19,7 +19,7 @@ import javax.annotation.concurrent.Immutable;
 
 @Immutable
 @ThriftStruct("Bonk")
-public class BonkConstructorNameOverride
+public final class BonkConstructorNameOverride
 {
     private final String message;
     private final int type;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkField.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkField.java
@@ -16,7 +16,7 @@
 package com.facebook.swift.codec;
 
 @ThriftStruct("Bonk")
-public class BonkField
+public final class BonkField
 {
     @ThriftField(1)
     public String message;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkMethod.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkMethod.java
@@ -16,7 +16,7 @@
 package com.facebook.swift.codec;
 
 @ThriftStruct("Bonk")
-public class BonkMethod
+public final class BonkMethod
 {
     private String message;
     private int type;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/CoercionBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/CoercionBean.java
@@ -18,7 +18,7 @@ package com.facebook.swift.codec;
 import java.util.List;
 
 @ThriftStruct
-public class CoercionBean
+public final class CoercionBean
 {
     private Boolean booleanValue;
     private Byte byteValue;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/IsSetBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/IsSetBean.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import static com.google.common.base.Charsets.UTF_8;
 
 @ThriftStruct
-public class IsSetBean
+public final class IsSetBean
 {
     public static IsSetBean createEmpty()
     {

--- a/swift-codec/src/test/java/com/facebook/swift/codec/OneOfEverything.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/OneOfEverything.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 @ThriftStruct
-public class OneOfEverything
+public final class OneOfEverything
 {
     @ThriftField(1)
     public boolean aBoolean;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/UnionBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/UnionBean.java
@@ -19,7 +19,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 
 @ThriftUnion("Union")
-public class UnionBean
+public final class UnionBean
 {
     private Object value;
     private short type;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/UnionBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/UnionBuilder.java
@@ -20,7 +20,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 
 @ThriftUnion(value = "Union", builder = Builder.class)
-public class UnionBuilder
+public final class UnionBuilder
 {
     private final Object value;
 

--- a/swift-codec/src/test/java/com/facebook/swift/codec/UnionConstructor.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/UnionConstructor.java
@@ -19,7 +19,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 
 @ThriftUnion("Union")
-public class UnionConstructor
+public final class UnionConstructor
 {
     private final Object value;
     private final short type;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/UnionField.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/UnionField.java
@@ -18,7 +18,7 @@ package com.facebook.swift.codec;
 import com.google.common.base.Objects;
 
 @ThriftUnion("Union")
-public class UnionField
+public final class UnionField
 {
     @ThriftField(1)
     public String stringValue;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/UnionMethod.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/UnionMethod.java
@@ -19,7 +19,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 
 @ThriftUnion("Union")
-public class UnionMethod
+public final class UnionMethod
 {
     private Object value;
     @ThriftUnionId

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGeneric.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGeneric.java
@@ -22,7 +22,7 @@ import com.facebook.swift.codec.ThriftStruct;
 import java.util.Objects;
 
 @ThriftStruct
-public class ConcreteDerivedFromGeneric extends GenericThriftStructBase<Double>
+public final class ConcreteDerivedFromGeneric extends GenericThriftStructBase<Double>
 {
     private final Double concreteProperty;
 

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGenericBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGenericBean.java
@@ -21,7 +21,7 @@ import com.facebook.swift.codec.ThriftStruct;
 import java.util.Objects;
 
 @ThriftStruct
-public class ConcreteDerivedFromGenericBean extends GenericThriftStructBeanBase<String>
+public final class ConcreteDerivedFromGenericBean extends GenericThriftStructBeanBase<String>
 {
     private String concreteField;
 

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteThriftStructDerivedFromGenericField.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteThriftStructDerivedFromGenericField.java
@@ -21,7 +21,7 @@ import com.facebook.swift.codec.ThriftStruct;
 import java.util.Objects;
 
 @ThriftStruct
-public class ConcreteThriftStructDerivedFromGenericField extends GenericThriftStructFieldBase<String>
+public final class ConcreteThriftStructDerivedFromGenericField extends GenericThriftStructFieldBase<String>
 {
     @ThriftField(2)
     public String concreteField;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStruct.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStruct.java
@@ -15,36 +15,16 @@
  */
 package com.facebook.swift.codec.generics;
 
+import com.facebook.swift.codec.ThriftConstructor;
 import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
 
-import java.util.Objects;
-
-public class GenericThriftStructBeanBase<T>
+@ThriftStruct
+public final class GenericThriftStruct<T> extends GenericThriftStructBase<T>
 {
-    private T genericProperty;
-
-    @ThriftField(1)
-    public T getGenericProperty()
+    @ThriftConstructor
+    public GenericThriftStruct(@ThriftField(1) T genericProperty)
     {
-        return genericProperty;
-    }
-
-    @ThriftField(1)
-    public void setGenericProperty(T value)
-    {
-        this.genericProperty = value;
-    }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (obj == this) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        GenericThriftStructBeanBase<?> other = (GenericThriftStructBeanBase<?>) obj;
-        return Objects.equals(this.genericProperty, other.genericProperty);
+        super(genericProperty);
     }
 }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBase.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBase.java
@@ -17,16 +17,13 @@ package com.facebook.swift.codec.generics;
 
 import com.facebook.swift.codec.ThriftConstructor;
 import com.facebook.swift.codec.ThriftField;
-import com.facebook.swift.codec.ThriftStruct;
 
 import java.util.Objects;
 
-@ThriftStruct
 public class GenericThriftStructBase<T>
 {
     private T genericProperty;
 
-    @ThriftConstructor
     public GenericThriftStructBase(@ThriftField(1) T genericProperty)
     {
         this.genericProperty = genericProperty;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBean.java
@@ -15,25 +15,9 @@
  */
 package com.facebook.swift.codec.generics;
 
-import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
 
-import java.util.Objects;
-
-public class GenericThriftStructFieldBase<T>
+@ThriftStruct
+public final class GenericThriftStructBean<T> extends GenericThriftStructBeanBase<T>
 {
-    @ThriftField(1)
-    public T genericField;
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (obj == this) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        GenericThriftStructFieldBase<?> other = (GenericThriftStructFieldBase<?>) obj;
-        return Objects.equals(genericField, other.genericField);
-    }
 }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructField.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructField.java
@@ -15,25 +15,9 @@
  */
 package com.facebook.swift.codec.generics;
 
-import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
 
-import java.util.Objects;
-
-public class GenericThriftStructFieldBase<T>
+@ThriftStruct
+public final class GenericThriftStructField<T> extends GenericThriftStructFieldBase<T>
 {
-    @ThriftField(1)
-    public T genericField;
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (obj == this) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        GenericThriftStructFieldBase<?> other = (GenericThriftStructFieldBase<?>) obj;
-        return Objects.equals(genericField, other.genericField);
-    }
 }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructFromBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructFromBuilder.java
@@ -21,13 +21,13 @@ import com.facebook.swift.codec.ThriftStruct;
 
 import java.util.Objects;
 
-@ThriftStruct(builder = GenericThriftStructBaseFromBuilder.Builder.class)
-public class GenericThriftStructBaseFromBuilder<S, T>
+@ThriftStruct(builder = GenericThriftStructFromBuilder.Builder.class)
+public final class GenericThriftStructFromBuilder<S, T>
 {
     private final S firstGenericProperty;
     private final T secondGenericProperty;
 
-    private GenericThriftStructBaseFromBuilder(S firstGenericProperty, T secondGenericProperty)
+    private GenericThriftStructFromBuilder(S firstGenericProperty, T secondGenericProperty)
     {
         this.firstGenericProperty = firstGenericProperty;
         this.secondGenericProperty = secondGenericProperty;
@@ -54,7 +54,7 @@ public class GenericThriftStructBaseFromBuilder<S, T>
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        GenericThriftStructBaseFromBuilder<?, ?> other = (GenericThriftStructBaseFromBuilder<?, ?>) obj;
+        GenericThriftStructFromBuilder<?, ?> other = (GenericThriftStructFromBuilder<?, ?>) obj;
         return
                 Objects.equals(firstGenericProperty, other.firstGenericProperty) &&
                 Objects.equals(secondGenericProperty, other.secondGenericProperty);
@@ -80,9 +80,9 @@ public class GenericThriftStructBaseFromBuilder<S, T>
         }
 
         @ThriftConstructor
-        public GenericThriftStructBaseFromBuilder<X, Y> build()
+        public GenericThriftStructFromBuilder<X, Y> build()
         {
-            return new GenericThriftStructBaseFromBuilder<>(firstGenericProperty, secondGenericProperty);
+            return new GenericThriftStructFromBuilder<>(firstGenericProperty, secondGenericProperty);
         }
     }
 }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -220,7 +220,7 @@ public class TestThriftStructMetadataBuilder
     }
 
     @ThriftStruct(builder = GenericStruct.GenericBuilder.class)
-    public static class GenericStruct<T>
+    public final static class GenericStruct<T>
     {
         private T fieldValue;
 

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -50,7 +50,7 @@ public class TestThriftStructMetadataBuilder
     }
 
     @ThriftStruct
-    public static class NoId
+    public final static class NoId
     {
         @ThriftField
         public String getField1()
@@ -86,7 +86,7 @@ public class TestThriftStructMetadataBuilder
     }
 
     @ThriftStruct
-    public static class MultipleIds
+    public final static class MultipleIds
     {
         @ThriftField(name = "foo", value = 1)
         public void setField1(String value)
@@ -133,7 +133,7 @@ public class TestThriftStructMetadataBuilder
     }
 
     @ThriftStruct
-    public static class MultipleNames
+    public final static class MultipleNames
     {
         @ThriftField(value = 1, name = "foo")
         public String getFoo()
@@ -169,7 +169,7 @@ public class TestThriftStructMetadataBuilder
     }
 
     @ThriftStruct
-    public static class UnsupportedJavaType
+    public final static class UnsupportedJavaType
     {
         @ThriftField(1)
         public Lock unsupportedJavaType;
@@ -197,7 +197,7 @@ public class TestThriftStructMetadataBuilder
     }
 
     @ThriftStruct
-    public static class MultipleTypes
+    public final static class MultipleTypes
     {
         @ThriftField(1)
         public int getFoo()

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
@@ -49,7 +49,7 @@ public class TestThriftUnionMetadataBuilder
     }
 
     @ThriftUnion
-    public static class NoId
+    public final static class NoId
     {
         @ThriftUnionId
         public short id;
@@ -88,7 +88,7 @@ public class TestThriftUnionMetadataBuilder
     }
 
     @ThriftUnion
-    public static class MultipleIds
+    public final static class MultipleIds
     {
         @ThriftUnionId
         public void setId(short id)
@@ -140,7 +140,7 @@ public class TestThriftUnionMetadataBuilder
     }
 
     @ThriftUnion
-    public static class MultipleNames
+    public final static class MultipleNames
     {
         @ThriftUnionId
         public void setId(short id)
@@ -181,7 +181,7 @@ public class TestThriftUnionMetadataBuilder
     }
 
     @ThriftUnion
-    public static class UnsupportedJavaType
+    public final static class UnsupportedJavaType
     {
         @ThriftUnionId
         public void setId(short id)
@@ -214,7 +214,7 @@ public class TestThriftUnionMetadataBuilder
     }
 
     @ThriftUnion
-    public static class MultipleTypes
+    public final static class MultipleTypes
     {
         @ThriftUnionId
         public void setId(short id)

--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -66,7 +66,7 @@ import java.util.*;
 import static com.google.common.base.Objects.toStringHelper;
 
 @ThriftUnion("<context.name>")
-public class <context.javaName>
+public final class <context.javaName>
 {
     <_union_body(context)>
 
@@ -82,7 +82,6 @@ public class <context.javaName>
     {
         return this.name;
     }
-
 
     <_union_toString(context)>
 }<\n>

--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -42,7 +42,7 @@ import java.util.*;
 import static com.google.common.base.Objects.toStringHelper;
 
 @ThriftStruct("<context.name>")
-public class <context.javaName>
+public final class <context.javaName>
 {
     <_structbody(context)>
 
@@ -102,7 +102,7 @@ import com.facebook.swift.codec.*;
 import java.util.*;
 
 @ThriftStruct("<context.name>")
-public class <context.javaName> extends <if(tweaks.EXTEND_RUNTIME_EXCEPTION)>RuntimeException<else>Exception<endif>
+public final class <context.javaName> extends <if(tweaks.EXTEND_RUNTIME_EXCEPTION)>RuntimeException<else>Exception<endif>
 {
     private static final long serialVersionUID = 1L;
 
@@ -249,7 +249,7 @@ _toStringField(field) ::= <<
 >>
 
 _union_field(field) ::= <<
-<_annotation(field)> 
+<_annotation(field)>
 public <field.javaType> <field.javaGetterName>() {
     if (this.id != <field.id>) {
         throw new IllegalStateException("Not a <field.name> element!");

--- a/swift-service/src/test/java/com/facebook/swift/generics/GenericStruct.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/GenericStruct.java
@@ -21,7 +21,7 @@ import com.facebook.swift.codec.ThriftStruct;
 import java.util.Objects;
 
 @ThriftStruct
-public class GenericStruct<T>
+public final class GenericStruct<T>
 {
     @ThriftField(1)
     public T genericField;

--- a/swift-service/src/test/java/com/facebook/swift/service/LogEntry.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/LogEntry.java
@@ -20,7 +20,7 @@ import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftStruct;
 
 @ThriftStruct
-public class LogEntry
+public final class LogEntry
 {
     private final String category;
     private final String message;

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftCheckedException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftCheckedException.java
@@ -18,6 +18,6 @@ package com.facebook.swift.service.exceptions;
 import com.facebook.swift.codec.ThriftStruct;
 
 @ThriftStruct
-public class ThriftCheckedException extends Exception {
+public final class ThriftCheckedException extends Exception {
     private static final long serialVersionUID = 1L;
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftUncheckedException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftUncheckedException.java
@@ -18,6 +18,6 @@ package com.facebook.swift.service.exceptions;
 import com.facebook.swift.codec.ThriftStruct;
 
 @ThriftStruct
-public class ThriftUncheckedException extends RuntimeException {
+public final class ThriftUncheckedException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/explicitidentifiers/CustomArgument.java
@@ -19,7 +19,7 @@ import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftStruct;
 
 @ThriftStruct
-public class CustomArgument
+public final class CustomArgument
 {
     public CustomArgument()
     {

--- a/swift-service/src/test/java/com/facebook/swift/service/metadata/TestThriftMethodMetadata.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/metadata/TestThriftMethodMetadata.java
@@ -126,13 +126,13 @@ public class TestThriftMethodMetadata
     }
 
     @ThriftStruct
-    public static class ExceptionA extends Exception
+    public final static class ExceptionA extends Exception
     {
         private static final long serialVersionUID = 1L;
     }
 
     @ThriftStruct
-    public static class ExceptionB extends Exception
+    public final static class ExceptionB extends Exception
     {
         private static final long serialVersionUID = 1L;
     }

--- a/swift-service/src/test/java/com/facebook/swift/service/oneway/OneWayException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/oneway/OneWayException.java
@@ -18,6 +18,6 @@ package com.facebook.swift.service.oneway;
 import com.facebook.swift.codec.ThriftStruct;
 
 @ThriftStruct
-public class OneWayException extends Exception {
+public final class OneWayException extends Exception {
     private static final long serialVersionUID = 1L;
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/swift/MergeAggregationQueryInfo.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/swift/MergeAggregationQueryInfo.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @ThriftStruct
-public class MergeAggregationQueryInfo
+public final class MergeAggregationQueryInfo
 {
     private final List<SingleQueryInfo> queries;
     private final long startTime;

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadQueryInfoTimeString.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadQueryInfoTimeString.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 @ThriftStruct
-public class ReadQueryInfoTimeString
+public final class ReadQueryInfoTimeString
 {
     private final String name;
     private final String startTime;

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadResultQueryInfo.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadResultQueryInfo.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
 @ThriftStruct
-public class ReadResultQueryInfo
+public final class ReadResultQueryInfo
 {
     private final long startTimeResultWindow;
     private final Map<String, String> columnNameValueMap;

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadResultQueryInfoTimeString.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadResultQueryInfoTimeString.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
 @ThriftStruct
-public class ReadResultQueryInfoTimeString
+public final class ReadResultQueryInfoTimeString
 {
     private final String startTimeResultWindow;
     private final Map<String, String> columnNameValueMap;

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadSemanticException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/swift/ReadSemanticException.java
@@ -20,7 +20,7 @@ import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftStruct;
 
 @ThriftStruct
-public class ReadSemanticException extends Exception
+public final class ReadSemanticException extends Exception
 {
     private static final long serialVersionUID = 1L;
 

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/swift/SingleQueryInfo.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/swift/SingleQueryInfo.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 @ThriftStruct
-public class SingleQueryInfo
+public final class SingleQueryInfo
 {
     private final String logicalTableName;
     private final Map<String, String> filter;

--- a/swift-service/src/test/java/com/facebook/swift/service/scribe/LogEntry.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/scribe/LogEntry.java
@@ -45,7 +45,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fields>, java.io.Serializable, Cloneable {
+public final class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("LogEntry");
 
   private static final org.apache.thrift.protocol.TField CATEGORY_FIELD_DESC = new org.apache.thrift.protocol.TField("category", org.apache.thrift.protocol.TType.STRING, (short)1);
@@ -125,9 +125,9 @@ public class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fie
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-    tmpMap.put(_Fields.CATEGORY, new org.apache.thrift.meta_data.FieldMetaData("category", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+    tmpMap.put(_Fields.CATEGORY, new org.apache.thrift.meta_data.FieldMetaData("category", org.apache.thrift.TFieldRequirementType.DEFAULT,
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
-    tmpMap.put(_Fields.MESSAGE, new org.apache.thrift.meta_data.FieldMetaData("message", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+    tmpMap.put(_Fields.MESSAGE, new org.apache.thrift.meta_data.FieldMetaData("message", org.apache.thrift.TFieldRequirementType.DEFAULT,
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(LogEntry.class, metaDataMap);
@@ -404,7 +404,7 @@ public class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fie
       while (true)
       {
         schemeField = iprot.readFieldBegin();
-        if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+        if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
           break;
         }
         switch (schemeField.id) {
@@ -412,7 +412,7 @@ public class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fie
             if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
               struct.category = iprot.readString();
               struct.setCategoryIsSet(true);
-            } else { 
+            } else {
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
@@ -420,7 +420,7 @@ public class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fie
             if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
               struct.message = iprot.readString();
               struct.setMessageIsSet(true);
-            } else { 
+            } else {
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;


### PR DESCRIPTION
Also:
- makes generator generate final classes.
- adds a check that all thrift struct classes used as parameters, return types, or field types are final

The motivation is to reduce confusion about what level of support swift has for inheritance: you can build your thrift struct types by inheriting from base types that have some common thrift fields, but you should not try to declare a base type for a param, return value, or field, and then try to send derived types in place of that base type (because thrift protocol doesn't support polymorphism).
