### PR TITLE
Requiredness should be after field id.

### DIFF
--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -44,7 +44,7 @@ _structkind(struct) ::= <<
 
 _field(field) ::= <<
 <_doc(field.documentation)><\\\>
-<_fieldRequiredness(field)><field.id>: <field.thriftType> <field.name>
+<field.id>: <_fieldRequiredness(field)><field.thriftType> <field.name>
 >>
 
 _fieldRequiredness(field) ::= <<


### PR DESCRIPTION
Tested with 
java -cp ~/.m2/repository/com/facebook/swift/swift2thrift-generator-cli/0.14.0-SNAPSHOT/swift2thrift-generator-cli-0.14.0-SNAPSHOT-standalone.jar:gen-swift/ com.facebook.swift.generator.swift2thrift.Main -package sum -recursive SumService

and it generates correct result:
struct SumRequest {
  1: required i32 num1;
  2: required i32 num2;
}
