### PR TITLE
add builder for immutable interface

### DIFF
--- a/swift-generator/src/main/resources/templates/java/immutable.st
+++ b/swift-generator/src/main/resources/templates/java/immutable.st
@@ -1,6 +1,8 @@
 _structbody(context) ::= <<
 <_constructor(context)>
 
+<_builder(context)>
+
 <context.fields : { field |<_field(field)>}; separator="\n\n">
 >>
 
@@ -20,6 +22,36 @@ public <element.javaName><_params(element.fields)> {
 
 _ctorAssignment(field) ::= <<
 this.<field.javaName> = <field.javaName>;
+>>
+
+_builder(element) ::= <<
+public static class Builder {
+    <element.fields: {field|<_builder_field(field)>}; separator="\n">
+
+    public Builder() { }
+    public Builder(<element.javaName> other) {
+        <element.fields: {field|<_builderInitAssignment(field)>}; separator="\n">
+    }
+
+    public <element.javaName> build() {
+        return new <element.javaName> (
+            <element.fields: {field|this.<field.javaName>}; separator=",\n">
+        );
+    }
+}
+>>
+
+_builderInitAssignment(field) ::= <<
+this.<field.javaName> = other.<field.javaName>;
+>>
+
+_builder_field(field) ::= <<
+private <field.javaType> <field.javaName>;
+
+public Builder <field.javaSetterName>(<field.javaType> <field.javaName>) {
+    this.<field.javaName> = <field.javaName>;
+    return this;
+}
 >>
 
 _union_ctor(context, field) ::= <<


### PR DESCRIPTION
Summary: add builder for immutable interface. Otherwise I need either to use bean like setter/getter. 

Test Plan: generated interface
