### PR TITLE
Make it possible to configure worker executor by name

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerWorkerExecutor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerWorkerExecutor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Retention(RUNTIME)
+@Target({METHOD, FIELD, PARAMETER})
+public @interface ThriftServerWorkerExecutor
+{
+}

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
@@ -15,9 +15,13 @@
  */
 package com.facebook.swift.service;
 
+import com.facebook.swift.codec.guice.ThriftCodecModule;
+import com.facebook.swift.service.guice.ThriftServerModule;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.configuration.testing.ConfigAssertions;
 import io.airlift.units.DataSize;
@@ -25,9 +29,17 @@ import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 
+import static com.facebook.swift.service.guice.ThriftServerModule.bindWorkerExecutor;
+import static com.facebook.swift.service.guice.ThriftServiceExporter.thriftServerBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestThriftServerConfig
 {
@@ -47,6 +59,7 @@ public class TestThriftServerConfig
                         .setIdleConnectionTimeout(Duration.valueOf("60s"))
                         .setTransportName("framed")
                         .setProtocolName("binary")
+                        .setWorkerExecutorKey(null)
         );
     }
 
@@ -63,6 +76,7 @@ public class TestThriftServerConfig
                 .put("thrift.io-threads.count", "27")
                 .put("thrift.idle-connection-timeout", "157ms")
                 .put("thrift.connection-limit", "1111")
+                .put("thrift.worker-executor-key", "my-executor")
                 .put("thrift.transport", "buffered")
                 .put("thrift.protocol", "compact")
                 .build();
@@ -77,6 +91,7 @@ public class TestThriftServerConfig
                 .setIoThreadCount(27)
                 .setIdleConnectionTimeout(Duration.valueOf("157ms"))
                 .setConnectionLimit(1111)
+                .setWorkerExecutorKey("my-executor")
                 .setTransportName("buffered")
                 .setProtocolName("compact");
 
@@ -105,5 +120,138 @@ public class TestThriftServerConfig
 
         ThriftServerConfig config = injector.getInstance(ThriftServerConfig.class);
         assertNotNull(config);
+    }
+
+    @Test
+    public void testWorkerThreadsConfiguration()
+            throws Exception
+    {
+        final int WORKER_THREAD_COUNT = 43;
+
+        Bootstrap bootstrap = new Bootstrap(
+                new ThriftCodecModule(),
+                new ThriftServerModule(),
+                new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bind(ExampleService.class);
+                        thriftServerBinder(binder()).exportThriftService(ExampleService.class);
+                    }
+                }
+        );
+
+        Map<String, String> properties = ImmutableMap.of(
+                "thrift.threads.max", Integer.toString(WORKER_THREAD_COUNT)
+        );
+
+        Injector injector =
+                bootstrap.doNotInitializeLogging()
+                         .strictConfig()
+                         .setRequiredConfigurationProperties(properties)
+                         .initialize();
+
+        ThriftServer server = injector.getInstance(ThriftServer.class);
+        Executor executor = server.getWorkerExecutor();
+        assertTrue(executor instanceof ThreadPoolExecutor);
+        assertEquals(((ThreadPoolExecutor)executor).getMaximumPoolSize(), WORKER_THREAD_COUNT);
+    }
+
+    @Test
+    public void testWorkerExecutorConfiguration()
+            throws Exception
+    {
+        final int WORKER_THREAD_COUNT = 43;
+        final ExecutorService myExecutor = Executors.newFixedThreadPool(WORKER_THREAD_COUNT);
+
+        Bootstrap bootstrap = new Bootstrap(
+                new ThriftCodecModule(),
+                overrideThriftServerModuleWithWorkerExecutorInstance(myExecutor),
+                new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bind(ExampleService.class);
+                        thriftServerBinder(binder()).exportThriftService(ExampleService.class);
+                    }
+                }
+        );
+
+        Map<String, String> properties = ImmutableMap.of();
+
+        Injector injector =
+                bootstrap.doNotInitializeLogging()
+                         .strictConfig()
+                         .setRequiredConfigurationProperties(properties)
+                         .initialize();
+
+        ThriftServer server = injector.getInstance(ThriftServer.class);
+        assertEquals(server.getWorkerExecutor(), myExecutor);
+    }
+
+    @Test
+    public void testWorkerExecutorKeyConfiguration()
+            throws Exception
+    {
+        final int WORKER_THREAD_COUNT = 44;
+        final ExecutorService myExecutor = Executors.newFixedThreadPool(WORKER_THREAD_COUNT);
+
+        Bootstrap bootstrap = new Bootstrap(
+                new ThriftCodecModule(),
+                new ThriftServerModule(),
+                new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bind(ExampleService.class);
+
+                        bindWorkerExecutor(binder(), "my-executor", myExecutor);
+                        thriftServerBinder(binder()).exportThriftService(ExampleService.class);
+                    }
+                }
+        );
+
+        Map<String, String> properties = ImmutableMap.of(
+                "thrift.worker-executor-key", "my-executor"
+        );
+
+        Injector injector =
+                bootstrap.doNotInitializeLogging()
+                         .strictConfig()
+                         .setRequiredConfigurationProperties(properties)
+                         .initialize();
+
+        ThriftServer server = injector.getInstance(ThriftServer.class);
+        assertEquals(server.getWorkerExecutor(), myExecutor);
+    }
+
+    /**
+     * Creates a {@link com.facebook.swift.service.guice.ThriftServerModule} with the binding
+     * for {@link com.facebook.swift.service.ThriftServerConfig} overridden to specify a specific
+     * instance of {@link java.util.concurrent.ExecutorService} for the worker executor.
+     */
+    private Module overrideThriftServerModuleWithWorkerExecutorInstance(final ExecutorService myExecutor)
+    {
+        return Modules.override(new ThriftServerModule()).with(
+                new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bind(ThriftServerConfig.class).toInstance(
+                                new ThriftServerConfig().setWorkerExecutor(myExecutor)
+                        );
+                    }
+                }
+        );
+    }
+
+    @ThriftService
+    private static class ExampleService
+    {
+        // Intentionally empty: this is just a placeholder
     }
 }


### PR DESCRIPTION
This change allows you to bind ExecutorServices to names, and then select a named executor from the set that was bound using a string property in ThriftServerConfig (thus allowing you to configure the possible exeuctors in your custom Guice module, and then select one by name in your application's config map).
