### PR TITLE
The worker thread count is now manageable inside ThriftClientManagerConfig 

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManagerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManagerConfig.java
@@ -22,15 +22,24 @@ import io.airlift.configuration.Config;
 public class ThriftClientManagerConfig
 {
     private HostAndPort defaultSocksProxyAddress = null;
+    private Integer workerThreadCount = null;
 
     public HostAndPort getDefaultSocksProxyAddress()
     {
         return defaultSocksProxyAddress;
     }
 
+    public Integer getWorkerThreadCount() { return workerThreadCount; }
+
     @Config("thrift.clientmanager.default-socks-proxy")
     public void setDefaultSocksProxyAddress(HostAndPort defaultSocksProxyAddress)
     {
         this.defaultSocksProxyAddress = defaultSocksProxyAddress;
+    }
+
+    @Config("thrift.clientmanager.worker-thread-count")
+    public void setWorkerThreadCount(int workerThreadCount)
+    {
+        this.workerThreadCount = Integer.valueOf(workerThreadCount);
     }
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
@@ -16,6 +16,7 @@
 package com.facebook.swift.service.guice;
 
 import com.facebook.nifty.client.NettyClientConfig;
+import com.facebook.nifty.client.NettyClientConfigBuilder;
 import com.facebook.nifty.client.NiftyClient;
 import com.facebook.swift.service.ThriftClientManager;
 import com.facebook.swift.service.ThriftClientManagerConfig;
@@ -53,8 +54,14 @@ public class ThriftClientModule implements Module
         @Override
         public NiftyClient get()
         {
-            NettyClientConfig config = NettyClientConfig.newBuilder().setDefaultSocksProxyAddress(clientManagerConfig.getDefaultSocksProxyAddress()).build();
-            return new NiftyClient(config);
+            NettyClientConfigBuilder builder = NettyClientConfig.newBuilder().setDefaultSocksProxyAddress(clientManagerConfig.getDefaultSocksProxyAddress());
+
+            if (clientManagerConfig.getWorkerThreadCount() != null)
+            {
+                builder.setWorkerThreadCount(clientManagerConfig.getWorkerThreadCount());
+            }
+
+            return new NiftyClient(builder.build());
         }
     }
 }


### PR DESCRIPTION
I created a fix that resolves #228. All of the tests pass. The thread input value is not checked, however it is checked once it is given to Netty. 
