### PR TITLE
Optional and required field handling

### DIFF
--- a/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftField.java
+++ b/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftField.java
@@ -36,5 +36,49 @@ public @interface ThriftField
 
     String name() default "";
 
-    boolean required() default false;
+    Requiredness requiredness() default Requiredness.UNSPECIFIED;
+
+    /**
+     * Indicates the behavior for a field when a value is not received, or when the value
+     * of the field is not set when sending.
+     */
+    public static enum Requiredness
+    {
+        /**
+         * This is the default (unset) value for {@link ThriftField#requiredness()}. It will not
+         * conflict with other explicit settings of {@link #NONE}, {@link #REQUIRED}, or {@link
+         * #OPTIONAL}. If all of the {@link com.facebook.swift.codec.ThriftField} annotations for
+         * a field are left {@link #UNSPECIFIED}, it will default to {@link #NONE}.
+         */
+        UNSPECIFIED,
+        /**
+         * This behavior is equivalent to leaving out 'optional' and 'required' in thrift IDL
+         * syntax. However, despite the name, this actually does correspond to defined behavior so
+         * if this value is explicitly specified in any annotations, it will conflict with other
+         * annotations that specify either {@link #OPTIONAL} or {@link #REQUIRED} for the same
+         * field.
+         *
+         * The serialization behavior is that {@code null} values will be serialized, but
+         * if the field is non-nullable (i.e. it's type is primitive) it will be serialized, even
+         * if the field was not explicitly set.
+         *
+         * The deserialization behavior is similar: When no value is read, the field will be set
+         * to {@code null} if the type of the field is nullable, but for primitive types the
+         * field will be left untouched (so it will hold the default value for the type).
+         */
+        NONE,
+        /**
+         * This behavior indicates that the field will always be serialized (and it is an error if the
+         * value is {@code null}), and must always be deserialized (and it is an error if a value
+         * is not read).
+         */
+        REQUIRED,
+        /**
+         * This behavior indicates that it is always ok if the field is {@code null} when serializing,
+         * and that it is always ok to not read a value (and the field will be set to {@code null}
+         * when this happens). As such, primitive types should be replaced with boxed types, so that
+         * null is always a possibility.
+         */
+        OPTIONAL
+    }
 }

--- a/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftField.java
+++ b/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftField.java
@@ -58,7 +58,7 @@ public @interface ThriftField
          * annotations that specify either {@link #OPTIONAL} or {@link #REQUIRED} for the same
          * field.
          *
-         * The serialization behavior is that {@code null} values will be serialized, but
+         * The serialization behavior is that {@code null} values will not be serialized, but
          * if the field is non-nullable (i.e. it's type is primitive) it will be serialized, even
          * if the field was not explicitly set.
          *

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import static com.facebook.swift.codec.ThriftField.Requiredness;
 import static com.facebook.swift.codec.metadata.FieldMetadata.extractThriftFieldName;
 import static com.facebook.swift.codec.metadata.FieldMetadata.getOrExtractThriftFieldName;
 import static com.facebook.swift.codec.metadata.FieldMetadata.getThriftFieldId;
@@ -408,7 +409,7 @@ public abstract class AbstractThriftMetadataBuilder
                     if (!annotation.name().isEmpty()) {
                         metadataErrors.addError("A method with annotated parameters can not have a field name specified: %s.%s ", clazz.getName(), method.getName());
                     }
-                    if (annotation.required()) {
+                    if (annotation.requiredness() == Requiredness.REQUIRED) {
                         metadataErrors.addError("A method with annotated parameters can not be marked as required: %s.%s ", clazz.getName(), method.getName());
                     }
                 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -150,12 +150,12 @@ public abstract class AbstractThriftMetadataBuilder
         }
 
         if (!(structType instanceof ParameterizedType)) {
-            metadataErrors.addError("Builder class [%s] may only be generic if the type it builds ([%s]) is also generic", builderClass.getName(), getStructClass().getName());
+            metadataErrors.addError("Builder class '%s' may only be generic if the type it builds ('%s') is also generic", builderClass.getName(), getStructClass().getName());
             return builderClass;
         }
 
         if (builderClass.getTypeParameters().length != getStructClass().getTypeParameters().length) {
-            metadataErrors.addError("Generic builder class [%s] must have the same number of type parameters as the type it builds ([%s])", builderClass.getName(), getStructClass().getName());
+            metadataErrors.addError("Generic builder class '%s' must have the same number of type parameters as the type it builds ('%s')", builderClass.getName(), getStructClass().getName());
             return builderClass;
         }
 
@@ -169,14 +169,14 @@ public abstract class AbstractThriftMetadataBuilder
     {
         // Verify struct class is public and not abstract
         if (Modifier.isAbstract(getStructClass().getModifiers())) {
-            metadataErrors.addError("%s class [%s] is abstract", annotation.getSimpleName(), getStructClass().getName());
+            metadataErrors.addError("%s class '%s' is abstract", annotation.getSimpleName(), getStructClass().getName());
         }
         if (!Modifier.isPublic(getStructClass().getModifiers())) {
-            metadataErrors.addError("%s class [%s] is not public", annotation.getSimpleName(), getStructClass().getName());
+            metadataErrors.addError("%s class '%s' is not public", annotation.getSimpleName(), getStructClass().getName());
         }
 
         if (!getStructClass().isAnnotationPresent(annotation)) {
-            metadataErrors.addError("%s class [%s] does not have a @%s annotation", getStructClass().getName(), annotation.getSimpleName());
+            metadataErrors.addError("%s class '%s' does not have a @%s annotation", getStructClass().getName(), annotation.getSimpleName());
         }
     }
 
@@ -196,7 +196,7 @@ public abstract class AbstractThriftMetadataBuilder
             // verify struct class does not have @ThriftConstructors
             for (Constructor<?> constructor : getStructClass().getConstructors()) {
                 if (constructor.isAnnotationPresent(ThriftConstructor.class)) {
-                    metadataErrors.addWarning("Thrift class [%s] has a builder class, but constructor %s annotated with @ThriftConstructor", getStructClass().getName(), constructor);
+                    metadataErrors.addWarning("Thrift class '%s' has a builder class, but constructor '%s' annotated with @ThriftConstructor", getStructClass().getName(), constructor);
                 }
             }
         }
@@ -215,7 +215,7 @@ public abstract class AbstractThriftMetadataBuilder
             }
 
             if (!Modifier.isPublic(constructor.getModifiers())) {
-                metadataErrors.addError("@ThriftConstructor [%s] is not public", constructor.toGenericString());
+                metadataErrors.addError("@ThriftConstructor '%s' is not public", constructor.toGenericString());
                 continue;
             }
 
@@ -235,12 +235,12 @@ public abstract class AbstractThriftMetadataBuilder
             try {
                 Constructor<?> constructor = clazz.getDeclaredConstructor();
                 if (!Modifier.isPublic(constructor.getModifiers())) {
-                    metadataErrors.addError("Default constructor [%s] is not public", constructor.toGenericString());
+                    metadataErrors.addError("Default constructor '%s' is not public", constructor.toGenericString());
                 }
                 constructorInjections.add(new ConstructorInjection(constructor));
             }
             catch (NoSuchMethodException e) {
-                metadataErrors.addError("Struct class [%s] does not have a public no-arg constructor", clazz.getName());
+                metadataErrors.addError("Struct class '%s' does not have a public no-arg constructor", clazz.getName());
             }
         }
 
@@ -264,7 +264,7 @@ public abstract class AbstractThriftMetadataBuilder
 
             if (!getStructClass().isAssignableFrom(method.getReturnType())) {
                 metadataErrors.addError(
-                        "[%s] says that [%s] is its builder class, but @ThriftConstructor method [%s] in the builder does not build an instance assignable to that type",
+                        "'%s' says that '%s' is its builder class, but @ThriftConstructor method '%s' in the builder does not build an instance assignable to that type",
                         structType,
                         builderType,
                         method.getName());
@@ -275,16 +275,16 @@ public abstract class AbstractThriftMetadataBuilder
         for (Method method : getAllDeclaredMethods(getBuilderClass())) {
             if (method.isAnnotationPresent(ThriftConstructor.class) || hasThriftFieldAnnotation(method)) {
                 if (!Modifier.isPublic(method.getModifiers())) {
-                    metadataErrors.addError("@ThriftConstructor method [%s] is not public", method.toGenericString());
+                    metadataErrors.addError("@ThriftConstructor method '%s' is not public", method.toGenericString());
                 }
                 if (Modifier.isStatic(method.getModifiers())) {
-                    metadataErrors.addError("@ThriftConstructor method [%s] is static", method.toGenericString());
+                    metadataErrors.addError("@ThriftConstructor method '%s' is static", method.toGenericString());
                 }
             }
         }
 
         if (builderMethodInjections.isEmpty()) {
-            metadataErrors.addError("Struct builder class [%s] does not have a public builder method annotated with @ThriftConstructor", getBuilderClass().getName());
+            metadataErrors.addError("Struct builder class '%s' does not have a public builder method annotated with @ThriftConstructor", getBuilderClass().getName());
         }
         if (builderMethodInjections.size() > 1) {
             metadataErrors.addError("Multiple builder methods are annotated with @ThriftConstructor ", builderMethodInjections);
@@ -315,10 +315,10 @@ public abstract class AbstractThriftMetadataBuilder
         for (Field field : getAllDeclaredFields(clazz)) {
             if (field.isAnnotationPresent(ThriftField.class)) {
                 if (!Modifier.isPublic(field.getModifiers())) {
-                    metadataErrors.addError("@ThriftField field [%s] is not public", field.toGenericString());
+                    metadataErrors.addError("@ThriftField field '%s' is not public", field.toGenericString());
                 }
                 if (Modifier.isStatic(field.getModifiers())) {
-                    metadataErrors.addError("@ThriftField field [%s] is static", field.toGenericString());
+                    metadataErrors.addError("@ThriftField field '%s' is static", field.toGenericString());
                 }
             }
         }
@@ -367,10 +367,10 @@ public abstract class AbstractThriftMetadataBuilder
         for (Method method : getAllDeclaredMethods(clazz)) {
             if (method.isAnnotationPresent(ThriftField.class) || hasThriftFieldAnnotation(method)) {
                 if (!Modifier.isPublic(method.getModifiers())) {
-                    metadataErrors.addError("@ThriftField method [%s] is not public", method.toGenericString());
+                    metadataErrors.addError("@ThriftField method '%s' is not public", method.toGenericString());
                 }
                 if (Modifier.isStatic(method.getModifiers())) {
-                    metadataErrors.addError("@ThriftField method [%s] is static", method.toGenericString());
+                    metadataErrors.addError("@ThriftField method '%s' is static", method.toGenericString());
                 }
             }
         }
@@ -489,11 +489,12 @@ public abstract class AbstractThriftMetadataBuilder
                 for (String fieldName : newTreeSet(transform(fields, getOrExtractThriftFieldName()))) {
                     // only report errors for fields that don't have conflicting ids
                     if (!fieldsWithConflictingIds.contains(fieldName)) {
-                        metadataErrors.addError("Thrift class %s fields %s do not have an id", structName, newTreeSet(transform(fields, getOrExtractThriftFieldName())));
+                        metadataErrors.addError("Thrift class '%s' fields %s do not have an id", structName, newTreeSet(transform(fields, getOrExtractThriftFieldName())));
                     }
                 }
                 continue;
             }
+
             short fieldId = entry.getKey().get();
 
             // assure all fields for this ID have the same name
@@ -548,7 +549,7 @@ public abstract class AbstractThriftMetadataBuilder
             if (ids.size() > 1) {
                 String fieldName = entry.getKey();
                 if (!fieldsWithConflictingIds.contains(fieldName)) {
-                    metadataErrors.addError("Thrift class '%s' field '%s' has multiple ids: %s", structName, fieldName, ids);
+                    metadataErrors.addError("Thrift class '%s' field '%s' has multiple ids: %s", structName, fieldName, ids.toString());
                     fieldsWithConflictingIds.add(fieldName);
                 }
                 continue;
@@ -593,7 +594,7 @@ public abstract class AbstractThriftMetadataBuilder
         boolean isSupportedType = true;
         for (FieldMetadata field : fields) {
             if (!catalog.isSupportedStructFieldType(field.getJavaType())) {
-                metadataErrors.addError("Thrift class %s field %s(%s) type %s is not a supported Java type", structName, name, id, TypeToken.of(field.getJavaType()));
+                metadataErrors.addError("Thrift class '%s' field '%s(%s)' type '%s' is not a supported Java type", structName, name, id, TypeToken.of(field.getJavaType()));
                 isSupportedType = false;
                 // only report the error once
                 break;
@@ -607,7 +608,7 @@ public abstract class AbstractThriftMetadataBuilder
                 types.add(catalog.getThriftType(field.getJavaType()));
             }
             if (types.size() > 1) {
-                metadataErrors.addWarning("Thrift class %s field %s(%s) has multiple types %s", structName, name, id, types);
+                metadataErrors.addWarning("Thrift class '%s' field '%s(%s)' has multiple types: %s", structName, name, id, types);
             }
         }
     }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -19,6 +19,7 @@ import com.facebook.swift.codec.ThriftConstructor;
 import com.facebook.swift.codec.ThriftField;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -29,6 +30,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.internal.MoreTypes;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.lang.annotation.Annotation;
@@ -50,6 +52,7 @@ import static com.facebook.swift.codec.metadata.FieldMetadata.getOrExtractThrift
 import static com.facebook.swift.codec.metadata.FieldMetadata.getThriftFieldId;
 import static com.facebook.swift.codec.metadata.FieldMetadata.getThriftFieldName;
 import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
+import static com.facebook.swift.codec.metadata.FieldMetadata.*;
 import static com.facebook.swift.codec.metadata.ReflectionHelper.extractParameterNames;
 import static com.facebook.swift.codec.metadata.ReflectionHelper.findAnnotatedMethods;
 import static com.facebook.swift.codec.metadata.ReflectionHelper.getAllDeclaredFields;
@@ -503,6 +506,11 @@ public abstract class AbstractThriftMetadataBuilder
                 field.setName(fieldName);
             }
 
+            Requiredness requiredness = extractFieldRequiredness(fieldId, fieldName, fields);
+            for (FieldMetadata field : fields) {
+                field.setRequiredness(requiredness);
+            }
+
             // verify fields have a supported java type and all fields
             // for this ID have the same thrift type
             verifyFieldType(fieldId, fieldName, fields, catalog);
@@ -583,6 +591,34 @@ public abstract class AbstractThriftMetadataBuilder
             name = Iterables.find(transform(fields, extractThriftFieldName()), notNull());
         }
         return name;
+    }
+
+    protected final Requiredness extractFieldRequiredness(short fieldId, String fieldName, Collection<FieldMetadata> fields)
+    {
+        Predicate<Requiredness> specificRequiredness = new Predicate<Requiredness>()
+        {
+            @Override
+            public boolean apply(@Nullable Requiredness input)
+            {
+                return (input != null) && (input != Requiredness.UNSPECIFIED);
+            }
+        };
+
+        Set<Requiredness> requirednessValues = ImmutableSet.copyOf(filter(transform(fields, getThriftFieldRequiredness()), specificRequiredness));
+
+        if (requirednessValues.size() > 1) {
+            metadataErrors.addError("Thrift class '%s' field '%s(%d)' has multiple requiredness values: %s", structName, fieldName, fieldId, requirednessValues.toString());
+        }
+
+        Requiredness resolvedRequiredness;
+        if (requirednessValues.isEmpty()) {
+            resolvedRequiredness = Requiredness.NONE;
+        }
+        else {
+            resolvedRequiredness = requirednessValues.iterator().next();
+        }
+
+        return resolvedRequiredness;
     }
 
     /**

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -500,7 +500,7 @@ public abstract class AbstractThriftMetadataBuilder
 
             short fieldId = entry.getKey().get();
 
-            // assure all fields for this ID have the same name
+            // ensure all fields for this ID have the same name
             String fieldName = extractFieldName(fieldId, fields);
             for (FieldMetadata field : fields) {
                 field.setName(fieldName);
@@ -577,19 +577,33 @@ public abstract class AbstractThriftMetadataBuilder
     protected final String extractFieldName(short id, Collection<FieldMetadata> fields)
     {
         // get the names used by these fields
+
+        // Field names specified in the 'name' field of the @ThriftField annotations (if any) should all match
         Set<String> names = ImmutableSet.copyOf(filter(transform(fields, getThriftFieldName()), notNull()));
+        if (names.size() > 1) {
+            metadataErrors.addError("Thrift class '%s' field '%d' has multiple names: %s", structName, id, names.toString());
+        }
+
+        // Field names extracted from the names of the fields, methods, or parameters should also all match
+        Set<String> extractedNames = ImmutableSet.copyOf(filter(transform(fields, extractThriftFieldName()), notNull()));
+        if (extractedNames.size() > 1) {
+            metadataErrors.addError("Thrift class '%s' field '%d' has multiple names: %s", structName, id, extractedNames.toString());
+        }
 
         String name;
         if (!names.isEmpty()) {
-            if (names.size() > 1) {
-                metadataErrors.addWarning("Thrift class %s field %s has multiple names %s", structName, id, names);
-            }
+            // If there is an override name available, use that
             name = names.iterator().next();
         }
-        else {
-            // pick a name for this field
-            name = Iterables.find(transform(fields, extractThriftFieldName()), notNull());
+        else if (!extractedNames.isEmpty()) {
+            // Otherwise use the extracted name
+            name = extractedNames.iterator().next();
         }
+        else {
+            metadataErrors.addError("Thrift class '%s' field '%d' has no names available", structName, id);
+            name = null;
+        }
+
         return name;
     }
 

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -608,7 +608,7 @@ public abstract class AbstractThriftMetadataBuilder
                 types.add(catalog.getThriftType(field.getJavaType()));
             }
             if (types.size() > 1) {
-                metadataErrors.addWarning("Thrift class '%s' field '%s(%s)' has multiple types: %s", structName, name, id, types);
+                metadataErrors.addError("Thrift class '%s' field '%s(%s)' has multiple types: %s", structName, name, id, types);
             }
         }
     }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/FieldMetadata.java
@@ -19,15 +19,20 @@ import com.facebook.swift.codec.ThriftField;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
+import com.google.inject.internal.asm.$AnnotationVisitor;
 
 import javax.annotation.Nullable;
 
 import java.lang.reflect.Type;
 
+import static com.facebook.swift.codec.ThriftField.Requiredness;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 abstract class FieldMetadata
 {
     private Short id;
     private String name;
+    private Requiredness requiredness;
     private final FieldKind type;
 
     protected FieldMetadata(ThriftField annotation, FieldKind type)
@@ -43,6 +48,7 @@ abstract class FieldMetadata
                     if (!annotation.name().isEmpty()) {
                         name = annotation.name();
                     }
+                    requiredness = checkNotNull(annotation.requiredness());
                 }
                 break;
             case THRIFT_UNION_ID:
@@ -151,6 +157,19 @@ abstract class FieldMetadata
         };
     }
 
+    static <T extends FieldMetadata> Function<T, Requiredness> getThriftFieldRequiredness()
+    {
+        return new Function<T, Requiredness>()
+        {
+            @Nullable
+            @Override
+            public Requiredness apply(@Nullable T input)
+            {
+                return input.getRequiredness();
+            }
+        };
+    }
+
     public static Predicate<FieldMetadata> isType(final FieldKind type)
     {
         return new Predicate<FieldMetadata>() {
@@ -160,5 +179,15 @@ abstract class FieldMetadata
                 return fieldMetadata.getType() == type;
             }
         };
+    }
+
+    public Requiredness getRequiredness()
+    {
+        return requiredness;
+    }
+
+    public void setRequiredness(Requiredness requiredness)
+    {
+        this.requiredness = requiredness;
     }
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.swift.codec.metadata;
 
+import com.facebook.swift.codec.ThriftField;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
@@ -25,6 +26,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Objects;
 
+import static com.facebook.swift.codec.ThriftField.Requiredness;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -45,9 +47,11 @@ public class ThriftFieldMetadata
     private final Optional<ThriftExtraction> extraction;
     private final Optional<TypeCoercion> coercion;
     private final ImmutableList<String> documentation;
+    private final Requiredness requiredness;
 
     public ThriftFieldMetadata(
             short id,
+            Requiredness requiredness,
             ThriftType thriftType,
             String name,
             FieldKind fieldKind,
@@ -58,6 +62,7 @@ public class ThriftFieldMetadata
             Optional<TypeCoercion> coercion
     )
     {
+        this.requiredness = requiredness;
         this.thriftType= checkNotNull(thriftType, "thriftType is null");
         this.fieldKind = checkNotNull(fieldKind, "type is null");
         this.name = checkNotNull(name, "name is null");
@@ -110,6 +115,8 @@ public class ThriftFieldMetadata
     {
         return thriftType;
     }
+
+    public Requiredness getRequiredness() { return requiredness; }
 
     public String getName()
     {

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 
+import static com.facebook.swift.codec.ThriftField.Requiredness;
 import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
 
 @NotThreadSafe
@@ -139,6 +140,7 @@ public class ThriftStructMetadataBuilder
     {
         short id = -1;
         String name = null;
+        Requiredness requiredness = Requiredness.UNSPECIFIED;
         ThriftType type = null;
 
         // process field injections and extractions
@@ -147,6 +149,7 @@ public class ThriftStructMetadataBuilder
         for (FieldMetadata fieldMetadata : input) {
             id = fieldMetadata.getId();
             name = fieldMetadata.getName();
+            requiredness = fieldMetadata.getRequiredness();
             type = catalog.getThriftType(fieldMetadata.getJavaType());
 
             if (fieldMetadata instanceof FieldInjection) {
@@ -180,6 +183,7 @@ public class ThriftStructMetadataBuilder
 
         ThriftFieldMetadata thriftFieldMetadata = new ThriftFieldMetadata(
                 id,
+                requiredness,
                 type,
                 name,
                 THRIFT_FIELD,

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
@@ -215,6 +215,20 @@ public class ThriftUnionMetadataBuilder
             fieldType = fieldMetadata.getType();
             thriftType = catalog.getThriftType(fieldMetadata.getJavaType());
 
+            switch (requiredness) {
+                case REQUIRED:
+                case OPTIONAL:
+                    metadataErrors.addError(
+                            "Thrift union '%s' field '%s(%s)' should not be marked required or optional",
+                            structName,
+                            name,
+                            id);
+                    break;
+
+                default:
+                    break;
+            }
+
             if (fieldMetadata instanceof FieldInjection) {
                 FieldInjection fieldInjection = (FieldInjection) fieldMetadata;
                 injections.add(new ThriftFieldInjection(fieldInjection.getId(), fieldInjection.getName(), fieldInjection.getField(), fieldInjection.getType()));

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.swift.codec.metadata;
 
+import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftUnion;
 import com.facebook.swift.codec.ThriftUnionId;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata.MetadataType;
@@ -30,6 +31,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 
+import static com.facebook.swift.codec.ThriftField.Requiredness;
 import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_UNION_ID;
 import static com.facebook.swift.codec.metadata.ReflectionHelper.findAnnotatedMethods;
 
@@ -197,6 +199,7 @@ public class ThriftUnionMetadataBuilder
     {
         short id = -1;
         String name = null;
+        Requiredness requiredness = Requiredness.UNSPECIFIED;
         FieldKind fieldType = FieldKind.THRIFT_FIELD;
         ThriftType thriftType = null;
         ThriftConstructorInjection thriftConstructorInjection = null;
@@ -208,6 +211,7 @@ public class ThriftUnionMetadataBuilder
         for (FieldMetadata fieldMetadata : input) {
             id = fieldMetadata.getId();
             name = fieldMetadata.getName();
+            requiredness = fieldMetadata.getRequiredness();
             fieldType = fieldMetadata.getType();
             thriftType = catalog.getThriftType(fieldMetadata.getJavaType());
 
@@ -256,6 +260,7 @@ public class ThriftUnionMetadataBuilder
 
         ThriftFieldMetadata thriftFieldMetadata = new ThriftFieldMetadata(
                 id,
+                requiredness,
                 thriftType,
                 name,
                 fieldType,

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -185,13 +185,13 @@ public class TestThriftStructMetadataBuilder
 
         assertThat(metadataErrors.getErrors())
                 .as("metadata errors")
-                .isEmpty();
+                .hasSize(1);
 
         assertThat(metadataErrors.getWarnings())
                 .as("metadata warnings")
-                .hasSize(1);
+                .isEmpty();
 
-        assertThat(metadataErrors.getWarnings().get(0).getMessage())
+        assertThat(metadataErrors.getErrors().get(0).getMessage())
                 .as("error message")
                 .containsIgnoringCase("multiple types");
     }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -19,12 +19,15 @@ import com.facebook.swift.codec.ThriftConstructor;
 import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftStruct;
 import com.google.common.reflect.TypeToken;
+import org.apache.commons.lang3.text.translate.NumericEntityUnescaper;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Type;
 import java.util.concurrent.locks.Lock;
 
+import static com.facebook.swift.codec.ThriftField.Requiredness;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 
 public class TestThriftStructMetadataBuilder
 {
@@ -121,13 +124,13 @@ public class TestThriftStructMetadataBuilder
 
         assertThat(metadataErrors.getErrors())
                 .as("metadata errors")
-                .isEmpty();
+                .hasSize(1);
 
         assertThat(metadataErrors.getWarnings())
                 .as("metadata warnings")
-                .hasSize(1);
+                .hasSize(0);
 
-        assertThat(metadataErrors.getWarnings().get(0).getMessage())
+        assertThat(metadataErrors.getErrors().get(0).getMessage())
                 .as("error message")
                 .containsIgnoringCase("multiple names");
     }
@@ -276,6 +279,65 @@ public class TestThriftStructMetadataBuilder
             {
                 return new NonGenericStruct();
             }
+        }
+    }
+
+    @Test
+    public void testMulitpleRequiredness()
+    {
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), MultipleRequiredness.class);
+
+        MetadataErrors metadataErrors = builder.getMetadataErrors();
+
+        assertThat(metadataErrors.getErrors())
+                .as("metadata errors")
+                .hasSize(1);
+
+        assertThat(metadataErrors.getWarnings())
+                .as("metadata warnings")
+                .isEmpty();
+
+        assertThat(metadataErrors.getErrors().get(0).getMessage())
+                .as("error message")
+                .containsIgnoringCase("multiple requiredness");
+    }
+
+    @ThriftStruct
+    public static class MultipleRequiredness
+    {
+        @ThriftField(value = 1, requiredness = Requiredness.OPTIONAL)
+        public int getFoo()
+        {
+            return 0;
+        }
+
+        @ThriftField(value = 1, requiredness = Requiredness.NONE)
+        public void setFoo(int value)
+        {
+        }
+    }
+
+    @Test
+    public void testMergeableRequiredness()
+    {
+        ThriftStructMetadata metadata = new ThriftStructMetadataBuilder(new ThriftCatalog(), MergeableRequiredness.class).build();
+        assertThat(metadata.getField(1).getRequiredness())
+                .as("requiredness of field 'foo'")
+                .isEqualTo(Requiredness.OPTIONAL);
+    }
+
+    @ThriftStruct
+    public static class MergeableRequiredness
+    {
+        @ThriftField(value = 1, requiredness = Requiredness.OPTIONAL)
+        public int getFoo()
+        {
+            return 0;
+        }
+
+        @ThriftField
+        public void setFoo(int value)
+        {
         }
     }
 }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
@@ -128,13 +128,13 @@ public class TestThriftUnionMetadataBuilder
 
         assertThat(metadataErrors.getErrors())
                 .as("metadata errors")
-                .isEmpty();
+                .hasSize(1);
 
         assertThat(metadataErrors.getWarnings())
                 .as("metadata warnings")
-                .hasSize(1);
+                .isEmpty();
 
-        assertThat(metadataErrors.getWarnings().get(0).getMessage())
+        assertThat(metadataErrors.getErrors().get(0).getMessage())
                 .as("error message")
                 .containsIgnoringCase("multiple names");
     }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
@@ -202,13 +202,13 @@ public class TestThriftUnionMetadataBuilder
 
         assertThat(metadataErrors.getErrors())
                 .as("metadata errors")
-                .isEmpty();
+                .hasSize(1);
 
         assertThat(metadataErrors.getWarnings())
                 .as("metadata warnings")
-                .hasSize(1);
+                .isEmpty();
 
-        assertThat(metadataErrors.getWarnings().get(0).getMessage())
+        assertThat(metadataErrors.getErrors().get(0).getMessage())
                 .as("error message")
                 .containsIgnoringCase("multiple types");
     }

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -16,12 +16,14 @@
 package com.facebook.swift.generator.swift2thrift;
 
 import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.codec.ThriftField.Requiredness;
 import com.facebook.swift.codec.ThriftProtocolType;
 import com.facebook.swift.codec.metadata.FieldKind;
 import com.facebook.swift.codec.metadata.ReflectionHelper;
 import com.facebook.swift.codec.metadata.ThriftFieldMetadata;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata;
 import com.facebook.swift.codec.metadata.ThriftType;
+import com.facebook.swift.generator.swift2thrift.template.FieldRequirednessRenderer;
 import com.facebook.swift.generator.swift2thrift.template.ThriftContext;
 import com.facebook.swift.generator.swift2thrift.template.ThriftServiceMetadataRenderer;
 import com.facebook.swift.generator.swift2thrift.template.ThriftTypeRenderer;
@@ -427,7 +429,10 @@ public class Swift2ThriftGenerator
         this.thriftTypeRenderer = new ThriftTypeRenderer(typenameMap.build());
         ThriftServiceMetadataRenderer serviceRenderer = new ThriftServiceMetadataRenderer(serviceMap.build());
         TemplateLoader tl = new TemplateLoader(ImmutableList.of("thrift/common.st"),
-                ImmutableMap.of(ThriftType.class, thriftTypeRenderer, ThriftServiceMetadata.class, serviceRenderer));
+                ImmutableMap.of(
+                        ThriftType.class, thriftTypeRenderer,
+                        ThriftServiceMetadata.class, serviceRenderer,
+                        Requiredness.class, new FieldRequirednessRenderer()));
         ThriftContext ctx = new ThriftContext(packageName, ImmutableList.copyOf(includes.build()), thriftTypes, thriftServices, namespaceMap);
         ST template = tl.load("thriftfile");
         template.add("context", ctx);

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/template/FieldRequirednessRenderer.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/template/FieldRequirednessRenderer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.generator.swift2thrift.template;
+
+import com.facebook.swift.codec.ThriftField;
+import org.stringtemplate.v4.AttributeRenderer;
+
+import java.util.Locale;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class FieldRequirednessRenderer implements AttributeRenderer
+{
+    @Override
+    public String toString(Object o, String formatString, Locale locale)
+    {
+        checkArgument(o instanceof ThriftField.Requiredness);
+
+        ThriftField.Requiredness requiredness = (ThriftField.Requiredness)o;
+
+        switch (requiredness) {
+            case NONE:
+                return "";
+
+            case REQUIRED:
+                return "required";
+
+            case OPTIONAL:
+                return "optional";
+
+            default:
+                throw new IllegalArgumentException("Invalid value for field requiredness");
+        }
+    }
+}

--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/FieldContext.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/FieldContext.java
@@ -15,9 +15,12 @@
  */
 package com.facebook.swift.generator.template;
 
+import static com.facebook.swift.parser.model.ThriftField.Requiredness;
+
 public class FieldContext
 {
     private final String name;
+    private final Requiredness requiredness;
     private final short id;
     private final String javaType;
     private final String javaName;
@@ -25,15 +28,18 @@ public class FieldContext
     private final String javaSetterName;
     private final String javaTestPresenceName;
 
-    FieldContext(final String name,
-                 final short id,
-                 final String javaType,
-                 final String javaName,
-                 final String javaGetterName,
-                 final String javaSetterName,
-                 final String javaTestPresenceName)
+    FieldContext(
+            final String name,
+            final Requiredness requiredness,
+            final short id,
+            final String javaType,
+            final String javaName,
+            final String javaGetterName,
+            final String javaSetterName,
+            final String javaTestPresenceName)
     {
         this.name = name;
+        this.requiredness = requiredness;
         this.id = id;
         this.javaType = javaType;
         this.javaName = javaName;
@@ -45,6 +51,11 @@ public class FieldContext
     public String getName()
     {
         return name;
+    }
+
+    public Requiredness getRequiredness()
+    {
+        return requiredness;
     }
 
     public short getId()

--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
@@ -116,9 +116,11 @@ public class TemplateContextGenerator
     {
         Preconditions.checkState(field.getIdentifier().isPresent(), "exception %s has no identifier!", field.getName());
 
+        boolean isOptional = field.getRequired() == ThriftField.Required.OPTIONAL;
+
         return new FieldContext(field.getName(),
                                 field.getIdentifier().get().shortValue(),
-                                typeConverter.convertType(field.getType()),
+                                typeConverter.convert(field.getType(), !isOptional),
                                 mangleJavamethodName(field.getName()),
                                 getterName(field),
                                 setterName(field),

--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
@@ -119,6 +119,7 @@ public class TemplateContextGenerator
         boolean isOptional = field.getRequiredness() == ThriftField.Requiredness.OPTIONAL;
 
         return new FieldContext(field.getName(),
+                                field.getRequiredness(),
                                 field.getIdentifier().get().shortValue(),
                                 typeConverter.convert(field.getType(), !isOptional),
                                 mangleJavamethodName(field.getName()),

--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/TemplateContextGenerator.java
@@ -116,7 +116,7 @@ public class TemplateContextGenerator
     {
         Preconditions.checkState(field.getIdentifier().isPresent(), "exception %s has no identifier!", field.getName());
 
-        boolean isOptional = field.getRequired() == ThriftField.Required.OPTIONAL;
+        boolean isOptional = field.getRequiredness() == ThriftField.Requiredness.OPTIONAL;
 
         return new FieldContext(field.getName(),
                                 field.getIdentifier().get().shortValue(),

--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -9,6 +9,7 @@ service(context, tweaks) ::= <<
 package <context.javaPackage>;
 
 import com.facebook.swift.codec.*;
+import com.facebook.swift.codec.ThriftField.Requiredness;
 import com.facebook.swift.service.*;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.*;
@@ -37,6 +38,7 @@ struct(context, tweaks) ::= <<
 package <context.javaPackage>;
 
 import com.facebook.swift.codec.*;
+import com.facebook.swift.codec.ThriftField.Requiredness;
 import java.util.*;
 
 import static com.google.common.base.Objects.toStringHelper;
@@ -61,6 +63,7 @@ union(context, tweaks) ::= <<
 package <context.javaPackage>;
 
 import com.facebook.swift.codec.*;
+import com.facebook.swift.codec.ThriftField.Requiredness;
 import java.util.*;
 
 import static com.google.common.base.Objects.toStringHelper;
@@ -99,6 +102,7 @@ exception(context, tweaks) ::= <<
 package <context.javaPackage>;
 
 import com.facebook.swift.codec.*;
+import com.facebook.swift.codec.ThriftField.Requiredness;
 import java.util.*;
 
 @ThriftStruct("<context.name>")
@@ -212,8 +216,8 @@ _annotatedExceptions(method) ::= <<
 <method.annotatedExceptions: {exception |<_exceptionElement(exception)>}; separator=",\n">
 >>
 
-_annotation(field) ::= <<
-@ThriftField(value=<field.id>, name="<field.name>")
+_fieldAnnotation(field) ::= <<
+@ThriftField(value=<field.id>, name="<field.name>"<if(field.requiredness)>, requiredness=Requiredness.<field.requiredness><endif>)
 >>
 
 _params(parameters) ::= <<
@@ -223,7 +227,7 @@ _params(parameters) ::= <<
 >>
 
 _param(param) ::= <<
-<_annotation(param)> final <param.javaType> <param.javaName>
+<_fieldAnnotation(param)> final <param.javaType> <param.javaName>
 >>
 
 _exceptionElement(exception) ::= <<
@@ -249,7 +253,7 @@ _toStringField(field) ::= <<
 >>
 
 _union_field(field) ::= <<
-<_annotation(field)> 
+<_fieldAnnotation(field)>
 public <field.javaType> <field.javaGetterName>() {
     if (this.id != <field.id>) {
         throw new IllegalStateException("Not a <field.name> element!");

--- a/swift-generator/src/main/resources/templates/java/ctor.st
+++ b/swift-generator/src/main/resources/templates/java/ctor.st
@@ -7,7 +7,7 @@ _structbody(context) ::= <<
 _field(field) ::= <<
 private <field.javaType> <field.javaName>;
 
-<_annotation(field)>
+<_fieldAnnotation(field)>
 public <field.javaType> <field.javaGetterName>() { return <field.javaName>; }
 
 public void <field.javaSetterName>(final <field.javaType> <field.javaName>) { this.<field.javaName> = <field.javaName>; }

--- a/swift-generator/src/main/resources/templates/java/immutable.st
+++ b/swift-generator/src/main/resources/templates/java/immutable.st
@@ -9,7 +9,7 @@ _structbody(context) ::= <<
 _field(field) ::= <<
 private final <field.javaType> <field.javaName>;
 
-<_annotation(field)>
+<_fieldAnnotation(field)>
 public <field.javaType> <field.javaGetterName>() { return <field.javaName>; }
 >>
 

--- a/swift-generator/src/main/resources/templates/java/regular.st
+++ b/swift-generator/src/main/resources/templates/java/regular.st
@@ -7,7 +7,7 @@ _structbody(context) ::= <<
 _field(field) ::= <<
 private <field.javaType> <field.javaName>;
 
-<_annotation(field)>
+<_fieldAnnotation(field)>
 public <field.javaType> <field.javaGetterName>() { return <field.javaName>; }
 
 @ThriftField

--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -44,7 +44,11 @@ _structkind(struct) ::= <<
 
 _field(field) ::= <<
 <_doc(field.documentation)><\\\>
-<field.requiredness> <field.id>: <field.thriftType> <field.name>
+<_fieldRequiredness(field)><field.id>: <field.thriftType> <field.name>
+>>
+
+_fieldRequiredness(field) ::= <<
+<if(field.requiredness)><field.requiredness> <endif>
 >>
 
 _service(service) ::= <<

--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -44,7 +44,7 @@ _structkind(struct) ::= <<
 
 _field(field) ::= <<
 <_doc(field.documentation)><\\\>
-<field.id>: <field.thriftType> <field.name>
+<field.requiredness> <field.id>: <field.thriftType> <field.name>
 >>
 
 _service(service) ::= <<

--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/DocumentGenerator.g
@@ -175,10 +175,10 @@ field returns [ThriftField value]
         { $value = new ThriftField($k.text, $t.value, $i.value, $r.value, $c.value, $a.value); }
     ;
 
-field_req returns [ThriftField.Required value]
-    : REQUIREDNESS             { $value = ThriftField.Required.NONE; }
-    | ^(REQUIREDNESS REQUIRED) { $value = ThriftField.Required.REQUIRED; }
-    | ^(REQUIREDNESS OPTIONAL) { $value = ThriftField.Required.OPTIONAL; }
+field_req returns [ThriftField.Requiredness value]
+    : REQUIREDNESS             { $value = ThriftField.Requiredness.NONE; }
+    | ^(REQUIREDNESS REQUIRED) { $value = ThriftField.Requiredness.REQUIRED; }
+    | ^(REQUIREDNESS OPTIONAL) { $value = ThriftField.Requiredness.OPTIONAL; }
     ;
 
 

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ThriftField.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/ThriftField.java
@@ -27,7 +27,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ThriftField implements Visitable
 {
-    public static enum Required
+    public static enum Requiredness
     {
         REQUIRED, OPTIONAL, NONE
     }
@@ -35,7 +35,7 @@ public class ThriftField implements Visitable
     private final String name;
     private final ThriftType type;
     private final Optional<Long> identifier;
-    private final Required required;
+    private final Requiredness requiredness;
     private final Optional<ConstValue> value;
     private final List<TypeAnnotation> annotations;
 
@@ -43,14 +43,14 @@ public class ThriftField implements Visitable
             String name,
             ThriftType type,
             Long identifier,
-            Required required,
+            Requiredness requiredness,
             ConstValue value,
             List<TypeAnnotation> annotations)
     {
         this.name = checkNotNull(name, "name");
         this.type = checkNotNull(type, "type");
         this.identifier = Optional.fromNullable(identifier);
-        this.required = checkNotNull(required, "required");
+        this.requiredness = checkNotNull(requiredness, "requiredness");
         this.value = Optional.fromNullable(value);
         this.annotations = checkNotNull(annotations, "annotations");
     }
@@ -70,9 +70,9 @@ public class ThriftField implements Visitable
         return identifier;
     }
 
-    public Required getRequired()
+    public Requiredness getRequiredness()
     {
-        return required;
+        return requiredness;
     }
 
     public Optional<ConstValue> getValue()
@@ -92,7 +92,7 @@ public class ThriftField implements Visitable
                 .add("name", name)
                 .add("type", type)
                 .add("identifier", identifier)
-                .add("required", required)
+                .add("requiredness", requiredness)
                 .add("value", value)
                 .add("annotations", annotations)
                 .toString();

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import static com.facebook.swift.codec.ThriftField.Requiredness;
 import static com.facebook.swift.codec.metadata.FieldKind.THRIFT_FIELD;
 import static com.facebook.swift.codec.metadata.ReflectionHelper.extractParameterNames;
 import static com.google.common.base.Preconditions.checkState;
@@ -103,8 +104,10 @@ public class ThriftMethodMetadata
 
             short parameterId = Short.MIN_VALUE;
             String parameterName = null;
+            Requiredness parameterRequiredness = Requiredness.UNSPECIFIED;
             if (thriftField != null) {
                 parameterId = thriftField.value();
+                parameterRequiredness = thriftField.requiredness();
                 if (!thriftField.name().isEmpty()) {
                     parameterName = thriftField.name();
                 }
@@ -123,6 +126,7 @@ public class ThriftMethodMetadata
             ThriftInjection parameterInjection = new ThriftParameterInjection(parameterId, parameterName, index, parameterType);
             ThriftFieldMetadata fieldMetadata = new ThriftFieldMetadata(
                     parameterId,
+                    parameterRequiredness,
                     thriftType,
                     parameterName,
                     THRIFT_FIELD,


### PR DESCRIPTION
A collection of diffs that mostly add _some_ support for optional.

This also makes the optional/required setting for fields available in swift at runtime, but required is not yet enforced. Will add some changes in the future for this.

And while I was touching normalization of field metadata, I tried to correct a few oddities like allowing multiple conflicting types or names on a field with only a warning (now this will be an error).
