### PR TITLE
Support for generically-typed thrift structs

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/ThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/ThriftCodecFactory.java
@@ -24,5 +24,5 @@ import com.facebook.swift.codec.metadata.ThriftStructMetadata;
  */
 public interface ThriftCodecFactory
 {
-    <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata);
+    ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata);
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
@@ -51,9 +51,9 @@ public class CompilerThriftCodecFactory implements ThriftCodecFactory
     }
 
     @Override
-    public <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata)
+    public ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata)
     {
-        ThriftCodecByteCodeGenerator<T> generator = new ThriftCodecByteCodeGenerator<>(
+        ThriftCodecByteCodeGenerator<?> generator = new ThriftCodecByteCodeGenerator<>(
                 codecManager,
                 metadata,
                 classLoader,

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/AbstractReflectionThriftCodec.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/AbstractReflectionThriftCodec.java
@@ -29,14 +29,14 @@ import com.google.common.collect.ImmutableSortedMap;
 import java.lang.reflect.InvocationTargetException;
 import java.util.SortedMap;
 
-import static com.facebook.swift.codec.metadata.FieldType.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
 
 public abstract class AbstractReflectionThriftCodec<T> implements ThriftCodec<T>
 {
-    protected final ThriftStructMetadata<T> metadata;
+    protected final ThriftStructMetadata metadata;
     protected final SortedMap<Short, ThriftCodec<?>> fields;
 
-    protected AbstractReflectionThriftCodec(ThriftCodecManager manager, ThriftStructMetadata<T> metadata)
+    protected AbstractReflectionThriftCodec(ThriftCodecManager manager, ThriftStructMetadata metadata)
     {
         this.metadata = metadata;
 

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftCodecFactory.java
@@ -31,7 +31,7 @@ import static java.lang.String.format;
 public class ReflectionThriftCodecFactory implements ThriftCodecFactory
 {
     @Override
-    public <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata)
+    public ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata)
     {
         switch (metadata.getMetadataType()) {
             case STRUCT:

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftStructCodec.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftStructCodec.java
@@ -36,14 +36,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.facebook.swift.codec.metadata.FieldType.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
 
 import static java.lang.String.format;
 
 @Immutable
 public class ReflectionThriftStructCodec<T> extends AbstractReflectionThriftCodec<T>
 {
-    public ReflectionThriftStructCodec(ThriftCodecManager manager, ThriftStructMetadata<T> metadata)
+    public ReflectionThriftStructCodec(ThriftCodecManager manager, ThriftStructMetadata metadata)
     {
         super(manager, metadata);
     }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftStructCodec.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftStructCodec.java
@@ -19,7 +19,6 @@ import com.facebook.swift.codec.ThriftCodec;
 import com.facebook.swift.codec.ThriftCodecManager;
 import com.facebook.swift.codec.internal.TProtocolReader;
 import com.facebook.swift.codec.internal.TProtocolWriter;
-import com.facebook.swift.codec.metadata.FieldType;
 import com.facebook.swift.codec.metadata.ThriftConstructorInjection;
 import com.facebook.swift.codec.metadata.ThriftFieldInjection;
 import com.facebook.swift.codec.metadata.ThriftFieldMetadata;

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftUnionCodec.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/reflection/ReflectionThriftUnionCodec.java
@@ -19,7 +19,7 @@ import com.facebook.swift.codec.ThriftCodec;
 import com.facebook.swift.codec.ThriftCodecManager;
 import com.facebook.swift.codec.internal.TProtocolReader;
 import com.facebook.swift.codec.internal.TProtocolWriter;
-import com.facebook.swift.codec.metadata.FieldType;
+import com.facebook.swift.codec.metadata.FieldKind;
 import com.facebook.swift.codec.metadata.ThriftConstructorInjection;
 import com.facebook.swift.codec.metadata.ThriftFieldInjection;
 import com.facebook.swift.codec.metadata.ThriftFieldMetadata;
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.Immutable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
-import static com.facebook.swift.codec.metadata.FieldType.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -49,11 +49,11 @@ public class ReflectionThriftUnionCodec<T> extends AbstractReflectionThriftCodec
     private final Map<Short, ThriftFieldMetadata> metadataMap;
     private final Map.Entry<ThriftFieldMetadata, ThriftCodec<?>> idField;
 
-    public ReflectionThriftUnionCodec(ThriftCodecManager manager, ThriftStructMetadata<T> metadata)
+    public ReflectionThriftUnionCodec(ThriftCodecManager manager, ThriftStructMetadata metadata)
     {
         super(manager, metadata);
 
-        ThriftFieldMetadata idField = getOnlyElement(metadata.getFields(FieldType.THRIFT_UNION_ID));
+        ThriftFieldMetadata idField = getOnlyElement(metadata.getFields(FieldKind.THRIFT_UNION_ID));
 
         this.idField = Maps.<ThriftFieldMetadata, ThriftCodec<?>>immutableEntry(idField, manager.getCodec(idField.getThriftType()));
         checkNotNull(this.idField.getValue(), "No codec for id field %s found", idField);

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -49,7 +49,11 @@ import static com.facebook.swift.codec.metadata.FieldMetadata.getOrExtractThrift
 import static com.facebook.swift.codec.metadata.FieldMetadata.getThriftFieldId;
 import static com.facebook.swift.codec.metadata.FieldMetadata.getThriftFieldName;
 import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
-import static com.facebook.swift.codec.metadata.ReflectionHelper.*;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.extractParameterNames;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.findAnnotatedMethods;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.getAllDeclaredFields;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.getAllDeclaredMethods;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.resolveFieldTypes;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.notNull;

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.reflect.TypeToken;
+import com.google.inject.internal.MoreTypes;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -35,6 +36,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashSet;
@@ -46,11 +48,8 @@ import static com.facebook.swift.codec.metadata.FieldMetadata.extractThriftField
 import static com.facebook.swift.codec.metadata.FieldMetadata.getOrExtractThriftFieldName;
 import static com.facebook.swift.codec.metadata.FieldMetadata.getThriftFieldId;
 import static com.facebook.swift.codec.metadata.FieldMetadata.getThriftFieldName;
-import static com.facebook.swift.codec.metadata.FieldType.THRIFT_FIELD;
-import static com.facebook.swift.codec.metadata.ReflectionHelper.extractParameterNames;
-import static com.facebook.swift.codec.metadata.ReflectionHelper.findAnnotatedMethods;
-import static com.facebook.swift.codec.metadata.ReflectionHelper.getAllDeclaredFields;
-import static com.facebook.swift.codec.metadata.ReflectionHelper.getAllDeclaredMethods;
+import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.*;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.notNull;
@@ -63,11 +62,11 @@ import static com.google.common.collect.Sets.newTreeSet;
 import static java.util.Arrays.asList;
 
 @NotThreadSafe
-public abstract class AbstractThriftMetadataBuilder<T>
+public abstract class AbstractThriftMetadataBuilder
 {
     protected final String structName;
-    protected final Class<T> structClass;
-    protected final Class<?> builderClass;
+    protected final Type structType;
+    protected final Type builderType;
 
     protected final List<String> documentation;
     protected final List<FieldMetadata> fields = newArrayList();
@@ -84,18 +83,18 @@ public abstract class AbstractThriftMetadataBuilder<T>
     protected final ThriftCatalog catalog;
     protected final MetadataErrors metadataErrors;
 
-    protected AbstractThriftMetadataBuilder(ThriftCatalog catalog, Class<T> structClass)
+    protected AbstractThriftMetadataBuilder(ThriftCatalog catalog, Type structType)
     {
         this.catalog = checkNotNull(catalog, "catalog is null");
-        this.structClass = checkNotNull(structClass, "structClass is null");
+        this.structType = checkNotNull(structType, "structType is null");
         this.metadataErrors = new MetadataErrors(catalog.getMonitor());
 
         // assign the struct name from the annotation or from the Java class
         structName = extractName();
-        // get the builder class from the annotation or from the Java class
-        builderClass = extractBuilderClass();
+        // get the builder type from the annotation or from the Java class
+        builderType = extractBuilderType();
         // grab any documentation from the annotation or saved JavaDocs
-        documentation = ThriftCatalog.getThriftDocumentation(structClass);
+        documentation = ThriftCatalog.getThriftDocumentation(getStructClass());
         // extract all of the annotated constructor and report an error if
         // there is more than one or none
         // also extract thrift fields from the annotated parameters and verify
@@ -116,53 +115,92 @@ public abstract class AbstractThriftMetadataBuilder<T>
 
     protected abstract ThriftFieldMetadata buildField(Collection<FieldMetadata> input);
 
-    public abstract ThriftStructMetadata<T> build();
-
+    public abstract ThriftStructMetadata build();
 
     public MetadataErrors getMetadataErrors()
     {
         return metadataErrors;
     }
 
+    public Class<?> getStructClass()
+    {
+        return TypeToken.of(structType).getRawType();
+    }
+
+    public Class<?> getBuilderClass()
+    {
+        return TypeToken.of(builderType).getRawType();
+    }
+
+    private Type extractBuilderType()
+    {
+        Class<?> builderClass = extractBuilderClass();
+
+        if (builderClass == null) {
+            return null;
+        }
+
+        if (builderClass.getTypeParameters().length == 0) {
+            return builderClass;
+        }
+
+        if (!(structType instanceof ParameterizedType)) {
+            metadataErrors.addError("Builder class [%s] may only be generic if the type it builds ([%s]) is also generic", builderClass.getName(), getStructClass().getName());
+            return builderClass;
+        }
+
+        if (builderClass.getTypeParameters().length != getStructClass().getTypeParameters().length) {
+            metadataErrors.addError("Generic builder class [%s] must have the same number of type parameters as the type it builds ([%s])", builderClass.getName(), getStructClass().getName());
+            return builderClass;
+        }
+
+        ParameterizedType parameterizedStructType = (ParameterizedType) structType;
+
+        return new MoreTypes.ParameterizedTypeImpl(builderClass.getEnclosingClass(), builderClass, parameterizedStructType.getActualTypeArguments());
+    }
+
+
     protected final void verifyClass(Class<? extends Annotation> annotation)
     {
         // Verify struct class is public and not abstract
-        if (Modifier.isAbstract(structClass.getModifiers())) {
-            metadataErrors.addError("%s class [%s] is abstract", annotation.getSimpleName(), structClass.getName());
+        if (Modifier.isAbstract(getStructClass().getModifiers())) {
+            metadataErrors.addError("%s class [%s] is abstract", annotation.getSimpleName(), getStructClass().getName());
         }
-        if (!Modifier.isPublic(structClass.getModifiers())) {
-            metadataErrors.addError("%s class [%s] is not public", annotation.getSimpleName(), structClass.getName());
+        if (!Modifier.isPublic(getStructClass().getModifiers())) {
+            metadataErrors.addError("%s class [%s] is not public", annotation.getSimpleName(), getStructClass().getName());
         }
 
-        if (!structClass.isAnnotationPresent(annotation)) {
-            metadataErrors.addError("%s class [%s] does not have a @%s annotation", structClass.getName(), annotation.getSimpleName());
+        if (!getStructClass().isAnnotationPresent(annotation)) {
+            metadataErrors.addError("%s class [%s] does not have a @%s annotation", getStructClass().getName(), annotation.getSimpleName());
         }
     }
 
     protected final void extractFromConstructors()
     {
-        if (builderClass == null) {
+        if (builderType == null) {
             // struct class must have a valid constructor
-            addConstructors(structClass);
+            addConstructors(structType);
         }
         else {
             // builder class must have a valid constructor
-            addConstructors(builderClass);
+            addConstructors(builderType);
 
             // builder class must have a build method annotated with @ThriftConstructor
             addBuilderMethods();
 
             // verify struct class does not have @ThriftConstructors
-            for (Constructor<?> constructor : structClass.getConstructors()) {
+            for (Constructor<?> constructor : getStructClass().getConstructors()) {
                 if (constructor.isAnnotationPresent(ThriftConstructor.class)) {
-                    metadataErrors.addWarning("Thrift class [%s] has a builder class, but constructor %s annotated with @ThriftConstructor", structClass.getName(), constructor);
+                    metadataErrors.addWarning("Thrift class [%s] has a builder class, but constructor %s annotated with @ThriftConstructor", getStructClass().getName(), constructor);
                 }
             }
         }
     }
 
-    protected final void addConstructors(Class<?> clazz)
+    protected final void addConstructors(Type type)
     {
+        Class<?> clazz = TypeToken.of(type).getRawType();
+
         for (Constructor<?> constructor : clazz.getConstructors()) {
             if (constructor.isSynthetic()) {
                 continue;
@@ -177,8 +215,9 @@ public abstract class AbstractThriftMetadataBuilder<T>
             }
 
             List<ParameterInjection> parameters = getParameterInjections(
+                    type,
                     constructor.getParameterAnnotations(),
-                    constructor.getGenericParameterTypes(),
+                    resolveFieldTypes(structType, constructor.getGenericParameterTypes()),
                     extractParameterNames(constructor));
             if (parameters != null) {
                 fields.addAll(parameters);
@@ -205,10 +244,11 @@ public abstract class AbstractThriftMetadataBuilder<T>
 
     protected final void addBuilderMethods()
     {
-        for (Method method : findAnnotatedMethods(builderClass, ThriftConstructor.class)) {
+        for (Method method : findAnnotatedMethods(getBuilderClass(), ThriftConstructor.class)) {
             List<ParameterInjection> parameters = getParameterInjections(
+                    builderType,
                     method.getParameterAnnotations(),
-                    method.getGenericParameterTypes(),
+                    resolveFieldTypes(builderType, method.getGenericParameterTypes()),
                     extractParameterNames(method));
 
             // parameters are null if the method is misconfigured
@@ -216,10 +256,18 @@ public abstract class AbstractThriftMetadataBuilder<T>
                 fields.addAll(parameters);
                 builderMethodInjections.add(new MethodInjection(method, parameters));
             }
+
+            if (!getStructClass().isAssignableFrom(method.getReturnType())) {
+                metadataErrors.addError(
+                        "[%s] says that [%s] is its builder class, but @ThriftConstructor method [%s] in the builder does not build an instance assignable to that type",
+                        structType,
+                        builderType,
+                        method.getName());
+            }
         }
 
         // find invalid methods not skipped by findAnnotatedMethods()
-        for (Method method : getAllDeclaredMethods(builderClass)) {
+        for (Method method : getAllDeclaredMethods(getBuilderClass())) {
             if (method.isAnnotationPresent(ThriftConstructor.class) || hasThriftFieldAnnotation(method)) {
                 if (!Modifier.isPublic(method.getModifiers())) {
                     metadataErrors.addError("@ThriftConstructor method [%s] is not public", method.toGenericString());
@@ -231,7 +279,7 @@ public abstract class AbstractThriftMetadataBuilder<T>
         }
 
         if (builderMethodInjections.isEmpty()) {
-            metadataErrors.addError("Struct builder class [%s] does not have a public builder method annotated with @ThriftConstructor", builderClass.getName());
+            metadataErrors.addError("Struct builder class [%s] does not have a public builder method annotated with @ThriftConstructor", getBuilderClass().getName());
         }
         if (builderMethodInjections.size() > 1) {
             metadataErrors.addError("Multiple builder methods are annotated with @ThriftConstructor ", builderMethodInjections);
@@ -240,15 +288,15 @@ public abstract class AbstractThriftMetadataBuilder<T>
 
     protected final void extractFromFields()
     {
-        if (builderClass == null) {
+        if (builderType == null) {
             // struct fields are readable and writable
-            addFields(structClass, true, true);
+            addFields(getStructClass(), true, true);
         }
         else {
             // builder fields are writable
-            addFields(builderClass, false, true);
+            addFields(getBuilderClass(), false, true);
             // struct fields are readable
-            addFields(structClass, true, false);
+            addFields(getStructClass(), true, false);
         }
     }
 
@@ -277,12 +325,12 @@ public abstract class AbstractThriftMetadataBuilder<T>
 
         ThriftField annotation = fieldField.getAnnotation(ThriftField.class);
         if (allowReaders) {
-            FieldExtractor fieldExtractor = new FieldExtractor(fieldField, annotation, THRIFT_FIELD);
+            FieldExtractor fieldExtractor = new FieldExtractor(structType, fieldField, annotation, THRIFT_FIELD);
             fields.add(fieldExtractor);
             extractors.add(fieldExtractor);
         }
         if (allowWriters) {
-            FieldInjection fieldInjection = new FieldInjection(fieldField, annotation, THRIFT_FIELD);
+            FieldInjection fieldInjection = new FieldInjection(structType, fieldField, annotation, THRIFT_FIELD);
             fields.add(fieldInjection);
             fieldInjections.add(fieldInjection);
         }
@@ -290,22 +338,24 @@ public abstract class AbstractThriftMetadataBuilder<T>
 
     protected final void extractFromMethods()
     {
-        if (builderClass != null) {
+        if (builderType != null) {
             // builder methods are writable
-            addMethods(builderClass, false, true);
+            addMethods(builderType, false, true);
             // struct methods are readable
-            addMethods(structClass, true, false);
+            addMethods(structType, true, false);
         }
         else {
             // struct methods are readable and writable
-            addMethods(structClass, true, true);
+            addMethods(structType, true, true);
         }
     }
 
-    protected final void addMethods(Class<?> clazz, boolean allowReaders, boolean allowWriters)
+    protected final void addMethods(Type type, boolean allowReaders, boolean allowWriters)
     {
+        Class<?> clazz = TypeToken.of(type).getRawType();
+
         for (Method fieldMethod : findAnnotatedMethods(clazz, ThriftField.class)) {
-            addMethod(clazz, fieldMethod, allowReaders, allowWriters);
+            addMethod(type, fieldMethod, allowReaders, allowWriters);
         }
 
         // find invalid methods not skipped by findAnnotatedMethods()
@@ -321,16 +371,17 @@ public abstract class AbstractThriftMetadataBuilder<T>
         }
     }
 
-    protected final void addMethod(Class<?> clazz, Method method, boolean allowReaders, boolean allowWriters)
+    protected final void addMethod(Type type, Method method, boolean allowReaders, boolean allowWriters)
     {
         checkArgument(method.isAnnotationPresent(ThriftField.class));
 
         ThriftField annotation = method.getAnnotation(ThriftField.class);
+        Class<?> clazz = TypeToken.of(type).getRawType();
 
         // verify parameters
         if (isValidateGetter(method)) {
             if (allowReaders) {
-                MethodExtractor methodExtractor = new MethodExtractor(method, annotation, THRIFT_FIELD);
+                MethodExtractor methodExtractor = new MethodExtractor(type, method, annotation, THRIFT_FIELD);
                 fields.add(methodExtractor);
                 extractors.add(methodExtractor);
             }
@@ -343,8 +394,9 @@ public abstract class AbstractThriftMetadataBuilder<T>
                 List<ParameterInjection> parameters;
                 if (method.getParameterTypes().length > 1 || Iterables.any(asList(method.getParameterAnnotations()[0]), Predicates.instanceOf(ThriftField.class))) {
                     parameters = getParameterInjections(
+                            type,
                             method.getParameterAnnotations(),
-                            method.getGenericParameterTypes(),
+                            resolveFieldTypes(type, method.getGenericParameterTypes()),
                             extractParameterNames(method));
                     if (annotation.value() != Short.MIN_VALUE) {
                         metadataErrors.addError("A method with annotated parameters can not have a field id specified: %s.%s ", clazz.getName(), method.getName());
@@ -357,7 +409,8 @@ public abstract class AbstractThriftMetadataBuilder<T>
                     }
                 }
                 else {
-                    parameters = ImmutableList.of(new ParameterInjection(0, annotation, ReflectionHelper.extractFieldName(method), method.getGenericParameterTypes()[0]));
+                    Type parameterType = resolveFieldTypes(type, method.getGenericParameterTypes())[0];
+                    parameters = ImmutableList.of(new ParameterInjection(type, 0, annotation, ReflectionHelper.extractFieldName(method), parameterType));
                 }
                 fields.addAll(parameters);
                 methodInjections.add(new MethodInjection(method, parameters));
@@ -388,7 +441,7 @@ public abstract class AbstractThriftMetadataBuilder<T>
         return method.getParameterTypes().length == 0 && method.getReturnType() != void.class;
     }
 
-    protected final List<ParameterInjection> getParameterInjections(Annotation[][] parameterAnnotations, Type[] parameterTypes, String[] parameterNames)
+    protected final List<ParameterInjection> getParameterInjections(Type type, Annotation[][] parameterAnnotations, Type[] parameterTypes, String[] parameterNames)
     {
         List<ParameterInjection> parameters = newArrayListWithCapacity(parameterAnnotations.length);
         for (int parameterIndex = 0; parameterIndex < parameterAnnotations.length; parameterIndex++) {
@@ -403,6 +456,7 @@ public abstract class AbstractThriftMetadataBuilder<T>
             }
 
             ParameterInjection parameterInjection = new ParameterInjection(
+                    type,
                     parameterIndex,
                     thriftField,
                     parameterNames[parameterIndex],
@@ -557,7 +611,7 @@ public abstract class AbstractThriftMetadataBuilder<T>
     protected final ThriftMethodInjection buildBuilderConstructorInjections()
     {
         ThriftMethodInjection builderMethodInjection = null;
-        if (builderClass != null) {
+        if (builderType != null) {
             MethodInjection builderMethod = builderMethodInjections.get(0);
             builderMethodInjection = new ThriftMethodInjection(builderMethod.getMethod(), buildParameterInjections(builderMethod.getParameters()));
         }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/Extractor.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/Extractor.java
@@ -19,8 +19,8 @@ import com.facebook.swift.codec.ThriftField;
 
 abstract class Extractor extends FieldMetadata
 {
-    protected Extractor(ThriftField annotation, FieldType fieldType)
+    protected Extractor(ThriftField annotation, FieldKind fieldKind)
     {
-        super(annotation, fieldType);
+        super(annotation, fieldKind);
     }
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldExtractor.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldExtractor.java
@@ -20,13 +20,17 @@ import com.facebook.swift.codec.ThriftField;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
+import static com.facebook.swift.codec.metadata.ReflectionHelper.resolveFieldType;
+
 class FieldExtractor extends Extractor
 {
+    private final Type thriftStructType;
     private final Field field;
 
-    FieldExtractor(Field field, ThriftField annotation, FieldType fieldType)
+    FieldExtractor(Type thriftStructType, Field field, ThriftField annotation, FieldKind fieldKind)
     {
-        super(annotation, fieldType);
+        super(annotation, fieldKind);
+        this.thriftStructType = thriftStructType;
         this.field = field;
     }
 
@@ -44,7 +48,7 @@ class FieldExtractor extends Extractor
     @Override
     public Type getJavaType()
     {
-        return field.getGenericType();
+        return resolveFieldType(thriftStructType, field.getGenericType());
     }
 
     @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldInjection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldInjection.java
@@ -20,13 +20,17 @@ import com.facebook.swift.codec.ThriftField;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
+import static com.facebook.swift.codec.metadata.ReflectionHelper.resolveFieldType;
+
 class FieldInjection extends Injection
 {
+    private final Type thriftStructType;
     private final Field field;
 
-    FieldInjection(Field field, ThriftField annotation, FieldType fieldType)
+    FieldInjection(Type thriftStructType, Field field, ThriftField annotation, FieldKind fieldKind)
     {
-        super(annotation, fieldType);
+        super(annotation, fieldKind);
+        this.thriftStructType = thriftStructType;
         this.field = field;
     }
 
@@ -44,7 +48,7 @@ class FieldInjection extends Injection
     @Override
     public Type getJavaType()
     {
-        return field.getGenericType();
+        return resolveFieldType(thriftStructType, field.getGenericType());
     }
 
     @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldKind.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldKind.java
@@ -15,7 +15,7 @@
  */
 package com.facebook.swift.codec.metadata;
 
-public enum FieldType
+public enum FieldKind
 {
     THRIFT_FIELD,
     THRIFT_UNION_ID;

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldMetadata.java
@@ -28,9 +28,9 @@ abstract class FieldMetadata
 {
     private Short id;
     private String name;
-    private final FieldType type;
+    private final FieldKind type;
 
-    protected FieldMetadata(ThriftField annotation, FieldType type)
+    protected FieldMetadata(ThriftField annotation, FieldKind type)
     {
         this.type = type;
 
@@ -74,7 +74,7 @@ abstract class FieldMetadata
         this.name = name;
     }
 
-    public FieldType getType()
+    public FieldKind getType()
     {
         return type;
     }
@@ -151,7 +151,7 @@ abstract class FieldMetadata
         };
     }
 
-    public static Predicate<FieldMetadata> isType(final FieldType type)
+    public static Predicate<FieldMetadata> isType(final FieldKind type)
     {
         return new Predicate<FieldMetadata>() {
             @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/Injection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/Injection.java
@@ -19,8 +19,8 @@ import com.facebook.swift.codec.ThriftField;
 
 abstract class Injection extends FieldMetadata
 {
-    protected Injection(ThriftField annotation, FieldType fieldType)
+    protected Injection(ThriftField annotation, FieldKind fieldKind)
     {
-        super(annotation, fieldType);
+        super(annotation, fieldKind);
     }
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/MethodExtractor.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/MethodExtractor.java
@@ -21,14 +21,17 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
 import static com.facebook.swift.codec.metadata.ReflectionHelper.extractFieldName;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.resolveFieldType;
 
 class MethodExtractor extends Extractor
 {
+    private final Type thriftStructType;
     private final Method method;
 
-    public MethodExtractor(Method method, ThriftField annotation, FieldType fieldType)
+    public MethodExtractor(Type thriftStructType, Method method, ThriftField annotation, FieldKind fieldKind)
     {
-        super(annotation, fieldType);
+        super(annotation, fieldKind);
+        this.thriftStructType = thriftStructType;
         this.method = method;
     }
 
@@ -46,7 +49,7 @@ class MethodExtractor extends Extractor
     @Override
     public Type getJavaType()
     {
-        return method.getGenericReturnType();
+        return resolveFieldType(thriftStructType, method.getGenericReturnType());
     }
 
     @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ParameterInjection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ParameterInjection.java
@@ -20,17 +20,20 @@ import com.google.common.base.Preconditions;
 
 import java.lang.reflect.Type;
 
-import static com.facebook.swift.codec.metadata.FieldType.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.ReflectionHelper.resolveFieldType;
 
 class ParameterInjection extends Injection
 {
     private final int parameterIndex;
     private final String extractedName;
     private final Type parameterJavaType;
+    private final Type thriftStructType;
 
-    ParameterInjection(int parameterIndex, ThriftField annotation, String extractedName, Type parameterJavaType)
+    ParameterInjection(Type thriftStructType, int parameterIndex, ThriftField annotation, String extractedName, Type parameterJavaType)
     {
         super(annotation, THRIFT_FIELD);
+        this.thriftStructType = thriftStructType;
         Preconditions.checkNotNull(parameterJavaType, "parameterJavaType is null");
 
         this.parameterIndex = parameterIndex;
@@ -56,7 +59,7 @@ class ParameterInjection extends Injection
     @Override
     public Type getJavaType()
     {
-        return parameterJavaType;
+        return resolveFieldType(thriftStructType, parameterJavaType);
     }
 
     @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ReflectionHelper.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ReflectionHelper.java
@@ -16,9 +16,11 @@
 package com.facebook.swift.codec.metadata;
 
 import com.facebook.swift.codec.ThriftField;
+import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.thoughtworks.paranamer.AdaptiveParanamer;
 import com.thoughtworks.paranamer.AnnotationParanamer;
@@ -33,12 +35,15 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -304,5 +309,23 @@ public final class ReflectionHelper
         else {
             return methodName;
         }
+    }
+
+    public static Type resolveFieldType(Type structType, Type genericType)
+    {
+        return TypeToken.of(structType).resolveType(genericType).getType();
+    }
+
+    public static Type[] resolveFieldTypes(final Type structType, Type[] genericTypes)
+    {
+        return Lists.transform(Arrays.asList(genericTypes), new Function<Type, Type>()
+        {
+            @Nullable
+            @Override
+            public Type apply(@Nullable Type input)
+            {
+                return resolveFieldType(structType, input);
+            }
+        }).toArray(new Type[0]);
     }
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadata.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.List;
 import java.util.Map;
 
 import javax.annotation.concurrent.Immutable;

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftEnumMetadataBuilder.java
@@ -16,7 +16,6 @@
 package com.facebook.swift.codec.metadata;
 
 import com.facebook.swift.codec.ThriftEnum;
-import com.facebook.swift.codec.ThriftStruct;
 
 import javax.annotation.concurrent.NotThreadSafe;
 

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftExtraction.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftExtraction.java
@@ -27,5 +27,5 @@ public interface ThriftExtraction
 
     String getName();
 
-    FieldType getType();
+    FieldKind getFieldKind();
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldInjection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldInjection.java
@@ -28,15 +28,15 @@ public class ThriftFieldInjection implements ThriftInjection
     private final short id;
     private final String name;
     private final Field field;
-    private final FieldType fieldType;
+    private final FieldKind fieldKind;
 
-    public ThriftFieldInjection(short id, String name, Field field, FieldType fieldType)
+    public ThriftFieldInjection(short id, String name, Field field, FieldKind fieldKind)
     {
         this.name = checkNotNull(name, "name is null");
         this.field = checkNotNull(field, "field is null");
-        this.fieldType = checkNotNull(fieldType, "fieldType is null");
+        this.fieldKind = checkNotNull(fieldKind, "fieldKind is null");
 
-        switch (fieldType) {
+        switch (fieldKind) {
             case THRIFT_FIELD:
                 checkArgument(id >= 0, "fieldId is negative");
                 break;
@@ -49,9 +49,9 @@ public class ThriftFieldInjection implements ThriftInjection
     }
 
     @Override
-    public FieldType getType()
+    public FieldKind getFieldKind()
     {
-        return fieldType;
+        return fieldKind;
     }
 
     @Override
@@ -78,7 +78,7 @@ public class ThriftFieldInjection implements ThriftInjection
         sb.append("ThriftFieldInjection");
         sb.append("{fieldId=").append(id);
         sb.append(", name=").append(name);
-        sb.append(", fieldType=").append(fieldType);
+        sb.append(", fieldKind=").append(fieldKind);
         sb.append(", field=").append(field.getDeclaringClass().getSimpleName()).append(".").append(field.getName());
         sb.append('}');
         return sb.toString();

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
@@ -38,7 +38,7 @@ public class ThriftFieldMetadata
     private final short id;
     private final ThriftType thriftType;
     private final String name;
-    private final FieldType fieldType;
+    private final FieldKind fieldKind;
     private final List<ThriftInjection> injections;
     private final Optional<ThriftConstructorInjection> constructorInjection;
     private final Optional<ThriftMethodInjection> methodInjection;
@@ -50,7 +50,7 @@ public class ThriftFieldMetadata
             short id,
             ThriftType thriftType,
             String name,
-            FieldType fieldType,
+            FieldKind fieldKind,
             List<ThriftInjection> injections,
             Optional<ThriftConstructorInjection> constructorInjection,
             Optional<ThriftMethodInjection> methodInjection,
@@ -59,7 +59,7 @@ public class ThriftFieldMetadata
     )
     {
         this.thriftType= checkNotNull(thriftType, "thriftType is null");
-        this.fieldType = checkNotNull(fieldType, "type is null");
+        this.fieldKind = checkNotNull(fieldKind, "type is null");
         this.name = checkNotNull(name, "name is null");
         this.injections = ImmutableList.copyOf(checkNotNull(injections, "injections is null"));
         this.constructorInjection = checkNotNull(constructorInjection, "constructorInjection is null");
@@ -68,7 +68,7 @@ public class ThriftFieldMetadata
         this.extraction = checkNotNull(extraction, "extraction is null");
         this.coercion = checkNotNull(coercion, "coercion is null");
 
-        switch (fieldType) {
+        switch (fieldKind) {
             case THRIFT_FIELD:
                 checkArgument(id >= 0, "id is negative");
                 break;
@@ -116,9 +116,9 @@ public class ThriftFieldMetadata
         return name;
     }
 
-    public FieldType getType()
+    public FieldKind getType()
     {
-        return fieldType;
+        return fieldKind;
     }
 
     public boolean isInternal()
@@ -183,7 +183,7 @@ public class ThriftFieldMetadata
         sb.append("{id=").append(id);
         sb.append(", thriftType=").append(thriftType);
         sb.append(", name='").append(name).append('\'');
-        sb.append(", fieldType=").append(fieldType);
+        sb.append(", fieldKind=").append(fieldKind);
         sb.append(", injections=").append(injections);
         sb.append(", constructorInjection=").append(constructorInjection);
         sb.append(", methodInjection=").append(methodInjection);
@@ -223,7 +223,7 @@ public class ThriftFieldMetadata
         };
     }
 
-    public static Predicate<ThriftFieldMetadata> isTypePredicate(final FieldType type)
+    public static Predicate<ThriftFieldMetadata> isTypePredicate(final FieldKind type)
     {
         return new Predicate<ThriftFieldMetadata>() {
             @Override

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftInjection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftInjection.java
@@ -27,5 +27,5 @@ public interface ThriftInjection
 
     String getName();
 
-    FieldType getType();
+    FieldKind getFieldKind();
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftParameterInjection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftParameterInjection.java
@@ -60,9 +60,9 @@ public class ThriftParameterInjection implements ThriftInjection
     }
 
     @Override
-    public FieldType getType()
+    public FieldKind getFieldKind()
     {
-        return FieldType.THRIFT_FIELD;
+        return FieldKind.THRIFT_FIELD;
     }
 
     public int getParameterIndex()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
@@ -47,7 +47,7 @@ public class ThriftType
     public static final ThriftType STRING = new ThriftType(ThriftProtocolType.STRING, ByteBuffer.class);
     public static final ThriftType VOID = new ThriftType(ThriftProtocolType.STRUCT, void.class);
 
-    public static ThriftType struct(ThriftStructMetadata<?> structMetadata)
+    public static ThriftType struct(ThriftStructMetadata structMetadata)
     {
         return new ThriftType(structMetadata);
     }
@@ -97,7 +97,7 @@ public class ThriftType
     private final Type javaType;
     private final ThriftType keyType;
     private final ThriftType valueType;
-    private final ThriftStructMetadata<?> structMetadata;
+    private final ThriftStructMetadata structMetadata;
     private final ThriftEnumMetadata<?> enumMetadata;
     private final ThriftType uncoercedType;
 
@@ -130,7 +130,7 @@ public class ThriftType
         this.uncoercedType = null;
     }
 
-    private ThriftType(ThriftStructMetadata<?> structMetadata)
+    private ThriftType(ThriftStructMetadata structMetadata)
     {
         Preconditions.checkNotNull(structMetadata, "structMetadata is null");
 
@@ -190,7 +190,7 @@ public class ThriftType
         return valueType;
     }
 
-    public ThriftStructMetadata<?> getStructMetadata()
+    public ThriftStructMetadata getStructMetadata()
     {
         checkState(structMetadata != null, "%s does not have struct metadata", protocolType);
         return structMetadata;

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
@@ -26,19 +26,20 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 
-import static com.facebook.swift.codec.metadata.FieldType.THRIFT_UNION_ID;
+import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_UNION_ID;
 import static com.facebook.swift.codec.metadata.ReflectionHelper.findAnnotatedMethods;
 
 @NotThreadSafe
-public class ThriftUnionMetadataBuilder<T>
-    extends AbstractThriftMetadataBuilder<T>
+public class ThriftUnionMetadataBuilder
+    extends AbstractThriftMetadataBuilder
 {
-    public ThriftUnionMetadataBuilder(ThriftCatalog catalog, Class<T> structClass)
+    public ThriftUnionMetadataBuilder(ThriftCatalog catalog, Type structType)
     {
-        super(catalog, structClass);
+        super(catalog, structType);
 
         // verify the class is public and has the correct annotations
         verifyClass(ThriftUnion.class);
@@ -53,22 +54,22 @@ public class ThriftUnionMetadataBuilder<T>
     @Override
     protected String extractName()
     {
-        ThriftUnion annotation = structClass.getAnnotation(ThriftUnion.class);
+        ThriftUnion annotation = getStructClass().getAnnotation(ThriftUnion.class);
         if (annotation == null) {
-            return structClass.getSimpleName();
+            return getStructClass().getSimpleName();
         }
         else if (!annotation.value().isEmpty()) {
             return annotation.value();
         }
         else {
-            return structClass.getSimpleName();
+            return getStructClass().getSimpleName();
         }
     }
 
     @Override
     protected Class<?> extractBuilderClass()
     {
-        ThriftUnion annotation = structClass.getAnnotation(ThriftUnion.class);
+        ThriftUnion annotation = getStructClass().getAnnotation(ThriftUnion.class);
         if (annotation != null && !annotation.builder().equals(void.class)) {
             return annotation.builder();
         }
@@ -79,8 +80,8 @@ public class ThriftUnionMetadataBuilder<T>
 
     private void extractThriftUnionId()
     {
-        Collection<Field> idFields = ReflectionHelper.findAnnotatedFields(structClass, ThriftUnionId.class);
-        Collection<Method> idMethods = findAnnotatedMethods(structClass, ThriftUnionId.class);
+        Collection<Field> idFields = ReflectionHelper.findAnnotatedFields(getStructClass(), ThriftUnionId.class);
+        Collection<Method> idMethods = findAnnotatedMethods(getStructClass(), ThriftUnionId.class);
 
         if (idFields.size() + idMethods.size() != 1) {
             if (idFields.size() + idMethods.size() == 0) {
@@ -99,11 +100,11 @@ public class ThriftUnionMetadataBuilder<T>
         }
 
         for (Field idField : idFields) {
-            FieldExtractor fieldExtractor = new FieldExtractor(idField, null, THRIFT_UNION_ID);
+            FieldExtractor fieldExtractor = new FieldExtractor(structType, idField, null, THRIFT_UNION_ID);
             fields.add(fieldExtractor);
             extractors.add(fieldExtractor);
 
-            FieldInjection fieldInjection = new FieldInjection(idField, null, THRIFT_UNION_ID);
+            FieldInjection fieldInjection = new FieldInjection(structType, idField, null, THRIFT_UNION_ID);
             fields.add(fieldInjection);
             fieldInjections.add(fieldInjection);
         }
@@ -119,7 +120,7 @@ public class ThriftUnionMetadataBuilder<T>
             }
 
             if (isValidateGetter(idMethod)) {
-                MethodExtractor methodExtractor = new MethodExtractor(idMethod, null, THRIFT_UNION_ID);
+                MethodExtractor methodExtractor = new MethodExtractor(structType, idMethod, null, THRIFT_UNION_ID);
                 fields.add(methodExtractor);
                 extractors.add(methodExtractor);
             }
@@ -149,7 +150,7 @@ public class ThriftUnionMetadataBuilder<T>
     // Build final metadata
     //
     @Override
-    public ThriftStructMetadata<T> build()
+    public ThriftStructMetadata build()
     {
         // this code assumes that metadata is clean
         metadataErrors.throwIfHasErrors();
@@ -166,10 +167,10 @@ public class ThriftUnionMetadataBuilder<T>
         // methods injections
         List<ThriftMethodInjection> methodInjections = buildMethodInjections();
 
-        return new ThriftStructMetadata<>(
+        return new ThriftStructMetadata(
                 structName,
-                structClass,
-                builderClass,
+                structType,
+                builderType,
                 MetadataType.UNION,
                 Optional.fromNullable(builderMethodInjection),
                 ImmutableList.copyOf(documentation),
@@ -196,7 +197,7 @@ public class ThriftUnionMetadataBuilder<T>
     {
         short id = -1;
         String name = null;
-        FieldType fieldType = FieldType.THRIFT_FIELD;
+        FieldKind fieldType = FieldKind.THRIFT_FIELD;
         ThriftType thriftType = null;
         ThriftConstructorInjection thriftConstructorInjection = null;
         ThriftMethodInjection thriftMethodInjection = null;
@@ -239,11 +240,11 @@ public class ThriftUnionMetadataBuilder<T>
             }
             else if (fieldMetadata instanceof FieldExtractor) {
                 FieldExtractor fieldExtractor = (FieldExtractor) fieldMetadata;
-                extraction = new ThriftFieldExtractor(fieldExtractor.getId(), fieldExtractor.getName(), fieldExtractor.getField(), fieldExtractor.getType());
+                extraction = new ThriftFieldExtractor(fieldExtractor.getId(), fieldExtractor.getName(), fieldExtractor.getType(), fieldExtractor.getField(), fieldExtractor.getJavaType());
             }
             else if (fieldMetadata instanceof MethodExtractor) {
                 MethodExtractor methodExtractor = (MethodExtractor) fieldMetadata;
-                extraction = new ThriftMethodExtractor(methodExtractor.getId(), methodExtractor.getName(), methodExtractor.getMethod(), methodExtractor.getType());
+                extraction = new ThriftMethodExtractor(methodExtractor.getId(), methodExtractor.getName(), methodExtractor.getType(), methodExtractor.getMethod(), methodExtractor.getJavaType());
             }
         }
 

--- a/swift-codec/src/test/java/com/facebook/swift/codec/TestThriftCodecManager.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/TestThriftCodecManager.java
@@ -54,7 +54,6 @@ import static org.testng.Assert.fail;
 public class TestThriftCodecManager
 {
     private ThriftCodecManager codecManager;
-    private ThriftType fruitType;
 
     @BeforeMethod
     protected void setUp()
@@ -63,15 +62,15 @@ public class TestThriftCodecManager
         codecManager = new ThriftCodecManager(new ThriftCodecFactory()
         {
             @Override
-            public <T> ThriftCodec<T> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata<T> metadata)
+            public ThriftCodec<?> generateThriftTypeCodec(ThriftCodecManager codecManager, ThriftStructMetadata metadata)
             {
                 throw new UnsupportedOperationException();
             }
         });
         ThriftCatalog catalog = codecManager.getCatalog();
         catalog.addDefaultCoercions(DefaultJavaCoercions.class);
-        fruitType = catalog.getThriftType(Fruit.class);
-        codecManager.addCodec(new EnumThriftCodec<>(fruitType));
+        ThriftType fruitType = catalog.getThriftType(Fruit.class);
+        codecManager.addCodec(new EnumThriftCodec<Fruit>(fruitType));
     }
 
     @Test

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGeneric.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGeneric.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class ConcreteDerivedFromGeneric extends GenericThriftStructBase<Double>
+{
+    private final Double concreteProperty;
+
+    @ThriftConstructor
+    public ConcreteDerivedFromGeneric(
+            @ThriftField(1) Double genericProperty,
+            @ThriftField(2) Double concreteProperty)
+    {
+        super(genericProperty);
+        this.concreteProperty = concreteProperty;
+    }
+
+    @ThriftField(2)
+    public Double getConcreteProperty()
+    {
+        return concreteProperty;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConcreteDerivedFromGeneric other = (ConcreteDerivedFromGeneric) obj;
+        return Objects.equals(this.concreteProperty, other.concreteProperty) && super.equals(obj);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGenericBean.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteDerivedFromGenericBean.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class ConcreteDerivedFromGenericBean extends GenericThriftStructBeanBase<String>
+{
+    private String concreteField;
+
+    @ThriftField(2)
+    public String getConcreteField()
+    {
+        return concreteField;
+    }
+
+    @ThriftField(2)
+    public void setConcreteField(String concreteField)
+    {
+        this.concreteField = concreteField;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConcreteDerivedFromGenericBean other = (ConcreteDerivedFromGenericBean) obj;
+        return Objects.equals(this.concreteField, other.concreteField) && super.equals(obj);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteThriftStructDerivedFromGenericField.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/ConcreteThriftStructDerivedFromGenericField.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class ConcreteThriftStructDerivedFromGenericField extends GenericThriftStructFieldBase<String>
+{
+    @ThriftField(2)
+    public String concreteField;
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConcreteThriftStructDerivedFromGenericField other = (ConcreteThriftStructDerivedFromGenericField) obj;
+        return Objects.equals(concreteField, other.concreteField) && super.equals(obj);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBase.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBase.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericThriftStructBase<T>
+{
+    private T genericProperty;
+
+    @ThriftConstructor
+    public GenericThriftStructBase(@ThriftField(1) T genericProperty)
+    {
+        this.genericProperty = genericProperty;
+    }
+
+    @ThriftField(1)
+    public T getGenericProperty()
+    {
+        return genericProperty;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructBase<?> other = (GenericThriftStructBase<?>) obj;
+        return Objects.equals(this.genericProperty, other.genericProperty);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBaseFromBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBaseFromBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct(builder = GenericThriftStructBaseFromBuilder.Builder.class)
+public class GenericThriftStructBaseFromBuilder<S, T>
+{
+    private final S firstGenericProperty;
+    private final T secondGenericProperty;
+
+    private GenericThriftStructBaseFromBuilder(S firstGenericProperty, T secondGenericProperty)
+    {
+        this.firstGenericProperty = firstGenericProperty;
+        this.secondGenericProperty = secondGenericProperty;
+    }
+
+    @ThriftField(1)
+    public S getFirstGenericProperty()
+    {
+        return firstGenericProperty;
+    }
+
+    @ThriftField(2)
+    public T getSecondGenericProperty()
+    {
+        return secondGenericProperty;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructBaseFromBuilder<?, ?> other = (GenericThriftStructBaseFromBuilder<?, ?>) obj;
+        return
+                Objects.equals(firstGenericProperty, other.firstGenericProperty) &&
+                Objects.equals(secondGenericProperty, other.secondGenericProperty);
+    }
+
+    public static class Builder<X, Y>
+    {
+        private X firstGenericProperty;
+        private Y secondGenericProperty;
+
+        @ThriftField(1)
+        public Builder<X, Y> setFirstGenericProperty(X firstGenericProperty)
+        {
+            this.firstGenericProperty = firstGenericProperty;
+            return this;
+        }
+
+        @ThriftField(2)
+        public Builder<X, Y> setSecondGenericProperty(Y secondGenericProperty)
+        {
+            this.secondGenericProperty = secondGenericProperty;
+            return this;
+        }
+
+        @ThriftConstructor
+        public GenericThriftStructBaseFromBuilder<X, Y> build()
+        {
+            return new GenericThriftStructBaseFromBuilder<>(firstGenericProperty, secondGenericProperty);
+        }
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBeanBase.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructBeanBase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericThriftStructBeanBase<T>
+{
+    private T genericProperty;
+
+    @ThriftField(1)
+    public T getGenericProperty()
+    {
+        return genericProperty;
+    }
+
+    @ThriftField(1)
+    public void setGenericProperty(T value)
+    {
+        this.genericProperty = value;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructBeanBase<?> other = (GenericThriftStructBeanBase<?>) obj;
+        return Objects.equals(this.genericProperty, other.genericProperty);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructFieldBase.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/generics/GenericThriftStructFieldBase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericThriftStructFieldBase<T>
+{
+    @ThriftField(1)
+    public T genericField;
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        GenericThriftStructFieldBase<?> other = (GenericThriftStructFieldBase<?>) obj;
+        return Objects.equals(genericField, other.genericField);
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
@@ -35,7 +35,7 @@ public class TestThriftStructMetadata
     @Test
     public void testField()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkField.class, 0, 0);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkField.class, 0, 0);
 
         verifyFieldInjection(metadata, 1, "message");
         verifyFieldExtraction(metadata, 1, "message");
@@ -43,7 +43,7 @@ public class TestThriftStructMetadata
         verifyFieldExtraction(metadata, 2, "type");
     }
 
-    private void verifyFieldInjection(ThriftStructMetadata<?> metadata, int id, String name)
+    private void verifyFieldInjection(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftInjection injection = metadata.getField(id).getInjections().get(0);
         assertThat(injection).isNotNull().isInstanceOf(ThriftFieldInjection.class);
@@ -51,7 +51,7 @@ public class TestThriftStructMetadata
         assertEquals(fieldInjection.getField().getName(), name);
     }
 
-    private void verifyFieldExtraction(ThriftStructMetadata<?> metadata, int id, String name)
+    private void verifyFieldExtraction(ThriftStructMetadata metadata, int id, String name)
     {
         assertTrue(metadata.getField(id).getExtraction().isPresent());
         ThriftExtraction extraction = metadata.getField(id).getExtraction().get();
@@ -63,14 +63,14 @@ public class TestThriftStructMetadata
     @Test
     public void testBean()
     {
-        ThriftStructMetadata<BonkBean> metadata = testMetadataBuild(BonkBean.class, 0, 2);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkBean.class, 0, 2);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 0);
         verifyMethodExtraction(metadata, 2, "type", "getType");
     }
 
-    private void verifyParameterInjection(ThriftStructMetadata<?> metadata, int id, String name, int parameterIndex)
+    private void verifyParameterInjection(ThriftStructMetadata metadata, int id, String name, int parameterIndex)
     {
         ThriftInjection injection = metadata.getField(id).getInjections().get(0);
         assertThat(injection).isNotNull().isInstanceOf(ThriftParameterInjection.class);
@@ -80,7 +80,7 @@ public class TestThriftStructMetadata
         assertEquals(parameterInjection.getParameterIndex(), parameterIndex);
     }
 
-    private void verifyMethodExtraction(ThriftStructMetadata<?> metadata, int id, String name, String methodName)
+    private void verifyMethodExtraction(ThriftStructMetadata metadata, int id, String name, String methodName)
     {
         assertTrue(metadata.getField(id).getExtraction().isPresent());
         ThriftExtraction extraction = metadata.getField(id).getExtraction().get();
@@ -93,7 +93,7 @@ public class TestThriftStructMetadata
     @Test
     public void testConstructor()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkConstructor.class, 2, 0);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkConstructor.class, 2, 0);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 1);
@@ -103,7 +103,7 @@ public class TestThriftStructMetadata
     @Test
     public void testMethod()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkMethod.class, 0, 1);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkMethod.class, 0, 1);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 1);
@@ -113,24 +113,24 @@ public class TestThriftStructMetadata
     @Test
     public void testBuilder()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(BonkBuilder.class, 0, 2);
+        ThriftStructMetadata metadata = testMetadataBuild(BonkBuilder.class, 0, 2);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 0);
         verifyMethodExtraction(metadata, 2, "type", "getType");
     }
 
-    private <T> ThriftStructMetadata<T> testMetadataBuild(Class<T> structClass, int expectedConstructorParameters, int expectedMethodInjections)
+    private ThriftStructMetadata testMetadataBuild(Class<?> structClass, int expectedConstructorParameters, int expectedMethodInjections)
     {
         ThriftCatalog catalog = new ThriftCatalog();
-        ThriftStructMetadataBuilder<T> builder = new ThriftStructMetadataBuilder<>(catalog, structClass);
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(catalog, structClass);
         assertNotNull(builder);
 
         assertNotNull(builder.getMetadataErrors());
         builder.getMetadataErrors().throwIfHasErrors();
         assertEquals(builder.getMetadataErrors().getWarnings().size(), 0);
 
-        ThriftStructMetadata<T> metadata = builder.build();
+        ThriftStructMetadata metadata = builder.build();
         assertNotNull(metadata);
         assertEquals(MetadataType.STRUCT, metadata.getMetadataType());
 
@@ -146,7 +146,7 @@ public class TestThriftStructMetadata
         return metadata;
     }
 
-    private <T> void verifyField(ThriftStructMetadata<T> metadata, int id, String name)
+    private <T> void verifyField(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftFieldMetadata messageField = metadata.getField(id);
         assertNotNull(messageField, "messageField is null");

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadata.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadata.java
@@ -36,7 +36,7 @@ public class TestThriftUnionMetadata
     @Test
     public void testField()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(UnionField.class, 0, 0);
+        ThriftStructMetadata metadata = testMetadataBuild(UnionField.class, 0, 0);
 
         verifyFieldInjection(metadata, 1, "stringValue");
         verifyFieldExtraction(metadata, 1, "stringValue");
@@ -49,7 +49,7 @@ public class TestThriftUnionMetadata
     @Test
     public void testBean()
     {
-        ThriftStructMetadata<UnionBean> metadata = testMetadataBuild(UnionBean.class, 0, 3);
+        ThriftStructMetadata metadata = testMetadataBuild(UnionBean.class, 0, 3);
         verifyParameterInjection(metadata, 1, "stringValue", 0);
         verifyMethodExtraction(metadata, 1, "stringValue", "getStringValue");
         verifyParameterInjection(metadata, 2, "longValue", 0);
@@ -61,7 +61,7 @@ public class TestThriftUnionMetadata
     @Test
     public void testConstructor()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(UnionConstructor.class, 1, 0);
+        ThriftStructMetadata metadata = testMetadataBuild(UnionConstructor.class, 1, 0);
         verifyParameterInjection(metadata, 1, "stringValue", 0);
         verifyMethodExtraction(metadata, 1, "stringValue", "getStringValue");
         verifyParameterInjection(metadata, 2, "longValue", 0);
@@ -87,7 +87,7 @@ public class TestThriftUnionMetadata
     @Test
     public void testBuilder()
     {
-        ThriftStructMetadata<?> metadata = testMetadataBuild(UnionBuilder.class, 0, 3);
+        ThriftStructMetadata metadata = testMetadataBuild(UnionBuilder.class, 0, 3);
         verifyParameterInjection(metadata, 1, "stringValue", 0);
         verifyMethodExtraction(metadata, 1, "stringValue", "getStringValue");
         verifyParameterInjection(metadata, 2, "longValue", 0);
@@ -96,7 +96,7 @@ public class TestThriftUnionMetadata
         verifyMethodExtraction(metadata, 3, "fruitValue", "getFruitValue");
     }
 
-    private void verifyFieldInjection(ThriftStructMetadata<?> metadata, int id, String name)
+    private void verifyFieldInjection(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftInjection injection = metadata.getField(id).getInjections().get(0);
         assertThat(injection).isNotNull().isInstanceOf(ThriftFieldInjection.class);
@@ -104,7 +104,7 @@ public class TestThriftUnionMetadata
         assertEquals(fieldInjection.getField().getName(), name);
     }
 
-    private void verifyFieldExtraction(ThriftStructMetadata<?> metadata, int id, String name)
+    private void verifyFieldExtraction(ThriftStructMetadata metadata, int id, String name)
     {
         assertTrue(metadata.getField(id).getExtraction().isPresent());
         ThriftExtraction extraction = metadata.getField(id).getExtraction().get();
@@ -113,7 +113,7 @@ public class TestThriftUnionMetadata
         assertEquals(fieldExtractor.getField().getName(), name);
     }
 
-    private void verifyParameterInjection(ThriftStructMetadata<?> metadata, int id, String name, int parameterIndex)
+    private void verifyParameterInjection(ThriftStructMetadata metadata, int id, String name, int parameterIndex)
     {
         ThriftInjection injection = metadata.getField(id).getInjections().get(0);
         assertThat(injection).isNotNull().isInstanceOf(ThriftParameterInjection.class);
@@ -123,7 +123,7 @@ public class TestThriftUnionMetadata
         assertEquals(parameterInjection.getParameterIndex(), parameterIndex);
     }
 
-    private void verifyMethodExtraction(ThriftStructMetadata<?> metadata, int id, String name, String methodName)
+    private void verifyMethodExtraction(ThriftStructMetadata metadata, int id, String name, String methodName)
     {
         assertTrue(metadata.getField(id).getExtraction().isPresent());
         ThriftExtraction extraction = metadata.getField(id).getExtraction().get();
@@ -133,17 +133,17 @@ public class TestThriftUnionMetadata
         assertEquals(methodExtractor.getName(), name);
     }
 
-    private <T> ThriftStructMetadata<T> testMetadataBuild(Class<T> structClass, int expectedConstructorParameters, int expectedMethodInjections)
+    private ThriftStructMetadata testMetadataBuild(Class<?> structClass, int expectedConstructorParameters, int expectedMethodInjections)
     {
         ThriftCatalog catalog = new ThriftCatalog();
-        ThriftUnionMetadataBuilder<T> builder = new ThriftUnionMetadataBuilder<>(catalog, structClass);
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(catalog, structClass);
         assertNotNull(builder);
 
         assertNotNull(builder.getMetadataErrors());
         builder.getMetadataErrors().throwIfHasErrors();
         assertEquals(builder.getMetadataErrors().getWarnings().size(), 0);
 
-        ThriftStructMetadata<T> metadata = builder.build();
+        ThriftStructMetadata metadata = builder.build();
         assertNotNull(metadata);
         assertEquals(MetadataType.UNION, metadata.getMetadataType());
 
@@ -168,7 +168,7 @@ public class TestThriftUnionMetadata
         return metadata;
     }
 
-    private <T> void verifyField(ThriftStructMetadata<T> metadata, int id, String name)
+    private <T> void verifyField(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftFieldMetadata metadataField = metadata.getField(id);
         assertNotNull(metadataField, "metadataField is null");

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadata.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadata.java
@@ -157,7 +157,7 @@ public class TestThriftUnionMetadata
             assertEquals(constructorInjection.getParameters().size(), 0);
         }
         else {
-            for (ThriftFieldMetadata fieldMetadata : metadata.getFields(FieldType.THRIFT_FIELD)) {
+            for (ThriftFieldMetadata fieldMetadata : metadata.getFields(FieldKind.THRIFT_FIELD)) {
                 assertTrue(fieldMetadata.getConstructorInjection().isPresent());
                 assertEquals(fieldMetadata.getConstructorInjection().get().getParameters().size(), expectedConstructorParameters);
             }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
@@ -31,7 +31,7 @@ public class TestThriftUnionMetadataBuilder
     public void testNoId()
             throws Exception
     {
-        ThriftUnionMetadataBuilder<NoId> builder = new ThriftUnionMetadataBuilder<>(new ThriftCatalog(), NoId.class);
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(new ThriftCatalog(), NoId.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -70,7 +70,7 @@ public class TestThriftUnionMetadataBuilder
     public void testMultipleIds()
             throws Exception
     {
-        ThriftUnionMetadataBuilder<MultipleIds> builder = new ThriftUnionMetadataBuilder<>(new ThriftCatalog(), MultipleIds.class);
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(new ThriftCatalog(), MultipleIds.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -122,7 +122,7 @@ public class TestThriftUnionMetadataBuilder
     public void testMultipleNames()
             throws Exception
     {
-        ThriftUnionMetadataBuilder<MultipleNames> builder = new ThriftUnionMetadataBuilder<>(new ThriftCatalog(), MultipleNames.class);
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(new ThriftCatalog(), MultipleNames.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -163,7 +163,7 @@ public class TestThriftUnionMetadataBuilder
     public void testUnsupportedType()
             throws Exception
     {
-        ThriftUnionMetadataBuilder<UnsupportedJavaType> builder = new ThriftUnionMetadataBuilder<>(new ThriftCatalog(), UnsupportedJavaType.class);
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(new ThriftCatalog(), UnsupportedJavaType.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 
@@ -196,7 +196,7 @@ public class TestThriftUnionMetadataBuilder
     public void testMultipleTypes()
             throws Exception
     {
-        ThriftUnionMetadataBuilder<MultipleTypes> builder = new ThriftUnionMetadataBuilder<>(new ThriftCatalog(), MultipleTypes.class);
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(new ThriftCatalog(), MultipleTypes.class);
 
         MetadataErrors metadataErrors = builder.getMetadataErrors();
 

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -354,9 +354,9 @@ public class Swift2ThriftGenerator
 
     private boolean verifyStruct(ThriftType t, boolean quiet)
     {
-        ThriftStructMetadata<?> metadata = t.getStructMetadata();
+        ThriftStructMetadata metadata = t.getStructMetadata();
         boolean ok = true;
-        for (ThriftFieldMetadata fieldMetadata: metadata.getFields(FieldType.THRIFT_FIELD)) {
+        for (ThriftFieldMetadata fieldMetadata: metadata.getFields(FieldKind.THRIFT_FIELD)) {
             boolean fieldOk = verifyField(fieldMetadata.getThriftType());
             if (!fieldOk) {
                 ok = false;

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -17,7 +17,7 @@ package com.facebook.swift.generator.swift2thrift;
 
 import com.facebook.swift.codec.ThriftCodecManager;
 import com.facebook.swift.codec.ThriftProtocolType;
-import com.facebook.swift.codec.metadata.FieldType;
+import com.facebook.swift.codec.metadata.FieldKind;
 import com.facebook.swift.codec.metadata.ReflectionHelper;
 import com.facebook.swift.codec.metadata.ThriftFieldMetadata;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata;

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AbstractClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/AbstractClientWorker.java
@@ -17,7 +17,6 @@ package com.facebook.swift.perf.loadgenerator;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.facebook.swift.service.ThriftClientManager;
 import com.google.common.net.HostAndPort;
 
 import java.nio.ByteBuffer;

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/LoadGenerator.java
@@ -21,7 +21,6 @@ import com.facebook.nifty.client.NiftyClientChannel;
 import com.facebook.nifty.client.NiftyClientConnector;
 import com.facebook.nifty.client.UnframedClientConnector;
 import com.facebook.swift.codec.guice.ThriftCodecModule;
-import com.facebook.swift.service.ThriftClientEventHandler;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.guice.ThriftClientModule;
 import com.facebook.swift.service.guice.ThriftClientStatsModule;

--- a/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/SyncClientWorker.java
+++ b/swift-load-generator/src/main/java/com/facebook/swift/perf/loadgenerator/SyncClientWorker.java
@@ -15,16 +15,12 @@
  */
 package com.facebook.swift.perf.loadgenerator;
 
-import com.facebook.nifty.client.NiftyClient;
 import com.facebook.nifty.client.NiftyClientChannel;
 import com.facebook.nifty.client.NiftyClientConnector;
 import com.facebook.swift.service.RuntimeTException;
 import com.facebook.swift.service.ThriftClient;
-import com.facebook.swift.service.ThriftClientConfig;
-import com.facebook.swift.service.ThriftClientManager;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Inject;
-import io.airlift.units.Duration;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;

--- a/swift-service/src/main/java/com/facebook/swift/service/ClientContextChain.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ClientContextChain.java
@@ -15,8 +15,6 @@
  */
 package com.facebook.swift.service;
 
-import com.facebook.nifty.core.RequestContext;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodHandler.java
@@ -35,7 +35,6 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TTransportException;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.weakref.jmx.Managed;
 

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -49,7 +49,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.facebook.swift.codec.metadata.FieldType.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
 import static com.facebook.swift.codec.metadata.ReflectionHelper.extractParameterNames;
 import static com.google.common.base.Preconditions.checkState;
 

--- a/swift-service/src/test/java/com/facebook/swift/generics/GenericInterface.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/GenericInterface.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftService;
+
+@ThriftService
+public interface GenericInterface
+{
+    @ThriftMethod
+    GenericStruct<String> echo(GenericStruct<String> gen);
+
+    public static interface Client extends GenericInterface, AutoCloseable
+    {
+        @Override
+        public void close();
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/generics/GenericService.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/GenericService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.swift.service.ThriftMethod;
+
+public class GenericService implements GenericInterface
+{
+    @Override
+    @ThriftMethod
+    public GenericStruct<String> echo(GenericStruct<String> genericObject)
+    {
+        return genericObject;
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/generics/GenericStruct.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/GenericStruct.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+import java.util.Objects;
+
+@ThriftStruct
+public class GenericStruct<T>
+{
+    @ThriftField(1)
+    public T genericField;
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this || getClass() != obj.getClass()) {
+            return true;
+        }
+        GenericStruct<?> other = (GenericStruct<?>) obj;
+        return Objects.equals(genericField, other.genericField);
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/generics/TestGenericProcessor.java
+++ b/swift-service/src/test/java/com/facebook/swift/generics/TestGenericProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generics;
+
+import com.facebook.nifty.client.FramedClientConnector;
+import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.service.ThriftClient;
+import com.facebook.swift.service.ThriftClientManager;
+import com.facebook.swift.service.ThriftEventHandler;
+import com.facebook.swift.service.ThriftServer;
+import com.facebook.swift.service.ThriftServerConfig;
+import com.facebook.swift.service.ThriftServiceProcessor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+public class TestGenericProcessor
+{
+    @Test
+    public void testGenericProcessor()
+            throws ExecutionException, InterruptedException
+    {
+        ThriftCodecManager codecManager = new ThriftCodecManager();
+        ThriftServiceProcessor processor = new ThriftServiceProcessor(codecManager, ImmutableList.<ThriftEventHandler>of(), new GenericService());
+
+        try (ThriftServer server = new ThriftServer(processor, new ThriftServerConfig()).start();
+             ThriftClientManager clientManager = new ThriftClientManager(codecManager)) {
+            ThriftClient<GenericInterface.Client> clientOpener = new ThriftClient<>(clientManager, GenericInterface.Client.class);
+            try (GenericInterface.Client client = clientOpener.open(new FramedClientConnector(HostAndPort.fromParts("localhost", server.getPort()))).get()) {
+                GenericStruct<String> original = new GenericStruct<>();
+                original.genericField = "original.genericField";
+                GenericStruct<String> copy = client.echo(original);
+                assertEquals(original, copy);
+            }
+        }
+    }
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/async/DelayedMapSyncHandler.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/swift-service/src/test/java/com/facebook/swift/service/puma/TestPuma.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/puma/TestPuma.java
@@ -30,7 +30,6 @@ import com.facebook.swift.service.puma.swift.ReadSemanticException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
-import org.apache.thrift.TProcessor;
 import org.testng.annotations.Test;
 
 import java.util.List;


### PR DESCRIPTION
Adds support for generically-typed @ThriftFields.

With tests for generic @ThriftStruct classes using all types of extractions (ctor+getters, builder+getters, setters+getters, public fields)
