### PR TITLE
Tolerate non-NiftyClientChannel RequestChannels for swift clients

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftClientManager.java
@@ -508,12 +508,11 @@ public class ThriftClientManager implements Closeable
                 }
 
                 SocketAddress remoteAddress = null;
-                try {
-                    NiftyClientChannel niftyClientChannel = (NiftyClientChannel)channel;
+                // Can only get remote address if this is a nifty channel, plain RequestChannel does
+                // not support it
+                if (channel instanceof NiftyClientChannel) {
+                    NiftyClientChannel niftyClientChannel = (NiftyClientChannel) channel;
                     remoteAddress = niftyClientChannel.getNettyChannel().getRemoteAddress();
-                }
-                catch (ClassCastException e) {
-                    throw new IllegalArgumentException("The swift client uses a channel that is not a NiftyClientChannel", e);
                 }
 
                 ClientRequestContext requestContext = new NiftyClientRequestContext(getInputProtocol(), getOutputProtocol(), channel, remoteAddress);


### PR DESCRIPTION
We can live with a remoteAddress == null in the request context.
