### PR TITLE
Fix swift2thrift service generation

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -124,6 +124,13 @@ public class ThriftMethodMetadata
             ThriftType thriftType = catalog.getThriftType(parameterType);
 
             ThriftInjection parameterInjection = new ThriftParameterInjection(parameterId, parameterName, index, parameterType);
+
+            if (parameterRequiredness == Requiredness.UNSPECIFIED) {
+                // There is only one field injection used to build metadata for method parameters, and if a
+                // single injection point has UNSPECIFIED requiredness, that resolves to NONE.
+                parameterRequiredness = Requiredness.NONE;
+            }
+
             ThriftFieldMetadata fieldMetadata = new ThriftFieldMetadata(
                     parameterId,
                     parameterRequiredness,


### PR DESCRIPTION
This fixes a bug that swift2thrift won't work if you don't explicitly provide a non-UNSPECIFIED requiredness on all @ThriftField annotations on all parameters in your service. Though the @ThriftField annotation default for 'requiredness' is UNSPECIFIED, for a method parameter, this should resolve to NONE.
