### PR TITLE
[swift2thrift] Support classes in different packages with a command-line flag

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -47,6 +47,7 @@ public class Swift2ThriftGenerator {
     private final boolean verbose;
     private final ThriftCodecManager codecManager = new ThriftCodecManager();
     private final String defaultPackage;
+    private final boolean allowMultiplePackages;
     private ThriftTypeRenderer thriftTypeRenderer;
     private List<ThriftType> thriftTypes = Lists.newArrayList();
     private List<ThriftServiceMetadata> thriftServices = Lists.newArrayList();
@@ -89,6 +90,7 @@ public class Swift2ThriftGenerator {
             }
         }
         this.namespaceMap = config.getNamespaceMap();
+        this.allowMultiplePackages = config.isAllowMultiplePackages();
     }
 
     public void parse(Iterable<String> inputs) throws IOException {
@@ -102,8 +104,11 @@ public class Swift2ThriftGenerator {
             if (packageName == null) {
                 packageName = cls.getPackage().getName();
             } else if (!packageName.equals(cls.getPackage().getName())) {
-                throw new IllegalStateException(String.format("Class %s is in package %s, previous classes were in package %s",
-                        cls.getName(), cls.getPackage().getName(), packageName));
+                if (!allowMultiplePackages) {
+                    throw new IllegalStateException(
+                        String.format("Class %s is in package %s, previous classes were in package %s",
+                            cls.getName(), cls.getPackage().getName(), packageName));
+                }
             }
             Object result = convertToThrift(cls);
             if (result instanceof ThriftType) {

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGeneratorConfig.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGeneratorConfig.java
@@ -26,15 +26,18 @@ public class Swift2ThriftGeneratorConfig {
     private final boolean verbose;
     private final String defaultPackage;
     private final Map<String, String> namespaceMap;
+    private final boolean allowMultiplePackages;
 
     private Swift2ThriftGeneratorConfig(final File outputFile, final Map<String, String> includeMap,
-                                        boolean verbose, String defaultPackage, final Map<String, String> namespaceMap)
+                                        boolean verbose, String defaultPackage, final Map<String, String> namespaceMap,
+                                        boolean allowMultiplePackages)
     {
         this.outputFile = outputFile;
         this.includeMap = includeMap;
         this.verbose = verbose;
         this.defaultPackage = defaultPackage;
         this.namespaceMap = namespaceMap;
+        this.allowMultiplePackages = allowMultiplePackages;
     }
 
     public static Builder builder()
@@ -70,6 +73,11 @@ public class Swift2ThriftGeneratorConfig {
         return namespaceMap;
     }
 
+    public boolean isAllowMultiplePackages()
+    {
+        return allowMultiplePackages;
+    }
+
     public static class Builder
     {
         private File outputFile = null;
@@ -77,6 +85,7 @@ public class Swift2ThriftGeneratorConfig {
         private boolean verbose;
         private String defaultPackage;
         private Map<String, String> namespaceMap;
+        private boolean allowMultiplePackages;
 
         private Builder()
         {
@@ -85,7 +94,7 @@ public class Swift2ThriftGeneratorConfig {
         public Swift2ThriftGeneratorConfig build()
         {
             return new Swift2ThriftGeneratorConfig(outputFile, includeMap, verbose, defaultPackage,
-                    namespaceMap);
+                    namespaceMap, allowMultiplePackages);
         }
 
         public Builder outputFile(final File outputFile)
@@ -115,6 +124,12 @@ public class Swift2ThriftGeneratorConfig {
         public Builder namespaceMap(Map<String, String> namespaceMap)
         {
             this.namespaceMap = namespaceMap;
+            return this;
+        }
+
+        public Builder allowMultiplePackages(boolean allowMultiplePackages)
+        {
+            this.allowMultiplePackages = allowMultiplePackages;
             return this;
         }
     }

--- a/swift2thrift-generator-cli/src/main/java/com/facebook/swift/generator/swift2thrift/Main.java
+++ b/swift2thrift-generator-cli/src/main/java/com/facebook/swift/generator/swift2thrift/Main.java
@@ -57,7 +57,8 @@ public class Main
                 .includeMap(mapBuilder.build())
                 .verbose(cliConfig.verbose)
                 .defaultPackage(cliConfig.defaultPackage)
-                .namespaceMap(namespaceMapBuilder.build());
+                .namespaceMap(namespaceMapBuilder.build())
+                .allowMultiplePackages(cliConfig.allowMultiplePackages);
 
         new Swift2ThriftGenerator(configBuilder.build()).parse(cliConfig.inputFiles);
     }

--- a/swift2thrift-generator-cli/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGeneratorCommandLineConfig.java
+++ b/swift2thrift-generator-cli/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGeneratorCommandLineConfig.java
@@ -38,4 +38,11 @@ public class Swift2ThriftGeneratorCommandLineConfig {
 
     @Parameter(names = "-namespace", arity = 2, description = "Namespace for a particular language to include")
     public List<String> namespaceMap;
+
+    @Parameter(names = "-allow_multiple_packages", description =
+        "Allow input classes to reside in different packages. " +
+        "The package of the first specified class will define the generated java.swift namespace. " +
+        "Note that Swift classes generated from the resultant Thrift file will all reside in one package"
+    )
+    public boolean allowMultiplePackages;
 }


### PR DESCRIPTION
This is useful if you want to generate one thrift file from java classes
in different packges.

Usually it's better to generate one thrift file per package, but if one
thrift file is easier to deal with, generating swift files back from it
is not necessary, and the thrift file will only be used to generate code
in other languages where namespacing is not an issue, add an option to
have one thrift file.
