### PR TITLE
equalsImpl: <if(fields)> { Objects.equals()...}<else>true<endif>

### DIFF
--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -280,7 +280,7 @@ public boolean equals(Object o) {
     <context.javaName> other = (<context.javaName>)o;
 
     return
-        <context.fields : { field |<_checkFieldEquality(field)>}; separator=" &&\n">;
+        <if(context.fields)><context.fields : { field |<_checkFieldEquality(field)>}; separator=" &&\n"><else>true<endif>;
 }
 >>
 


### PR DESCRIPTION
current implementation of equalsImpl fails to generate valid java if there aren't any fields in the class. this special cases empty fields and returns true
