### PR TITLE
Fix generation of thrift map constants

### DIFF
--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
@@ -32,6 +32,7 @@ options {
     import java.util.HashMap;
     import java.util.List;
     import java.util.Map;
+    import java.util.AbstractMap;
 }
 
 
@@ -137,7 +138,13 @@ const_list returns [List<ConstValue> value = new ArrayList<>()]
     ;
 
 const_map returns [Map<ConstValue, ConstValue> value = new HashMap<>()]
-    : ^(MAP ( ^(ENTRY k=const_value v=const_value) { $value.put($k.value, $v.value); } )*)
+    : ^(MAP ( e=const_map_entry { $value.put($e.value.getKey(), $e.value.getValue()); } )* )
+    ;
+
+const_map_entry returns [Map.Entry<ConstValue, ConstValue> value]
+    : ^(ENTRY k=const_value v=const_value) {
+        $value = new AbstractMap.SimpleImmutableEntry<ConstValue, ConstValue>($k.value, $v.value);
+    }
     ;
 
 enum_fields returns [IntegerEnumFieldList value = new IntegerEnumFieldList()]

--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
@@ -230,10 +230,13 @@ const_list
     : '[' (const_value list_separator?)* ']' -> ^(LIST const_value*)
     ;
 
-const_map
-    : '{' (k=const_value ':' v=const_value list_separator?)* '}' -> ^(MAP ^(ENTRY $k $v)*)
+const_map_entry
+    : k=const_value ':' v=const_value list_separator? -> ^(ENTRY $k $v)
     ;
 
+const_map
+    : '{' const_map_entry* '}' -> ^(MAP const_map_entry*)
+    ;
 
 list_separator
     : COMMA | ';'

--- a/swift-idl-parser/src/test/resources/const.thrift
+++ b/swift-idl-parser/src/test/resources/const.thrift
@@ -1,0 +1,13 @@
+namespace java.swift com.facebook.const_test
+
+const map<string, bool> ABC = {
+ "B": 1,
+ "C": 0,
+ "D": 1,
+}
+
+const list<string> DEF = [
+ "D",
+ "E",
+ "F",
+]


### PR DESCRIPTION
map constants generated from .thrift files only contained the last entry. rearranged the ANTLR rules for parsing map constants in .thrift files to fix this.
