### PR TITLE
bug for thriftCodec cache , which 'MAP/SET/LIST' has difference valueTyp...

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftType.java
@@ -243,8 +243,22 @@ public class ThriftType
         if (javaType != null ? !javaType.equals(that.javaType) : that.javaType != null) {
             return false;
         }
+
         if (protocolType != that.protocolType) {
             return false;
+        }
+
+        if(protocolType == ThriftProtocolType.SET || protocolType == ThriftProtocolType.LIST
+            || protocolType == ThriftProtocolType.MAP){
+            if(valueType != null ? !valueType.equals(that.valueType) : that.valueType != null){
+                return false;
+            }
+        }
+
+        if(protocolType == ThriftProtocolType.MAP){
+            if(keyType != null ? !keyType.equals(that.valueType) : that.keyType != null){
+                return false;
+            }
         }
 
         return true;
@@ -255,6 +269,8 @@ public class ThriftType
     {
         int result = protocolType != null ? protocolType.hashCode() : 0;
         result = 31 * result + (javaType != null ? javaType.hashCode() : 0);
+        result = 31 * result + (valueType != null ? valueType.hashCode() : 0);
+        result = 31 * result + (keyType != null ? keyType.hashCode() : 0);
         return result;
     }
 

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/template/FieldRequirednessRenderer.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/template/FieldRequirednessRenderer.java
@@ -40,9 +40,10 @@ public class FieldRequirednessRenderer implements AttributeRenderer
 
             case OPTIONAL:
                 return "optional";
-
+            case UNSPECIFIED:
+                return "";
             default:
-                throw new IllegalArgumentException("Invalid value for field requiredness");
+                throw new IllegalArgumentException("Invalid value for field requiredness "+requiredness);
         }
     }
 }

--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -6,7 +6,7 @@ thriftfile(context) ::= <<
 <! = called from the generator to render a new thrift source file.                  = !>
 <! =                                                                                = !>
 <! ================================================================================== !>
-namespace java.swift <context.namespace>
+namespace java <context.namespace>
 <context.customNamespaces : {key | namespace <key> <context.customNamespaces.(key)>}; separator="\n">
 
 <context.includes : {inc | include "<inc>"}; separator="\n">
@@ -44,7 +44,7 @@ _structkind(struct) ::= <<
 
 _field(field) ::= <<
 <_doc(field.documentation)><\\\>
-<_fieldRequiredness(field)><field.id>: <field.thriftType> <field.name>
+<field.id>:<_fieldRequiredness(field)> <field.thriftType> <field.name>
 >>
 
 _fieldRequiredness(field) ::= <<

--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -6,6 +6,7 @@ thriftfile(context) ::= <<
 <! = called from the generator to render a new thrift source file.                  = !>
 <! =                                                                                = !>
 <! ================================================================================== !>
+namespace java.swift <context.namespace>
 namespace java <context.namespace>
 <context.customNamespaces : {key | namespace <key> <context.customNamespaces.(key)>}; separator="\n">
 

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -264,7 +264,7 @@ public class ThriftClientManager implements Closeable
 
         return type.cast(Proxy.newProxyInstance(
                 type.getClassLoader(),
-                new Class<?>[]{ type, Closeable.class },
+                new Class<?>[]{ type, Closeable.class,ThriftClientStatus.class },
                 handler
         ));
     }
@@ -470,6 +470,8 @@ public class ThriftClientManager implements Closeable
             if (args.length == 0 && "close".equals(method.getName())) {
                 channel.close();
                 return null;
+            }else if(args.length==0 && "isOpen".equals(method.getName())){
+                return channel.getNettyChannel().isOpen();
             }
 
             ThriftMethodHandler methodHandler = methods.get(method);

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientStatus.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientStatus.java
@@ -1,0 +1,27 @@
+package com.facebook.swift.service;
+
+
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+public interface ThriftClientStatus {
+    /**
+     * if the channel of client is closed ,return false
+     * @return boolean
+     */
+    boolean isOpen();
+
+
+}


### PR DESCRIPTION
bug for thriftCodec cache , which 'MAP/SET/LIST' has difference valueType or keyType.

In my case : 
service Service1{
  map&lt;i32 , i32&gt; query1();
}

service Service2{
   map&lt;i32,TObject&gt; query2();
}

while I start the server ,
NiftyProcessor processor = new ThriftServiceProcessor(new ThriftCodecManager(),
                        Arrays.asList(new ThriftEventHandler[] {  }),
                        context.getBean("service1"), context.getBean("service2"));

and I call the method query2(), it will cause an exception : 
java.lang.IllegalArgumentException: argument type mismatch
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.7.0_51]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[na:1.7.0_51]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_51]
    at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_51]
    at com.facebook.swift.codec.internal.coercion.CoercionThriftCodec.write(CoercionThriftCodec.java:62) ~[swift-codec-0.12.0.jar:0.12.0]
    at com.facebook.swift.codec.internal.TProtocolWriter.writeMap(TProtocolWriter.java:299) ~[swift-codec-0.12.0.jar:0.12.0]
