### PR TITLE
add bindWorkerExecutorProvider() that binds to a Provider type

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
@@ -119,6 +119,11 @@ public class ThriftServerModule implements Module
         return workerExecutorBinder(binder).addBinding(key).toProvider(executorServiceProvider);
     }
 
+    public static ScopedBindingBuilder bindWorkerExecutorProvider(Binder binder, String key, Class<? extends javax.inject.Provider<? extends ExecutorService>> executorServiceProvider)
+    {
+      return workerExecutorBinder(binder).addBinding(key).toProvider(executorServiceProvider);
+    }
+
     public static void bindWorkerExecutor(Binder binder, String key, ExecutorService executorService)
     {
         workerExecutorBinder(binder).addBinding(key).toInstance(executorService);


### PR DESCRIPTION
This solves issue #199 by providing a new method that binds to a Provider type, rather than a Provider instance.
