### PR TITLE
Fix swift-generator handling of list/set/map constant declarations

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/ConstantRenderer.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/ConstantRenderer.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generator;
+
+import com.facebook.swift.parser.model.BaseType;
+import com.facebook.swift.parser.model.Const;
+import com.facebook.swift.parser.model.ConstDouble;
+import com.facebook.swift.parser.model.ConstIdentifier;
+import com.facebook.swift.parser.model.ConstInteger;
+import com.facebook.swift.parser.model.ConstList;
+import com.facebook.swift.parser.model.ConstMap;
+import com.facebook.swift.parser.model.ConstString;
+import com.facebook.swift.parser.model.ConstValue;
+import com.facebook.swift.parser.model.IdentifierType;
+import com.facebook.swift.parser.model.ListType;
+import com.facebook.swift.parser.model.MapType;
+import com.facebook.swift.parser.model.SetType;
+import com.facebook.swift.parser.model.ThriftType;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Shorts;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+
+public class ConstantRenderer
+{
+    private final TypeToJavaConverter typeConverter;
+    private final String defaultNamespace;
+    private final TypeRegistry typeRegistry;
+    private final TypedefRegistry typedefRegistry;
+
+    public ConstantRenderer(
+            TypeToJavaConverter typeConverter,
+            String defaultNamespace,
+            TypeRegistry typeRegistry,
+            TypedefRegistry typedefRegistry)
+    {
+        this.typeConverter = typeConverter;
+        this.defaultNamespace = defaultNamespace;
+        this.typeRegistry = typeRegistry;
+        this.typedefRegistry = typedefRegistry;
+    }
+
+    public String render(Const constant)
+    {
+        return render(constant.getType(), constant.getValue());
+    }
+
+    public String render(ThriftType thriftType, ConstValue value)
+    {
+        if (thriftType instanceof BaseType) {
+            return renderBaseConstant((BaseType) thriftType, value);
+        }
+        else if (thriftType instanceof ListType) {
+            checkArgument(value instanceof ConstList);
+            return renderListConstant((ListType) thriftType, (ConstList) value);
+        }
+        else if (thriftType instanceof MapType) {
+            checkArgument(value instanceof ConstMap);
+            return renderMapType((MapType) thriftType, (ConstMap) value);
+        }
+        else if (thriftType instanceof SetType) {
+            checkArgument(value instanceof ConstList);
+            return renderSetConstant((SetType) thriftType, (ConstList) value);
+        }
+        else if (thriftType instanceof IdentifierType) {
+            String typeName = ((IdentifierType) thriftType).getName();
+            ThriftType resolvedType = typedefRegistry.findType(defaultNamespace, typeName);
+            checkState(resolvedType != null, format("Could not resolve type named '%s'", typeName));
+            return render(resolvedType, value);
+        }
+        else {
+            throw new IllegalStateException("Not yet implemented");
+        }
+    }
+
+    private String renderIdentifierType(IdentifierType identifierType, ConstIdentifier value)
+    {
+        return value.value();
+    }
+
+    private String renderMapType(MapType mapType, ConstMap value)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("ImmutableMap.<");
+        sb.append(typeConverter.convert(mapType.getKeyType(), false));
+        sb.append(", ");
+        sb.append(typeConverter.convert(mapType.getValueType(), false));
+        sb.append(">builder()\n");
+
+        Set<Map.Entry<ConstValue, ConstValue>> entries = value.value().entrySet();
+        for (Map.Entry<ConstValue, ConstValue> entry : entries) {
+            sb.append(format("    .put(%s, %s)\n",
+                             render(mapType.getKeyType(), entry.getKey()),
+                             render(mapType.getValueType(), entry.getValue())));
+        }
+        sb.append("    .build()");
+
+        return sb.toString();
+    }
+
+    private String renderListConstant(ListType listType, ConstList value)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("ImmutableList.<");
+        sb.append(typeConverter.convert(listType.getElementType(), false));
+        sb.append(">builder()\n");
+
+        List<ConstValue> elements = value.value();
+        for (ConstValue element : elements) {
+            sb.append(format("    .add(%s)\n", render(listType.getElementType(), element)));
+        }
+        sb.append("    .build()");
+
+        return sb.toString();
+    }
+
+    private String renderSetConstant(SetType setType, ConstList value)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("ImmutableSet.<");
+        sb.append(typeConverter.convert(setType.getElementType(), false));
+        sb.append(">builder()\n");
+
+        List<ConstValue> elements = value.value();
+        for (ConstValue element : elements) {
+            sb.append(format("    .add(%s)\n", render(setType.getElementType(), element)));
+        }
+        sb.append("    .build()");
+
+        return sb.toString();
+    }
+
+    private String renderBaseConstant(BaseType baseType, ConstValue value)
+    {
+        switch (baseType.getType()) {
+            case I16:
+            case I32:
+            case I64:
+                checkArgument(value instanceof ConstInteger);
+                return renderIntegerConstant(baseType, (ConstInteger) value);
+
+            case STRING:
+                checkArgument(value instanceof ConstString);
+                return "\"" + value.value() + "\"";
+
+            case DOUBLE:
+                checkArgument(value instanceof ConstDouble);
+                return Double.toString((Double) value.value());
+
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private String renderIntegerConstant(BaseType baseType, ConstInteger value)
+    {
+        switch (baseType.getType()) {
+            case I16:
+                return Short.toString(Shorts.checkedCast(value.value()));
+
+            case I32:
+                return Integer.toString(Ints.checkedCast(value.value()));
+
+            case I64:
+                return Long.toString(value.value()) + "L";
+
+            default:
+                throw new IllegalStateException();
+        }
+    }
+}

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftDocumentContext.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftDocumentContext.java
@@ -33,6 +33,7 @@ public class SwiftDocumentContext
     private final TypeRegistry typeRegistry;
     private final TypedefRegistry typedefRegistry;
     private final TypeToJavaConverter typeConverter;
+    private final ConstantRenderer constantRenderer;
     private final URI thriftUri;
 
     public SwiftDocumentContext(final URI thriftUri,
@@ -51,6 +52,7 @@ public class SwiftDocumentContext
                                                      typedefRegistry,
                                                      namespace,
                                                      getJavaPackage());
+        this.constantRenderer = new ConstantRenderer(typeConverter, namespace, typeRegistry, typedefRegistry);
     }
 
     public String getNamespace()
@@ -78,9 +80,14 @@ public class SwiftDocumentContext
         return typeConverter;
     }
 
+    public ConstantRenderer getConstantRenderer()
+    {
+        return constantRenderer;
+    }
+
     public TemplateContextGenerator getTemplateContextGenerator()
     {
-        return new TemplateContextGenerator(generatorConfig, typeRegistry, typeConverter, namespace);
+        return new TemplateContextGenerator(generatorConfig, typeRegistry, typeConverter, constantRenderer, namespace);
     }
 
     public String getJavaPackage()

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftGenerator.java
@@ -143,7 +143,7 @@ public class SwiftGenerator
         String javaPackage = context.getJavaPackage();
 
         // Add a Constants type so that the Constants visitor can render is.
-        typeRegistry.add(new SwiftJavaType(thriftNamespace, "Constants", javaPackage));
+        typeRegistry.add(new SwiftJavaType(thriftNamespace, "Constants", "Constants", javaPackage));
 
         // Make a note that this document is a parent of all the documents included, directly or recursively
         parentDocuments.push(thriftUri);

--- a/swift-generator/src/main/java/com/facebook/swift/generator/SwiftJavaType.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/SwiftJavaType.java
@@ -18,15 +18,19 @@ package com.facebook.swift.generator;
 public class SwiftJavaType
 {
     private final String thriftNamespace;
-    private final String name;
+    private final String javaTypeName;
+    private final String thriftTypeName;
     private final String javaPackageName;
 
-    public SwiftJavaType(final String thriftNamespace,
-                         final String name,
-                         final String javaPackageName)
+    public SwiftJavaType(
+            final String thriftNamespace,
+            final String javaTypeName,
+            final String thriftTypeName,
+            final String javaPackageName)
     {
         this.thriftNamespace = thriftNamespace;
-        this.name = name;
+        this.javaTypeName = javaTypeName;
+        this.thriftTypeName = thriftTypeName;
         this.javaPackageName = javaPackageName;
     }
 
@@ -37,17 +41,17 @@ public class SwiftJavaType
 
     public String getSimpleName()
     {
-        return name;
+        return javaTypeName;
     }
 
     public String getClassName()
     {
-        return javaPackageName + "." + name;
+        return javaPackageName + "." + javaTypeName;
     }
 
     public String getKey()
     {
-        return thriftNamespace + "." + name;
+        return thriftNamespace + "." + thriftTypeName;
     }
 
     @Override
@@ -56,7 +60,7 @@ public class SwiftJavaType
         final int prime = 31;
         int result = 1;
         result = prime * result + ((javaPackageName == null) ? 0 : javaPackageName.hashCode());
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((javaTypeName == null) ? 0 : javaTypeName.hashCode());
         result = prime * result + ((thriftNamespace == null) ? 0 : thriftNamespace.hashCode());
         return result;
     }
@@ -82,12 +86,12 @@ public class SwiftJavaType
         else if (!javaPackageName.equals(other.javaPackageName)) {
             return false;
         }
-        if (name == null) {
-            if (other.name != null) {
+        if (javaTypeName == null) {
+            if (other.javaTypeName != null) {
                 return false;
             }
         }
-        else if (!name.equals(other.name)) {
+        else if (!javaTypeName.equals(other.javaTypeName)) {
             return false;
         }
         if (thriftNamespace == null) {
@@ -104,6 +108,9 @@ public class SwiftJavaType
     @Override
     public String toString()
     {
-        return "[thrift namespace=" + thriftNamespace + ", name=" + name + ", java package=" + javaPackageName + "]";
+        return "[thrift namespace=" + thriftNamespace +
+               ", javaTypeName=" + javaTypeName +
+               ", thriftTypeName=" + thriftTypeName +
+               ", java package=" + javaPackageName + "]";
     }
 }

--- a/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/TypeToJavaConverter.java
@@ -177,10 +177,10 @@ public class TypeToJavaConverter
                 thriftNamespace = names.get(0);
             }
 
-            final String javatypeName = thriftNamespace + "." + TemplateContextGenerator.mangleJavatypeName(thriftName);
-            final ThriftType thriftType = typedefRegistry.findType(javatypeName);
+            final String thriftTypeName = thriftNamespace + "." + thriftName;
+            final ThriftType thriftType = typedefRegistry.findType(thriftTypeName);
             if (thriftType == null) {
-                final SwiftJavaType javaType = typeRegistry.findType(javatypeName);
+                final SwiftJavaType javaType = typeRegistry.findType(thriftTypeName);
                 return (javaType == null) ? null : shortenClassName(javaType.getClassName());
             }
             else {
@@ -212,7 +212,7 @@ public class TypeToJavaConverter
         {
             final SetType setType = SetType.class.cast(type);
 
-            final String actualType = TypeToJavaConverter.this.convert(setType.getType(), false);
+            final String actualType = TypeToJavaConverter.this.convert(setType.getElementType(), false);
 
             return "Set<" + actualType + ">";
         }
@@ -231,7 +231,7 @@ public class TypeToJavaConverter
         {
             final ListType listType = ListType.class.cast(type);
 
-            final String actualType = TypeToJavaConverter.this.convert(listType.getType(), false);
+            final String actualType = TypeToJavaConverter.this.convert(listType.getElementType(), false);
 
             return "List<" + actualType + ">";
         }

--- a/swift-generator/src/main/java/com/facebook/swift/generator/TypedefRegistry.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/TypedefRegistry.java
@@ -50,6 +50,15 @@ public class TypedefRegistry implements Iterable<Map.Entry<String, ThriftType>>
         registry.put(key, thriftType);
     }
 
+    public ThriftType findType(final String defaultNamespace, final String typeName)
+    {
+        String key = typeName;
+        if (!key.contains(".")) {
+            key = defaultNamespace + "." + typeName;
+        }
+        return findType(key);
+    }
+
     public ThriftType findType(final String key)
     {
         return registry.get(key);

--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.swift.generator.template;
 
+import com.facebook.swift.generator.ConstantRenderer;
 import com.facebook.swift.generator.SwiftGeneratorConfig;
 import com.facebook.swift.generator.SwiftGeneratorTweak;
 import com.facebook.swift.generator.SwiftJavaType;
@@ -31,7 +32,6 @@ import com.facebook.swift.parser.model.ThriftMethod;
 import com.google.common.base.Preconditions;
 
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 
 import static com.facebook.swift.generator.util.SwiftInternalStringUtils.isBlank;
@@ -45,22 +45,26 @@ public class TemplateContextGenerator
     private final TypeRegistry typeRegistry;
     private final TypeToJavaConverter typeConverter;
     private final String defaultNamespace;
+    private final ConstantRenderer constantRenderer;
 
-    public TemplateContextGenerator(final SwiftGeneratorConfig generatorConfig,
-                                    final TypeRegistry typeRegistry,
-                                    final TypeToJavaConverter typeConverter,
-                                    final String defaultNamespace)
+    public TemplateContextGenerator(
+            final SwiftGeneratorConfig generatorConfig,
+            final TypeRegistry typeRegistry,
+            final TypeToJavaConverter typeConverter,
+            final ConstantRenderer constantRenderer,
+            final String defaultNamespace)
     {
         this.generatorConfig = generatorConfig;
         this.typeRegistry = typeRegistry;
         this.defaultNamespace = defaultNamespace;
+        this.constantRenderer = constantRenderer;
         this.typeConverter = typeConverter;
     }
 
     public ServiceContext serviceFromThrift(final Service service)
     {
         final String name = mangleJavatypeName(service.getName());
-        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, name);
+        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, service.getName());
         final SwiftJavaType parentType = typeRegistry.findType(defaultNamespace, service.getParent().orNull());
 
         final Set<String> javaParents = new HashSet<>();
@@ -83,10 +87,10 @@ public class TemplateContextGenerator
 
     public StructContext structFromThrift(final AbstractStruct struct)
     {
-        final String name = mangleJavatypeName(struct.getName());
-        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, name);
+        final String thriftTypeName = struct.getName();
+        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, thriftTypeName);
 
-        return new StructContext(name,
+        return new StructContext(thriftTypeName,
                                  javaType.getPackage(),
                                  javaType.getSimpleName());
     }
@@ -114,10 +118,10 @@ public class TemplateContextGenerator
 
     public ConstantsContext constantsFromThrift()
     {
-        final String name = mangleJavatypeName("Constants");
-        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, name);
+        final String thriftTypeName = "Constants";
+        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, thriftTypeName);
 
-        return new ConstantsContext(name,
+        return new ConstantsContext(thriftTypeName,
                                     javaType.getPackage(),
                                     javaType.getSimpleName());
     }
@@ -127,7 +131,7 @@ public class TemplateContextGenerator
         return new ConstantContext(constant.getName(),
                                    typeConverter.convertType(constant.getType()),
                                    constant.getName(),
-                                   constant.getValue().render());
+                                   constantRenderer.render(constant));
     }
 
     public ExceptionContext exceptionFromThrift(final ThriftField field)
@@ -138,15 +142,15 @@ public class TemplateContextGenerator
 
     public EnumContext enumFromThrift(final IntegerEnum integerEnum)
     {
-        final String name = mangleJavatypeName(integerEnum.getName());
-        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, name);
+        final String thriftTypeName = integerEnum.getName();
+        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, thriftTypeName);
         return new EnumContext(javaType.getPackage(), javaType.getSimpleName());
     }
 
     public EnumContext enumFromThrift(final StringEnum stringEnum)
     {
-        final String name = mangleJavatypeName(stringEnum.getName());
-        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, name);
+        final String thriftTypeName = stringEnum.getName();
+        final SwiftJavaType javaType = typeRegistry.findType(defaultNamespace, thriftTypeName);
         return new EnumContext(javaType.getPackage(), javaType.getSimpleName());
     }
 

--- a/swift-generator/src/main/java/com/facebook/swift/generator/visitors/TypeVisitor.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/visitors/TypeVisitor.java
@@ -50,8 +50,11 @@ public class TypeVisitor implements DocumentVisitor
     public void visit(final Visitable visitable)
     {
         final Nameable type = Nameable.class.cast(visitable);
-        final SwiftJavaType swiftJavaType = new SwiftJavaType(documentContext.getNamespace(),
-                                                              TemplateContextGenerator.mangleJavatypeName(type.getName()), javaNamespace);
+        final SwiftJavaType swiftJavaType = new SwiftJavaType(
+                documentContext.getNamespace(),
+                TemplateContextGenerator.mangleJavatypeName(type.getName()),
+                type.getName(),
+                javaNamespace);
         if (visitable instanceof Typedef) {
             // Typedef checks must be done before the type is added to the registry. Otherwise it would be possible
             // to have a typedef point at itself.

--- a/swift-generator/src/test/resources/ConstantsDemo.thrift
+++ b/swift-generator/src/test/resources/ConstantsDemo.thrift
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-namespace cpp yozone
+namespace java.swift swift.test.constants_demo
 
 struct thing {
   1: i32 hello,
@@ -37,9 +37,15 @@ struct thing2 {
 typedef i32 myIntType
 const myIntType myInt = 3
 
-const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
+//const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
 
 const i32 hex_const = 0x0001F
+
+const i32 oct_const = 0700
+
+const i32 int_const_single_d = 9
+const i32 int_const_multi_d = 1000
+const i32 int_const_zero = 0
 
 const i32 GEN_ME = -3523553
 const double GEn_DUB = 325.532
@@ -51,11 +57,11 @@ const list<i32> GEN_LIST = [ 235235, 23598352, 3253523 ]
 
 const map<i32, map<i32, i32>> GEN_MAPMAP = { 235 : { 532 : 53255, 235:235}}
 
-const map<string,i32> GEN_MAP2 = { "hello" : 233, "lkj98d" : 853, 'lkjsdf' : 098325 }
+const map<string,i32> GEN_MAP2 = { "hello" : 233, "lkj98d" : 853, 'lkjsdf' : 98325 }
 
-const thing GEN_THING = { 'hello' : 325, 'goodbye' : 325352 }
-
-const map<i32,thing> GEN_WHAT = { 35 : { 'hello' : 325, 'goodbye' : 325352 } }
+// swift-generator doesn't support struct constants yet
+//const thing GEN_THING = { 'hello' : 325, 'goodbye' : 325352 }
+//const map<i32,thing> GEN_WHAT = { 35 : { 'hello' : 325, 'goodbye' : 325352 } }
 
 const set<i32> GEN_SET = [ 235, 235, 53235 ]
 

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstDouble.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstDouble.java
@@ -28,12 +28,6 @@ public class ConstDouble
     }
 
     @Override
-    public String render()
-    {
-        return Double.toString(value);
-    }
-
-    @Override
     public Double value()
     {
         return value;

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstIdentifier.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstIdentifier.java
@@ -30,13 +30,6 @@ public class ConstIdentifier
     }
 
     @Override
-    public String render()
-    {
-        return value;
-    }
-
-
-    @Override
     public String value()
     {
         return value;

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstInteger.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstInteger.java
@@ -34,13 +34,6 @@ public class ConstInteger
     }
 
     @Override
-    public String render()
-    {
-        return Long.toString(value) + "L";
-    }
-
-
-    @Override
     public String toString()
     {
         return Objects.toStringHelper(this)

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstList.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstList.java
@@ -41,17 +41,6 @@ public class ConstList
     }
 
     @Override
-    public String render()
-    {
-        StringBuilder sb = new StringBuilder(format("ImmutableList.builder()\n"));
-        for (ConstValue value : values) {
-            sb.append(format("    .add(%s)\n", value.render()));
-        }
-        return sb.append("    .build();\n").toString();
-    }
-
-
-    @Override
     public String toString()
     {
         return Objects.toStringHelper(this)

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstMap.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstMap.java
@@ -41,17 +41,6 @@ public class ConstMap
     }
 
     @Override
-    public String render()
-    {
-        StringBuilder sb = new StringBuilder(format("ImmutableMap.builder()\n"));
-        for (Map.Entry<ConstValue, ConstValue> entry : values.entrySet()) {
-            sb.append(format("    .put(%s, %s)\n", entry.getKey().render(), entry.getValue().render()));
-        }
-        return sb.append("    .build();\n").toString();
-    }
-
-
-    @Override
     public String toString()
     {
         return Objects.toStringHelper(this)

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstString.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstString.java
@@ -30,12 +30,6 @@ public class ConstString
     }
 
     @Override
-    public String render()
-    {
-        return "\"" + value + "\"";
-    }
-
-    @Override
     public String value()
     {
         return value;

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstValue.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ConstValue.java
@@ -19,8 +19,6 @@ public abstract class ConstValue
 {
     public abstract Object value();
 
-    public abstract String render();
-
     @Override
     public abstract String toString();
 }

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ListType.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ListType.java
@@ -32,7 +32,7 @@ public class ListType
         this.type = checkNotNull(type, "type");
     }
 
-    public ThriftType getType()
+    public ThriftType getElementType()
     {
         return type;
     }

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/SetType.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/SetType.java
@@ -32,7 +32,7 @@ public class SetType
         this.type = checkNotNull(type, "type");
     }
 
-    public ThriftType getType()
+    public ThriftType getElementType()
     {
         return type;
     }


### PR DESCRIPTION
Fixes bugs in generation of constant values for lists, sets, and maps.

Unfortunately, some things are still NYI, such as handling constant values for structs and enums (or containers where this is a key, value, or element type of the container). I'll have to get to those later.
