### PR TITLE
[codec] Allow negative field numbers in structs/unions

### DIFF
--- a/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftField.java
+++ b/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftField.java
@@ -34,6 +34,9 @@ public @interface ThriftField
 {
     short value() default Short.MIN_VALUE;
 
+    /** Indicates this ThriftField has a negative ID, which is deprecated. */
+    boolean isLegacyId() default false;
+
     String name() default "";
 
     Requiredness requiredness() default Requiredness.UNSPECIFIED;

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldExtractor.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldExtractor.java
@@ -44,7 +44,7 @@ public class ThriftFieldExtractor implements ThriftExtraction
 
         switch (fieldKind) {
             case THRIFT_FIELD:
-                checkArgument(fieldId >= 0, "fieldId is negative");
+                // nothing to check
                 break;
             case THRIFT_UNION_ID:
                 checkArgument (fieldId == Short.MIN_VALUE, "fieldId must be Short.MIN_VALUE for thrift_union_id");

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldInjection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldInjection.java
@@ -38,7 +38,7 @@ public class ThriftFieldInjection implements ThriftInjection
 
         switch (fieldKind) {
             case THRIFT_FIELD:
-                checkArgument(id >= 0, "fieldId is negative");
+                // Nothing to check
                 break;
             case THRIFT_UNION_ID:
                 checkArgument (id == Short.MIN_VALUE, "fieldId must be Short.MIN_VALUE for thrift_union_id");

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.swift.codec.metadata;
 
-import com.facebook.swift.codec.ThriftField;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
@@ -51,6 +50,7 @@ public class ThriftFieldMetadata
 
     public ThriftFieldMetadata(
             short id,
+            boolean isLegacyId,
             Requiredness requiredness,
             ThriftType thriftType,
             String name,
@@ -75,9 +75,14 @@ public class ThriftFieldMetadata
 
         switch (fieldKind) {
             case THRIFT_FIELD:
-                checkArgument(id >= 0, "id is negative");
+                if (isLegacyId)  {
+                    checkArgument(id < 0, "isLegacyId should only be specified on fields with negative IDs");
+                } else {
+                    checkArgument(id >= 0, "isLegacyId must be specified on fields with negative IDs");
+                }
                 break;
             case THRIFT_UNION_ID:
+                checkArgument(isLegacyId, "isLegacyId should be implicitly set on ThriftUnionId fields");
                 checkArgument(id == Short.MIN_VALUE, "thrift union id must be Short.MIN_VALUE");
                 break;
         }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftMethodExtractor.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftMethodExtractor.java
@@ -44,7 +44,7 @@ public class ThriftMethodExtractor implements ThriftExtraction
 
         switch (fieldKind) {
             case THRIFT_FIELD:
-                checkArgument(fieldId >= 0, "fieldId is negative");
+                // Nothing to check
                 break;
             case THRIFT_UNION_ID:
                 checkArgument (fieldId == Short.MIN_VALUE, "fieldId must be Short.MIN_VALUE for thrift_union_id");

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftParameterInjection.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftParameterInjection.java
@@ -37,7 +37,6 @@ public class ThriftParameterInjection implements ThriftInjection
             Type javaType)
     {
 
-        checkArgument(id >= 0, "fieldId is negative");
         checkArgument(parameterIndex >= 0, "parameterIndex is negative");
 
         this.javaType = checkNotNull(javaType, "javaType is null");

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
@@ -139,6 +139,7 @@ public class ThriftStructMetadataBuilder
     protected ThriftFieldMetadata buildField(Collection<FieldMetadata> input)
     {
         short id = -1;
+        boolean isLegacyId = false;
         String name = null;
         Requiredness requiredness = Requiredness.UNSPECIFIED;
         ThriftType type = null;
@@ -148,6 +149,7 @@ public class ThriftStructMetadataBuilder
         ThriftExtraction extraction = null;
         for (FieldMetadata fieldMetadata : input) {
             id = fieldMetadata.getId();
+            isLegacyId = fieldMetadata.isLegacyId();
             name = fieldMetadata.getName();
             requiredness = fieldMetadata.getRequiredness();
             type = catalog.getThriftType(fieldMetadata.getJavaType());
@@ -183,6 +185,7 @@ public class ThriftStructMetadataBuilder
 
         ThriftFieldMetadata thriftFieldMetadata = new ThriftFieldMetadata(
                 id,
+                isLegacyId,
                 requiredness,
                 type,
                 name,

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.swift.codec.metadata;
 
-import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftUnion;
 import com.facebook.swift.codec.ThriftUnionId;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata.MetadataType;
@@ -198,6 +197,7 @@ public class ThriftUnionMetadataBuilder
     protected ThriftFieldMetadata buildField(Collection<FieldMetadata> input)
     {
         short id = -1;
+        boolean isLegacyId = false;
         String name = null;
         Requiredness requiredness = Requiredness.UNSPECIFIED;
         FieldKind fieldType = FieldKind.THRIFT_FIELD;
@@ -210,6 +210,7 @@ public class ThriftUnionMetadataBuilder
         ThriftExtraction extraction = null;
         for (FieldMetadata fieldMetadata : input) {
             id = fieldMetadata.getId();
+            isLegacyId = fieldMetadata.isLegacyId();
             name = fieldMetadata.getName();
             requiredness = fieldMetadata.getRequiredness();
             fieldType = fieldMetadata.getType();
@@ -274,6 +275,7 @@ public class ThriftUnionMetadataBuilder
 
         ThriftFieldMetadata thriftFieldMetadata = new ThriftFieldMetadata(
                 id,
+                isLegacyId,
                 requiredness,
                 thriftType,
                 name,

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestLegacyFieldIds.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestLegacyFieldIds.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.metadata;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+import com.facebook.swift.codec.ThriftUnion;
+import com.facebook.swift.codec.ThriftUnionId;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+public class TestLegacyFieldIds
+{
+    @Test
+    public void testLegacyIdCorrectlyAnnotated()
+    {
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), LegacyIdCorrect.class);
+        ThriftStructMetadata metadata = builder.build();
+
+        Set<Integer> seen = new HashSet<>();
+        for (ThriftFieldMetadata field : metadata.getFields()) {
+            seen.add((int) field.getId());
+        }
+
+        assertThat(seen)
+                .as("fields found in LegacyIdCorrect")
+                .isEqualTo(LegacyIdCorrect.IDS);
+    }
+
+    @Test
+    public void testLegacyIdCorrectlyAnnotatedWhitebox()
+    {
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), LegacyIdCorrect.class);
+
+        Set<Integer> seen = new HashSet<>();
+
+        for (FieldMetadata field : builder.fields) {
+            String name = field.getName();
+            short id = field.getId();
+            boolean legacy = field.isLegacyId();
+
+            assertThat(name)
+                .as("name of field " + field)
+                .matches("^(notLegacy|legacy).*");
+            if (name.startsWith("legacy")) {
+                assertThat(id)
+                    .as("id of field " + field)
+                    .isLessThan((short) 0);
+                assertThat(legacy)
+                    .as("isLegacyId of field " + field)
+                    .isTrue();
+            } else {
+                assertThat(id)
+                    .as("id of field " + field)
+                    .isGreaterThanOrEqualTo((short) 0);
+                assertThat(legacy)
+                    .as("isLegacyId of field " + field)
+                    .isFalse();
+            }
+
+            seen.add((int) id);
+        }
+
+        assertThat(seen)
+             .as("present fields in the struct")
+             .isEqualTo(LegacyIdCorrect.IDS);
+    }
+
+    @ThriftStruct
+    public static final class LegacyIdCorrect
+    {
+        private static final Set<Integer> IDS =
+            ImmutableSet.<Integer>of(-4, -3, -2, -1, 0, 1, 2);
+
+        @ThriftField(value = 0, isLegacyId = false) public boolean notLegacyId0;
+        @ThriftField(value = 1, isLegacyId = false) public boolean notLegacyId1;
+        @ThriftField(value = 2) public boolean notLegacyId2;
+        @ThriftField(value = -1, isLegacyId = true) public boolean legacyIdOnField;
+
+        @ThriftField(value = -2, isLegacyId = true)
+        public boolean getLegacyIdOnGetterOnly()
+        {
+            return false;
+        }
+
+        @ThriftField
+        public void setLegacyIdOnGetterOnly(boolean value)
+        {
+        }
+
+        @ThriftField
+        public boolean getLegacyIdOnSetterOnly()
+        {
+            return false;
+        }
+
+        @ThriftField(value = -3, isLegacyId = true)
+        public void setLegacyIdOnSetterOnly(boolean value)
+        {
+        }
+
+        @ThriftField(value = -4, isLegacyId = true)
+        public boolean getLegacyIdOnBoth()
+        {
+            return false;
+        }
+
+        @ThriftField(value = -4, isLegacyId = true)
+        public void setLegacyIdOnBoth(boolean value)
+        {
+        }
+    }
+
+    @Test
+    public void testLegacyIdIncorrect()
+    {
+        // 1: Missing isLegacyId=true when necessary
+        {
+            ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), LegacyIdIncorrectlyMissing.class);
+
+            MetadataErrors metadataErrors = builder.getMetadataErrors();
+
+            assertThat(metadataErrors.getErrors())
+                    .as("metadata errors")
+                    .hasSize(1);
+
+            assertThat(metadataErrors.getWarnings())
+                    .as("metadata warnings")
+                    .isEmpty();
+
+            assertThat(metadataErrors.getErrors().get(0).getMessage())
+                    .as("error message")
+                    .containsIgnoringCase("has a negative field id but not isLegacyId=true");
+        }
+
+        // 2: Has isLegacyId=true when unnecessary
+        {
+            ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), LegacyIdIncorrectlyPresent.class);
+
+            MetadataErrors metadataErrors = builder.getMetadataErrors();
+
+            assertThat(metadataErrors.getErrors())
+                    .as("metadata errors")
+                    .hasSize(1);
+
+            assertThat(metadataErrors.getWarnings())
+                    .as("metadata warnings")
+                    .isEmpty();
+
+            assertThat(metadataErrors.getErrors().get(0).getMessage())
+                    .as("error message")
+                    .containsIgnoringCase("has isLegacyId=true but not a negative field id");
+        }
+
+        // 3: Must be consistent
+        for (Class<?> klass : Arrays.asList(
+                        LegacyIdInconsistent1.class,
+                        LegacyIdInconsistent2.class,
+                        LegacyIdInconsistent3.class,
+                        LegacyIdInconsistent4.class
+        )) {
+            ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), klass);
+
+            MetadataErrors metadataErrors = builder.getMetadataErrors();
+
+            assertThat(metadataErrors.getErrors())
+                    .as("metadata errors")
+                    .isNotEmpty();
+
+            assertThat(metadataErrors.getWarnings())
+                    .as("metadata warnings")
+                    .isEmpty();
+
+            assertThat(metadataErrors.getErrors().get(0).getMessage())
+                    .as("error message")
+                    .containsIgnoringCase("has both isLegacyId=true and isLegacyId=false");
+        }
+    }
+
+    @ThriftStruct
+    public static final class LegacyIdIncorrectlyMissing {
+        @ThriftField(value = -4) public boolean field;
+    }
+
+    @ThriftStruct
+    public static final class LegacyIdIncorrectlyPresent {
+        @ThriftField(value = 4, isLegacyId = true) public boolean field;
+    }
+
+    /* legacy, getter correct, setter wrong */
+    @ThriftStruct
+    public static final class LegacyIdInconsistent1 {
+        @ThriftField(value = -4, isLegacyId = true)
+        public boolean getField()
+        {
+            return false;
+        }
+
+        @ThriftField(value = -4, isLegacyId = false)
+        public void setField(boolean value)
+        {
+        }
+    }
+
+    /* legacy, setter correct, getter wrong */
+    @ThriftStruct
+    public static final class LegacyIdInconsistent2 {
+        @ThriftField(value = -4, isLegacyId = false)
+        public boolean getField()
+        {
+            return false;
+        }
+
+        @ThriftField(value = -4, isLegacyId = true)
+        public void setField(boolean value)
+        {
+        }
+    }
+
+    /* not legacy, setter correct, getter wrong */
+    @ThriftStruct
+    public static final class LegacyIdInconsistent3 {
+        @ThriftField(value = 4, isLegacyId = true)
+        public boolean getField()
+        {
+            return false;
+        }
+
+        @ThriftField(value = 4, isLegacyId = false)
+        public void setField(boolean value)
+        {
+        }
+    }
+
+    /* not legacy, getter correct, setter wrong */
+    @ThriftStruct
+    public static final class LegacyIdInconsistent4 {
+        @ThriftField(value = 4, isLegacyId = false)
+        public boolean getField()
+        {
+            return false;
+        }
+
+        @ThriftField(value = 4, isLegacyId = true)
+        public void setField(boolean value)
+        {
+        }
+    }
+
+    @Test
+    public void testGetThriftFieldIsLegacyId() {
+        Function<FieldMetadata, Optional<Boolean>> getter = FieldMetadata.getThriftFieldIsLegacyId();
+
+        Function<ThriftField, FieldMetadata> makeFakeFieldMetadata = new Function<ThriftField, FieldMetadata>() {
+            @Override
+            public FieldMetadata apply(ThriftField input)
+            {
+                return new FieldMetadata(input, FieldKind.THRIFT_FIELD) {
+                    @Override
+                    public Type getJavaType()
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public String extractName()
+                    {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+
+        for (Field f : ReflectionHelper.findAnnotatedFields(SomeThriftFields.class, ThriftField.class)) {
+            final Optional<Boolean> expected;
+            if (f.getName().startsWith("expectTrue")) {
+                expected = Optional.of(true);
+            } else if (f.getName().startsWith("expectFalse")) {
+                expected = Optional.of(false);
+            } else if (f.getName().startsWith("expectNothing")) {
+                expected = Optional.absent();
+            } else {
+                Preconditions.checkArgument(f.getName().startsWith("broken"));
+                continue;
+            }
+
+            Optional<Boolean> actual = getter.apply(makeFakeFieldMetadata.apply(f.getAnnotation(ThriftField.class)));
+
+            assertThat(actual)
+                .as("result of getThriftFieldIsLegacyId on " + f)
+                .isEqualTo(expected);
+        }
+    }
+
+    private static class SomeThriftFields
+    {
+        @ThriftField(value = +1, isLegacyId = false) boolean expectFalse1;
+        @ThriftField(value = -1, isLegacyId = false) boolean expectFalse2;
+        @ThriftField(isLegacyId = false) boolean broken;  // see comments in impl.
+
+        @ThriftField(value = +1, isLegacyId = true) boolean expectTrue1;
+        @ThriftField(value = -1, isLegacyId = true) boolean expectTrue2;
+        @ThriftField(isLegacyId = true) boolean expectTrue3;
+
+        @ThriftField boolean expectNothing;
+    }
+
+    @Test
+    public void testLegacyIdOnUnion()
+    {
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(new ThriftCatalog(), LegacyIdUnionCorrect.class);
+        ThriftStructMetadata metadata = builder.build();
+
+        Set<Integer> seen = new HashSet<>();
+        for (ThriftFieldMetadata field : metadata.getFields()) {
+            seen.add((int) field.getId());
+        }
+
+        assertThat(seen)
+                .as("fields found in LegacyIdUnionCorrect")
+                .isEqualTo(LegacyIdUnionCorrect.IDS);
+    }
+
+    @ThriftUnion
+    public static final class LegacyIdUnionCorrect
+    {
+        private static final Set<Integer> IDS =
+            ImmutableSet.<Integer>of(-4, -3, -2, -1, 0, 1, 2, (int) Short.MIN_VALUE);
+
+        @ThriftUnionId public short unionId;
+
+        @ThriftField(value = 0, isLegacyId = false) public boolean notLegacyId0;
+        @ThriftField(value = 1, isLegacyId = false) public boolean notLegacyId1;
+        @ThriftField(value = 2) public boolean notLegacyId2;
+        @ThriftField(value = -1, isLegacyId = true) public boolean legacyIdOnField;
+
+        @ThriftField(value = -2, isLegacyId = true)
+        public boolean getLegacyIdOnGetterOnly()
+        {
+            return false;
+        }
+
+        @ThriftField
+        public void setLegacyIdOnGetterOnly(boolean value)
+        {
+        }
+
+        @ThriftField
+        public boolean getLegacyIdOnSetterOnly()
+        {
+            return false;
+        }
+
+        @ThriftField(value = -3, isLegacyId = true)
+        public void setLegacyIdOnSetterOnly(boolean value)
+        {
+        }
+
+        @ThriftField(value = -4, isLegacyId = true)
+        public boolean getLegacyIdOnBoth()
+        {
+            return false;
+        }
+
+        @ThriftField(value = -4, isLegacyId = true)
+        public void setLegacyIdOnBoth(boolean value)
+        {
+        }
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -19,6 +19,7 @@ import com.facebook.swift.codec.ThriftConstructor;
 import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftStruct;
 import com.google.common.reflect.TypeToken;
+
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Type;

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -103,10 +103,12 @@ public class ThriftMethodMetadata
             }
 
             short parameterId = Short.MIN_VALUE;
+            boolean isLegacyId = false;
             String parameterName = null;
             Requiredness parameterRequiredness = Requiredness.UNSPECIFIED;
             if (thriftField != null) {
                 parameterId = thriftField.value();
+                isLegacyId = thriftField.isLegacyId();
                 parameterRequiredness = thriftField.requiredness();
                 if (!thriftField.name().isEmpty()) {
                     parameterName = thriftField.name();
@@ -133,6 +135,7 @@ public class ThriftMethodMetadata
 
             ThriftFieldMetadata fieldMetadata = new ThriftFieldMetadata(
                     parameterId,
+                    isLegacyId,
                     parameterRequiredness,
                     thriftType,
                     parameterName,

--- a/swift-service/src/test/java/com/facebook/swift/service/metadata/TestThriftMethodLegacyIds.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/metadata/TestThriftMethodLegacyIds.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.metadata;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.metadata.ReflectionHelper;
+import com.facebook.swift.codec.metadata.ThriftCatalog;
+import com.facebook.swift.codec.metadata.ThriftFieldMetadata;
+import com.facebook.swift.service.ThriftMethod;
+
+public class TestThriftMethodLegacyIds
+{
+    @DataProvider
+    public Object[][] getTestCasesWithLegacyFieldIds()
+    {
+        List<Object[]> cases = new ArrayList<>();
+        for (Method m : ReflectionHelper.findAnnotatedMethods(DummyService.class, ThriftMethod.class)) {
+            String name = m.getName();
+            if (name.startsWith("validNonLegacy")) {
+                continue;
+            } else if (name.startsWith("validLegacy")) {
+                cases.add(new Object[] { new Method[] { m } });
+            } else if (name.startsWith("invalid")) {
+                continue;
+            } else {
+                throw new AssertionError("Weird method " + m);
+            }
+        }
+        return cases.toArray(new Object[][] {});
+    }
+
+    @Test(dataProvider="getTestCasesWithLegacyFieldIds")
+    public void testLegacyFieldIds(Method[] mBox)
+    {
+        Method m = mBox[0];
+        ThriftMethodMetadata metadata = new ThriftMethodMetadata("DummyService", m, new ThriftCatalog());
+        List<ThriftFieldMetadata> parameters = metadata.getParameters();
+
+        assertThat(parameters)
+                .as("parameters")
+                .hasSize(1);
+
+        assertThat(parameters.get(0).getId())
+                .as("the parameter's ID")
+                .isNegative();
+    }
+
+    @DataProvider
+    public Object[][] getTestCasesWithNonLegacyFieldIds()
+    {
+        List<Object[]> cases = new ArrayList<>();
+        for (Method m : ReflectionHelper.findAnnotatedMethods(DummyService.class, ThriftMethod.class)) {
+            String name = m.getName();
+            if (name.startsWith("validNonLegacy")) {
+                cases.add(new Object[] { new Method[] { m } });
+            } else if (name.startsWith("validLegacy")) {
+                continue;
+            } else if (name.startsWith("invalid")) {
+                continue;
+            } else {
+                throw new AssertionError("Weird method " + m);
+            }
+        }
+        return cases.toArray(new Object[][] {});
+    }
+
+    @Test(dataProvider="getTestCasesWithNonLegacyFieldIds")
+    public void testNonLegacyFieldIds(Method[] mBox)
+    {
+        Method m = mBox[0];
+        ThriftMethodMetadata metadata = new ThriftMethodMetadata("DummyService", m, new ThriftCatalog());
+        List<ThriftFieldMetadata> parameters = metadata.getParameters();
+
+        assertThat(parameters)
+                .as("parameters")
+                .hasSize(1);
+
+        assertThat(parameters.get(0).getId())
+                .as("the parameter's ID")
+                .isGreaterThanOrEqualTo((short) 0);
+    }
+
+   @DataProvider
+   public Object[][] getTestCasesWithInvalids()
+   {
+       List<Object[]> cases = new ArrayList<>();
+       for (Method m : ReflectionHelper.findAnnotatedMethods(DummyService.class, ThriftMethod.class)) {
+           String name = m.getName();
+           if (name.startsWith("validNonLegacy")) {
+               continue;
+           } else if (name.startsWith("validLegacy")) {
+               continue;
+           } else if (name.startsWith("invalid")) {
+               cases.add(new Object[] { new Method[] { m } });
+           } else {
+               throw new AssertionError("Weird method " + m);
+           }
+       }
+       return cases.toArray(new Object[][] {});
+   }
+
+   @Test(
+       dataProvider = "getTestCasesWithInvalids",
+       expectedExceptions = IllegalArgumentException.class,
+       expectedExceptionsMessageRegExp = "isLegacyId (must|should only) be specified.*"
+   )
+   public void testInvalids(Method[] mBox)
+   {
+       Method m = mBox[0];
+       new ThriftMethodMetadata("DummyService", m, new ThriftCatalog());
+   }
+
+
+    public static interface DummyService {
+        @ThriftMethod
+        public void validNonLegacyFieldId1(@ThriftField(isLegacyId=false) boolean blah);
+
+        @ThriftMethod
+        public void validNonLegacyFieldId2(@ThriftField(4) boolean blah);
+
+        @ThriftMethod
+        public void validNonLegacyFieldId3(@ThriftField(value=4, isLegacyId=false) boolean blah);
+
+        @ThriftMethod
+        public void invalidSaysLegacyButShouldnt1(@ThriftField(value=4, isLegacyId=true) boolean blah);
+
+        @ThriftMethod
+        public void invalidSaysLegacyButShouldnt2(@ThriftField(isLegacyId=true) boolean blah);
+
+
+        @ThriftMethod
+        public void validLegacyFieldId(@ThriftField(value=-4, isLegacyId=true) boolean blah);
+
+        @ThriftMethod
+        public void invalidIsLegacyButDoesntSay(@ThriftField(value=-4) boolean blah);
+
+        @ThriftMethod
+        public void invalidIsLegacyButSaysNot(@ThriftField(value=-4, isLegacyId=false) boolean blah);
+    }
+}


### PR DESCRIPTION
Summary:

Negative field IDs are strongly discouraged, but some old services used
them and are stuck with them to maintain wire compatibility with older
clients. Don't error out on them.

Test Plan:

grep in swift-codec for `> 0`, `>= 0`, `< 0`, `<= 0`, (and the other way
around). A bunch of ThriftStructs which didn't used to be able to be
loaded are now.

Reviewers: alandau, andrewcox, haijunz

CC:
