### PR TITLE
Queued responses per connection config

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
@@ -210,7 +210,7 @@ public class ThriftMethodProcessor
                                             method.getName(),
                                             sequenceId,
                                             INTERNAL_ERROR,
-                                            "Internal error processing " + method.getName(),
+                                            "Internal error processing " + method.getName() + ": " + t.getMessage(),
                                             t);
 
                             contextChain.postWriteException(applicationException);

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServer.java
@@ -176,6 +176,7 @@ public class ThriftServer implements Closeable
                                                          .clientIdleTimeout(config.getIdleConnectionTimeout())
                                                          .withProcessorFactory(processorFactory)
                                                          .limitConnectionsTo(config.getConnectionLimit())
+                                                         .limitQueuedResponsesPerConnection(config.getMaxQueuedResponsesPerConnection())
                                                          .thriftFrameCodecFactory(availableFrameCodecFactories.get(transportName))
                                                          .protocol(availableProtocolFactories.get(protocolName))
                                                          .withSecurityFactory(securityFactoryHolder.niftySecurityFactory)

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
@@ -62,6 +62,7 @@ public class TestThriftServerConfig
                         .setWorkerExecutorKey(null)
                         .setTaskExpirationTimeout(Duration.valueOf("5s"))
                         .setMaxQueuedRequests(null)
+                        .setMaxQueuedResponsesPerConnection(16)
         );
     }
 
@@ -83,6 +84,7 @@ public class TestThriftServerConfig
                 .put("thrift.protocol", "compact")
                 .put("thrift.task-expiration-timeout", "10s")
                 .put("thrift.max-queued-requests", "1000")
+                .put("thrift.max-queued-responses-per-connection", "32")
                 .build();
 
         ThriftServerConfig expected = new ThriftServerConfig()
@@ -99,7 +101,8 @@ public class TestThriftServerConfig
                 .setTransportName("buffered")
                 .setProtocolName("compact")
                 .setTaskExpirationTimeout(Duration.valueOf("10s"))
-                .setMaxQueuedRequests(1000);
+                .setMaxQueuedRequests(1000)
+                .setMaxQueuedResponsesPerConnection(32);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add a ThriftServerConfig to allow you to set this Nifty option.

This limit applies when either server or client doesn't support sending/receiving out-of-order responses. In this case, the server queues up out-of-order responses until it has a string of them prepared to send in-order. If the # of responses for a given connection gets too high, the server will turn off reads for that connection until all the responses are ready.
