### PR TITLE
Fix generator name mangling with underscored inputs

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
@@ -208,9 +208,13 @@ public class TemplateContextGenerator
                     sb.append(Character.toUpperCase(src.charAt(i)));
                     lowerCase = false;
                 }
-                else {
+                else if (Character.isLowerCase(src.charAt(i))) {
                     sb.append(Character.toUpperCase(src.charAt(i)));
                     lowerCase = true;
+                }
+                else {
+                    // Not a letter (e.g. underscore) just emit it
+                    sb.append(src.charAt(i));
                 }
             }
         }

--- a/swift-generator/src/test/resources/Maestro.thrift
+++ b/swift-generator/src/test/resources/Maestro.thrift
@@ -1,6 +1,7 @@
 include "common/fb303/if/fb303.thrift"
 
 namespace java com.facebook.maestro
+namespace java.swift com.facebook.swift.maestro
 namespace py maestro.Maestro
 namespace py.twisted maestro_twisted.Maestro
 

--- a/swift-generator/src/test/resources/common/fb303/if/fb303.thrift
+++ b/swift-generator/src/test/resources/common/fb303/if/fb303.thrift
@@ -22,6 +22,7 @@
  */
 
 namespace java com.facebook.fb303
+namespace java.swift com.facebook.swift.fb303
 namespace cpp facebook.fb303
 namespace perl Facebook.FB303
 

--- a/swift-generator/src/test/resources/fb303.thrift
+++ b/swift-generator/src/test/resources/fb303.thrift
@@ -22,6 +22,7 @@
  */
 
 namespace java com.facebook.fb303
+namespace java.swift com.facebook.swift.fb303
 namespace cpp facebook.fb303
 namespace perl Facebook.FB303
 
@@ -35,6 +36,7 @@ enum fb_status {
   STOPPING = 3,
   STOPPED = 4,
   WARNING = 5,
+  TEST_VALUE = 6,
 }
 
 /**

--- a/swift-generator/src/test/resources/hive/metastore.thrift
+++ b/swift-generator/src/test/resources/hive/metastore.thrift
@@ -25,6 +25,7 @@
 include "share/fb303/if/fb303.thrift"
 
 namespace java org.apache.hadoop.hive.metastore.api
+namespace java.swift org.apache.swift.hadoop.hive.metastore.api
 namespace php metastore
 namespace cpp Apache.Hadoop.Hive
 

--- a/swift-generator/src/test/resources/share/fb303/if/fb303.thrift
+++ b/swift-generator/src/test/resources/share/fb303/if/fb303.thrift
@@ -22,6 +22,7 @@
  */
 
 namespace java com.facebook.fb303
+namespace java.swift com.facebook.swift.fb303
 namespace cpp facebook.fb303
 namespace perl Facebook.FB303
 


### PR DESCRIPTION
Generator currently mangles names like "UNKNOWN_ERROR" to "UNKNOWN__ERROR" because it treats all non-caps characters as lowercase letters. Fix is to differentiate between lowercase letters and other non-letter characters.
