### PR TITLE
Get rid of read/write size distribution counters in ThriftMethodStats

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodStats.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodStats.java
@@ -16,7 +16,6 @@
 package com.facebook.swift.service;
 
 import io.airlift.stats.CounterStat;
-import io.airlift.stats.DistributionStat;
 import io.airlift.stats.TimeStat;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
@@ -29,8 +28,6 @@ public class ThriftMethodStats
     private final TimeStat invoke = new TimeStat();
     private final TimeStat write = new TimeStat();
     private final TimeStat error = new TimeStat();
-    private final DistributionStat readSize = new DistributionStat();
-    private final DistributionStat writeSize = new DistributionStat();
     private final CounterStat readSizeTotal = new CounterStat();
     private final CounterStat writeSizeTotal = new CounterStat();
 
@@ -67,20 +64,6 @@ public class ThriftMethodStats
     public TimeStat getError()
     {
         return error;
-    }
-
-    @Managed
-    @Nested
-    public DistributionStat getReadSize()
-    {
-        return readSize;
-    }
-
-    @Managed
-    @Nested
-    public DistributionStat getWriteSize()
-    {
-        return writeSize;
     }
 
     @Managed
@@ -125,12 +108,10 @@ public class ThriftMethodStats
     public void addReadByteCount(int readByteCount)
     {
         readSizeTotal.update(readByteCount);
-        readSize.add(readByteCount);
     }
 
     public void addWriteByteCount(int writeByteCount)
     {
         writeSizeTotal.update(writeByteCount);
-        writeSize.add(writeByteCount);
     }
 }


### PR DESCRIPTION
airlift.Distribution has multiple QuantileDigests inside of it which makes recursive calls under a global lock. This is hurting performance so we should get rid of it. I'm afraid there is no fast way to do percentile counters.
