### PR TITLE
Make classloader choice explicit

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/ThriftCodecManager.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/ThriftCodecManager.java
@@ -65,7 +65,12 @@ public class ThriftCodecManager
 
     public ThriftCodecManager(ThriftCodec<?>... codecs)
     {
-        this(new CompilerThriftCodecFactory(), codecs);
+        this(new CompilerThriftCodecFactory(ThriftCodecManager.class.getClassLoader()), ImmutableSet.copyOf(codecs));
+    }
+
+    public ThriftCodecManager(ClassLoader parent, ThriftCodec<?>... codecs)
+    {
+        this(new CompilerThriftCodecFactory(parent), ImmutableSet.copyOf(codecs));
     }
 
     public ThriftCodecManager(ThriftCodecFactory factory, ThriftCodec<?>... codecs)

--- a/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecModule.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecModule.java
@@ -18,6 +18,7 @@ package com.facebook.swift.codec.guice;
 import com.facebook.swift.codec.InternalThriftCodec;
 import com.facebook.swift.codec.ThriftCodec;
 import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.codec.internal.ForCompiler;
 import com.facebook.swift.codec.internal.ThriftCodecFactory;
 import com.facebook.swift.codec.internal.compiler.CompilerThriftCodecFactory;
 import com.facebook.swift.codec.metadata.ThriftCatalog;
@@ -30,6 +31,18 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 public class ThriftCodecModule implements Module
 {
+    private final ClassLoader parent;
+
+    public ThriftCodecModule()
+    {
+        this(ThriftCodecModule.class.getClassLoader());
+    }
+
+    public ThriftCodecModule(ClassLoader parent)
+    {
+        this.parent = parent;
+    }
+
     @Override
     public void configure(Binder binder)
     {
@@ -40,6 +53,10 @@ public class ThriftCodecModule implements Module
         binder.bind(ThriftCatalog.class).in(Scopes.SINGLETON);
         binder.bind(ThriftCodecManager.class).in(Scopes.SINGLETON);
         newSetBinder(binder, new TypeLiteral<ThriftCodec<?>>() {}, InternalThriftCodec.class).permitDuplicates();
+
+        binder.bind(ClassLoader.class)
+                .annotatedWith(ForCompiler.class)
+                .toInstance(parent);
     }
 }
 

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/ForCompiler.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/ForCompiler.java
@@ -13,23 +13,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.codec.internal.compiler;
+package com.facebook.swift.codec.internal;
 
-import com.facebook.swift.codec.ThriftCodec;
+import com.google.inject.BindingAnnotation;
 
-/**
- * A ClassLoader that allows for loading of classes from an array of bytes.
- */
-public class DynamicClassLoader extends ClassLoader
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ METHOD, CONSTRUCTOR, FIELD, PARAMETER })
+@Retention(RUNTIME)
+@BindingAnnotation
+public @interface ForCompiler
 {
-    public DynamicClassLoader(ClassLoader parent)
-    {
-        super(parent);
-    }
-
-    public Class<?> defineClass(String name, byte[] byteCode)
-            throws ClassFormatError
-    {
-        return defineClass(name, byteCode, 0, byteCode.length);
-    }
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
@@ -17,8 +17,10 @@ package com.facebook.swift.codec.internal.compiler;
 
 import com.facebook.swift.codec.ThriftCodec;
 import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.codec.internal.ForCompiler;
 import com.facebook.swift.codec.internal.ThriftCodecFactory;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata;
+import com.google.inject.Inject;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -34,20 +36,21 @@ public class CompilerThriftCodecFactory implements ThriftCodecFactory
     private final boolean debug;
     private final DynamicClassLoader classLoader;
 
-    public CompilerThriftCodecFactory()
+    @Inject
+    public CompilerThriftCodecFactory(@ForCompiler ClassLoader parent)
     {
-        this(false);
+        this(false, parent);
     }
 
     public CompilerThriftCodecFactory(boolean debug)
     {
-        this(debug, getPriviledgedClassLoader());
+        this(debug, getPriviledgedClassLoader(CompilerThriftCodecFactory.class.getClassLoader()));
     }
 
-    public CompilerThriftCodecFactory(boolean debug, DynamicClassLoader classLoader)
+    public CompilerThriftCodecFactory(boolean debug, ClassLoader parent)
     {
-        this.classLoader = classLoader;
         this.debug = debug;
+        this.classLoader = getPriviledgedClassLoader(parent);
     }
 
     @Override
@@ -62,11 +65,11 @@ public class CompilerThriftCodecFactory implements ThriftCodecFactory
         return generator.getThriftCodec();
     }
 
-    private static DynamicClassLoader getPriviledgedClassLoader()
+    private static DynamicClassLoader getPriviledgedClassLoader(final ClassLoader parent)
     {
         return AccessController.doPrivileged(new PrivilegedAction<DynamicClassLoader>() {
             public DynamicClassLoader run() {
-                return new DynamicClassLoader();
+                return new DynamicClassLoader(parent);
             }
         });
     }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -102,6 +102,11 @@ public class ThriftClientManager implements Closeable
         this(new ThriftCodecManager());
     }
 
+    public ThriftClientManager(ClassLoader parent)
+    {
+        this(new ThriftCodecManager(parent));
+    }
+
     public ThriftClientManager(ThriftCodecManager codecManager)
     {
         this(codecManager, new NiftyClient(), ImmutableSet.<ThriftClientEventHandler>of());


### PR DESCRIPTION
If a caller needs the bytecode compiler to use a custom classloader, it should make an explicit choice.

In particular, Swift shouldn't try to infer a classloader by looking into the thread context classloader, which was designed as a way for various layers in a J2EE server to share information via a thread-local side channel.
