### PR TITLE
Allows codec to work with auto-value types

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/CompilerThriftCodecFactory.java
@@ -44,7 +44,7 @@ public class CompilerThriftCodecFactory implements ThriftCodecFactory
 
     public CompilerThriftCodecFactory(boolean debug)
     {
-        this(debug, getPriviledgedClassLoader(CompilerThriftCodecFactory.class.getClassLoader()));
+        this(debug, CompilerThriftCodecFactory.class.getClassLoader());
     }
 
     public CompilerThriftCodecFactory(boolean debug, ClassLoader parent)

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/DynamicClassLoader.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/DynamicClassLoader.java
@@ -15,21 +15,56 @@
  */
 package com.facebook.swift.codec.internal.compiler;
 
-import com.facebook.swift.codec.ThriftCodec;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static com.google.common.base.Throwables.propagate;
 
 /**
- * A ClassLoader that allows for loading of classes from an array of bytes.
+ * Codecs are defined at runtime in the same package as their type parameters. We avoid access
+ * issues by defining them in the same classloader.
  */
-public class DynamicClassLoader extends ClassLoader
+public class DynamicClassLoader
 {
-    public DynamicClassLoader(ClassLoader parent)
+    final ClassLoader delegate;
+    private final Method defineClass;
+
+    DynamicClassLoader(ClassLoader delegate)
     {
-        super(parent);
+        this.delegate = delegate;
+        try {
+            this.defineClass = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
+            this.defineClass.setAccessible(true);
+        }
+        catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
     }
 
-    public Class<?> defineClass(String name, byte[] byteCode)
-            throws ClassFormatError
+    /**
+     * In normal case, there is a single swift codec generating a given type within the scope of a
+     * classloader. This means a codec class would normally be generated only once per type. In
+     * case of misconfiguration, this falls back to loading the type instead of propagating an error
+     * when the codec already exists.
+     */
+    Class<?> defineOrLoadClass(String name, byte[] byteCode)
     {
-        return defineClass(name, byteCode, 0, byteCode.length);
+        try {
+            return (Class<?>) defineClass.invoke(delegate, name, byteCode, 0, byteCode.length);
+        }
+        catch (IllegalAccessException e) {
+            throw new AssertionError(e); // already set accessible, so this shouldn't happen.
+        }
+        catch (InvocationTargetException e) {
+            if (e.getCause() instanceof LinkageError) {
+                try {
+                    return delegate.loadClass(name);
+                }
+                catch (ClassNotFoundException cnfe) {
+                    // linkage error wasn't due to lost race
+                }
+            }
+            throw propagate(e.getCause());
+        }
     }
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
@@ -95,8 +95,6 @@ import static java.lang.String.format;
 @NotThreadSafe
 public class ThriftCodecByteCodeGenerator<T>
 {
-    private static final String PACKAGE = "$wift";
-
     private static final Map<ThriftProtocolType, Method> READ_METHODS;
     private static final Map<ThriftProtocolType, Method> WRITE_METHODS;
 
@@ -172,11 +170,11 @@ public class ThriftCodecByteCodeGenerator<T>
         // Run the asm verifier only in debug mode (prints a ton of info)
         if (debug) {
             ClassReader reader = new ClassReader(byteCode);
-            CheckClassAdapter.verify(reader, classLoader, true, new PrintWriter(System.out));
+            CheckClassAdapter.verify(reader, classLoader.delegate, true, new PrintWriter(System.out));
         }
 
         // load the class
-        Class<?> codecClass = classLoader.defineClass(codecType.getClassName().replace('/', '.'), byteCode);
+        Class<?> codecClass = classLoader.defineOrLoadClass(codecType.getClassName().replace('/', '.'), byteCode);
         try {
             Class<?>[] types = parameters.getTypes();
             Constructor<?> constructor = codecClass.getConstructor(types);
@@ -1091,7 +1089,7 @@ public class ThriftCodecByteCodeGenerator<T>
 
     private ParameterizedType toCodecType(ThriftStructMetadata metadata)
     {
-        return type(PACKAGE + "/" + type(metadata.getStructClass()).getClassName() + "Codec");
+        return type(type(metadata.getStructClass()).getClassName() + "Codec");
     }
 
     private static class ConstructorParameters

--- a/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
@@ -215,7 +215,15 @@ public abstract class AbstractThriftCodecManagerTest
             throws Exception
     {
         BonkBuilder bonkBuilder = new BonkBuilder("message", 42);
-        testRoundTripSerialize(bonkBuilder, new TCompactProtocol.Factory());
+        testRoundTripSerialize(TypeToken.of(BonkBuilder.class), bonkBuilder, new TCompactProtocol.Factory());
+    }
+
+    @Test
+    public void testGenerated()
+        throws Exception
+    {
+        BonkGenerated bonkGenerated = BonkGenerated.builder().message("message").type(42).build();
+        testRoundTripSerialize(TypeToken.of(BonkGenerated.class), bonkGenerated, new TCompactProtocol.Factory());
     }
 
     @Test

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkGenerated.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkGenerated.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2015 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec;
+
+@ThriftStruct(value = "BonkGenerated", builder = Generated_BonkGenerated.Builder.class)
+public abstract class BonkGenerated
+{
+
+    public static Builder builder()
+    {
+        return new Generated_BonkGenerated.Builder();
+    }
+
+    @ThriftField(value = 1)
+    public abstract String message();
+
+    @ThriftField(value = 2)
+    public abstract int type();
+
+    public interface Builder
+    {
+        @ThriftField
+        Builder message(String message);
+
+        @ThriftField
+        Builder type(int type);
+
+        @ThriftConstructor
+        BonkGenerated build();
+    }
+}
+
+final class Generated_BonkGenerated extends BonkGenerated
+{
+
+    private final String message;
+    private final int type;
+
+    private Generated_BonkGenerated(String message, int type)
+    {
+        this.message = message;
+        this.type = type;
+    }
+
+    @ThriftField(value = 1)
+    @Override
+    public String message()
+    {
+        return message;
+    }
+
+    @ThriftField(value = 2)
+    @Override
+    public int type()
+    {
+        return type;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BonkGenerated{"
+            + "message=" + message + ", "
+            + "type=" + type
+            + "}";
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof BonkGenerated) {
+            BonkGenerated that = (BonkGenerated) o;
+            return ((this.message == null) ? (that.message() == null) : this.message.equals(that.message()))
+                && (this.type == that.type());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int h = 1;
+        h *= 1000003;
+        h ^= (message == null) ? 0 : message.hashCode();
+        h *= 1000003;
+        h ^= type;
+        return h;
+    }
+
+    static final class Builder implements BonkGenerated.Builder
+    {
+        private String message;
+        private int type;
+
+        @Override
+        public BonkGenerated.Builder message(String message)
+        {
+            this.message = message;
+            return this;
+        }
+
+        @Override
+        public BonkGenerated.Builder type(int type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        @Override
+        public BonkGenerated build()
+        {
+            return new Generated_BonkGenerated(message, type);
+        }
+    }
+}


### PR DESCRIPTION
[Auto-Value](https://github.com/google/auto/tree/master/value) writes immutable value types based on a user defined abstract class. It also supports generating factories, based on a user-defined interface. The following change adjusts swift codec to work both reflectively and via ASM.

Here's an example type that works following this change:

``` java
@AutoValue
@ThriftStruct(value = "LogEntry", builder = AutoValue_LogEntry.Builder.class)
public abstract class LogEntry {

  public static Builder builder() {
    return new AutoValue_LogEntry.Builder();
  }

  @ThriftField(value = 1)
  public abstract String category();

  @ThriftField(value = 2)
  public abstract String message();

  @AutoValue.Builder
  public interface Builder {

    @ThriftField(value = 1)
    Builder category(String category);

    @ThriftField(value = 2)
    Builder message(String message);

    @ThriftConstructor
    LogEntry build();
  }
}
```

The notable change for ASM is that generated codecs are now placed in the same package as the value type, and defined in the same classloader. Also, this makes sure we use the correct injection method (ex. from the implementing class as opposed to the interface).

Tests pass and I've also verified with zipkin.

Closes #273
