### PR TITLE
annotation value should be optional

### DIFF
--- a/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
+++ b/swift-idl-parser/src/main/antlr3/com/facebook/swift/parser/antlr/Thrift.g
@@ -169,7 +169,7 @@ type_annotations
     ;
 
 type_annotation
-    : IDENTIFIER '=' annotation_value list_separator? -> ^(TYPE IDENTIFIER annotation_value)
+    : IDENTIFIER ('=' annotation_value)? list_separator? -> ^(TYPE IDENTIFIER annotation_value?)
     ;
 
 annotation_value

--- a/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/TypeAnnotation.java
+++ b/swift-idl-parser/src/main/java/com/facebook/swift/parser/model/TypeAnnotation.java
@@ -32,7 +32,7 @@ public class TypeAnnotation implements Visitable
     public TypeAnnotation(String name, String value)
     {
         this.name = checkNotNull(name, "name");
-        this.value = Preconditions.checkNotNull(value, "value");
+        this.value = value;
     }
 
     public String getName()

--- a/swift-idl-parser/src/test/resources/thrift/test/AnnotationTest.thrift
+++ b/swift-idl-parser/src/test/resources/thrift/test/AnnotationTest.thrift
@@ -28,6 +28,7 @@ struct foo {
   cpp.type = "DenseFoo",
   python.type = "DenseFoo",
   java.final = "",
+  java.empty_annotation,
 )
 
 typedef string ( unicode.encoding = "UTF-16" ) non_latin_string


### PR DESCRIPTION
Summary: Annotation value is optional in thrift parser so make it
optional here.

Test Plan: Added an annotation without value then mvn clean install
