### PR TITLE
Serialize TApplicationException for missing method names

### DIFF
--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionServiceClient.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionServiceClient.java
@@ -15,7 +15,14 @@
  */
 package com.facebook.swift.service.exceptions;
 
+import com.facebook.swift.service.ThriftMethod;
+import org.apache.thrift.TApplicationException;
+
 public interface ExceptionServiceClient extends ExceptionService, AutoCloseable {
+    // Extra method that doesn't exist in the service interface
+    @ThriftMethod
+    public void missingMethod() throws TApplicationException;
+
     @Override
     public void close();
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionTest.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionTest.java
@@ -20,7 +20,10 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.testng.annotations.Test;
 
-public class ExceptionTest extends SuiteBase<ExceptionService, ExceptionService>
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class ExceptionTest extends SuiteBase<ExceptionService, ExceptionServiceClient>
 {
     public ExceptionTest() {
         super(ExceptionServiceHandler.class, ExceptionServiceClient.class);
@@ -63,5 +66,19 @@ public class ExceptionTest extends SuiteBase<ExceptionService, ExceptionService>
     @Test(expectedExceptions = { TApplicationException.class })
     public void testThrowUnexpectedNonThriftUncheckedException() throws TException {
         getClient().throwUnexpectedNonThriftUncheckedException();
+    }
+
+    @Test
+    public void testMissingMethod() throws TApplicationException {
+        try {
+            getClient().missingMethod();
+            fail("Expected TApplicationException of type UNKNOWN_METHOD");
+        }
+        catch (TApplicationException e) {
+            assertEquals(
+                    e.getType(),
+                    TApplicationException.UNKNOWN_METHOD,
+                    "Expected TApplicationException of type UNKNOWN_METHOD");
+        }
     }
 }


### PR DESCRIPTION
We were throwing this exception, which didn't result in it getting serialized to the client. This fixes it.
