### PR TITLE
Allow extending multiple ThriftServices to compose a service

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -267,7 +267,14 @@ public class Swift2ThriftGenerator
     private boolean verifyService(ThriftServiceMetadata service, boolean quiet)
     {
         boolean ok = true;
-        ThriftServiceMetadata parent = service.getParentService();
+        List<ThriftServiceMetadata> parents = service.getParentServices();
+
+        Preconditions.checkState(
+                parents.size() <= 1,
+                "service " + service.getName() + " extends multiple services (thrift IDL does not support multiple inheritance for services)", service.getName());
+
+        ThriftServiceMetadata parent = parents.size() == 0 ? null : parents.get(0);
+
         if (parent != null && !knownServices.contains(parent)) {
             if (includeMap.containsKey(parent)) {
                 usedIncludedServices.add(parent);


### PR DESCRIPTION
When swift2thrift was implemented, we added a restriction that a @ThriftService class cannot extend multiple @ThriftService classes, ever. This was because if we find this pattern in Swift classes, we cannot generate code for it in Thrift IDL, because that language doesn't support it.

However we only need to disallow swift2thrift codegen for this. We can still allow this pattern in swift, as long as you separate the @ThriftServices you intend to export via swift2thrift into interface classes, and only compose them in an implementation @ThriftService class that you don't intend to export via swift2thrift.
