### PR TITLE
Upgrade to guava 16.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <dep.antlr.version>3.5</dep.antlr.version>
     <dep.maven-api.version>2.2.1</dep.maven-api.version>
     <dep.fb.nifty.version>0.12.0-SNAPSHOT</dep.fb.nifty.version>
+    <dep.guava.version>16.0.1</dep.guava.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This fixes a swift bug that is caused by a guava incompatibility with newer builds of the JDK (bug is not present in 7u45, and is present in 7u51, appeared somewhere in between)
