### PR TITLE
Remove the "structs must be final" check. Handle exception subclasses

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -67,7 +67,6 @@ import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.newArrayListWithCapacity;
 import static com.google.common.collect.Sets.newTreeSet;
-
 import static java.util.Arrays.asList;
 
 @NotThreadSafe
@@ -177,9 +176,6 @@ public abstract class AbstractThriftMetadataBuilder
         // Verify struct class is public and final
         if (!Modifier.isPublic(getStructClass().getModifiers())) {
             metadataErrors.addError("%s class '%s' is not public", annotationName, structClassName);
-        }
-        if (!Modifier.isFinal(getStructClass().getModifiers())) {
-            metadataErrors.addError("%s class '%s' is not final (thrift does not support polymorphic data types)", annotationName, structClassName);
         }
 
         if (!getStructClass().isAnnotationPresent(annotation)) {

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadataBuilder.java
@@ -339,4 +339,16 @@ public class TestThriftStructMetadataBuilder
         {
         }
     }
+
+    @Test
+    public void testNonFinalStructsOk()
+    {
+        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(new ThriftCatalog(), NotFinalStruct.class);
+        builder.build();
+    }
+
+    @ThriftStruct
+    public static class NotFinalStruct
+    {
+    }
 }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftUnionMetadataBuilder.java
@@ -18,7 +18,6 @@ package com.facebook.swift.codec.metadata;
 import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftUnion;
 import com.facebook.swift.codec.ThriftUnionId;
-
 import org.testng.annotations.Test;
 
 import java.util.concurrent.locks.Lock;
@@ -231,5 +230,18 @@ public class TestThriftUnionMetadataBuilder
         public void setFoo(short value)
         {
         }
+    }
+
+    @Test
+    public void testNonFinalUnionOk()
+    {
+        ThriftUnionMetadataBuilder builder = new ThriftUnionMetadataBuilder(new ThriftCatalog(), NotFinalUnion.class);
+        builder.build();
+    }
+
+    @ThriftUnion
+    public static class NotFinalUnion
+    {
+        @ThriftUnionId public short id;
     }
 }

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
@@ -191,6 +191,20 @@ public class ThriftMethodProcessor
                     contextChain.preWriteException(t);
                     if (!oneway) {
                         ExceptionProcessor exceptionCodec = exceptionCodecs.get(t.getClass());
+
+                        if (exceptionCodec == null) {
+                            // In case the method throws a subtype of one of its declared
+                            // exceptions, exact lookup will fail. We need to simulate it.
+                            // (This isn't a problem for normal returns because there the
+                            // output codec is decided in advance.)
+                            for (Map.Entry<Class<?>, ExceptionProcessor> entry : exceptionCodecs.entrySet()) {
+                                if (entry.getKey().isAssignableFrom(t.getClass())) {
+                                    exceptionCodec = entry.getValue();
+                                    break;
+                                }
+                            }
+                        }
+
                         if (exceptionCodec != null) {
                             // write expected exception response
                             writeResponse(

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionService.java
@@ -47,4 +47,10 @@ public interface ExceptionService
 
     @ThriftMethod
     public void throwUnexpectedNonThriftUncheckedException() throws TException;
+
+    @ThriftMethod(exception = { @ThriftException(type = ThriftCheckedSubclassableException.class, id = 1) })
+    public void throwSubclassableException() throws ThriftCheckedSubclassableException, TException;
+
+    @ThriftMethod(exception = { @ThriftException(type = ThriftCheckedSubclassableException.class, id = 1) })
+    public void throwSubclassOfSubclassableException() throws ThriftCheckedSubclassableException, TException;
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionServiceHandler.java
@@ -59,4 +59,15 @@ public class ExceptionServiceHandler implements ExceptionService
       throws TException {
         throw new NonThriftUncheckedException();
     }
+
+    @Override
+    public void throwSubclassableException() throws ThriftCheckedSubclassableException, TException {
+        throw new ThriftCheckedSubclassableException("not subclass");
+    }
+
+    @Override
+    public void throwSubclassOfSubclassableException() throws ThriftCheckedSubclassableException,
+            TException {
+        throw new ThriftCheckedSubclassableException.Subclass("is subclass");
+    }
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionTest.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionTest.java
@@ -69,6 +69,38 @@ public class ExceptionTest extends SuiteBase<ExceptionService, ExceptionServiceC
     }
 
     @Test
+    public void testThrowSubclassableException() throws TException {
+        try {
+            getClient().throwSubclassableException();
+            fail("Expected a ThriftCheckedSubclassableException");
+        }
+        catch (ThriftCheckedSubclassableException e) {
+            assertEquals(
+                    e.getMessage(),
+                    "not subclass",
+                    "Expected a 'not subclass' ThriftCheckedSubclassableException");
+        }
+    }
+
+    @Test
+    public void testThrowSubclassOfSubclassableException() throws TException {
+        try {
+            getClient().throwSubclassOfSubclassableException();
+            fail("Expected a ThriftCheckedSubclassableException");
+        }
+        catch (ThriftCheckedSubclassableException e) {
+            assertEquals(
+                    e.getMessage(),
+                    "is subclass",
+                    "Expected a 'is subclass' ThriftCheckedSubclassableException");
+            assertEquals(
+                    e.getClass(),
+                    ThriftCheckedSubclassableException.class,
+                    "Expected TCSE.Subclass to get serialized as a TCSE");
+        }
+    }
+
+    @Test
     public void testMissingMethod() {
         try {
             getClient().missingMethod();

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftCheckedSubclassableException.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ThriftCheckedSubclassableException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service.exceptions;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+
+@ThriftStruct
+public class ThriftCheckedSubclassableException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    @ThriftConstructor
+    public ThriftCheckedSubclassableException(@ThriftField String message) {
+        super(message);
+    }
+
+    @ThriftField(1)
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    public static class Subclass extends ThriftCheckedSubclassableException {
+        private static final long serialVersionUID = 1L;
+
+        public Subclass(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
We have a codebase which (for better or worse) has a bunch of specific subclasses of a more general ServerErrorException `@ThriftStruct`. Most of our `@ThriftMethods` are declared as throwing a SEE, but the subclasses are used internally for more precise things. Without some non-trivial codemods to our app, this is I think the best we can do.

The first commit introduces an annotation which bypasses the "struct must be final" check. Using this annotation makes the metadata work, and returning a subclass of a struct would be fine (since the codec used when a method returns successfully is determined by the method's return type and not by its returned object.)

The second commit makes exceptions work. It is necessary because the codec used when a method throws is determined not by the method declaration but by the type of the thrown object.

Both commits are independent, in the sense that the `src/main` changes apply cleanly in either order. They're in a single PR because it doesn't make sense to have the second commit without the first-- it would add correct but effectively dead code.
