### PR TITLE
Fix swift-maven-plugin integration tests

### DIFF
--- a/swift-maven-plugin/pom.xml
+++ b/swift-maven-plugin/pom.xml
@@ -125,6 +125,23 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <!-- Normally surefire tests run in an isolated environment, not carrying in any of the -->
+            <!-- default configuration, but integration tests for this plugin download a few versions -->
+            <!-- of maven to test the plugin against them. These downloads may need to use the network -->
+            <!-- settings from the user's environment. -->
+            <java.net.preferIPv6Addresses>${java.net.preferIPv6Addresses}</java.net.preferIPv6Addresses>
+            <http.proxyHost>${http.proxyHost}</http.proxyHost>
+            <http.proxyPort>${http.proxyPort}</http.proxyPort>
+            <http.nonProxyHosts>${http.nonProxyHosts}</http.nonProxyHosts>
+          </systemProperties>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This test downloads alternate versions of maven to test the plugin against, from a maven repo. Since it was running inside surefire (which for uniform testing purposes tries to provdie a clean environment separate from the user's environment) it was not respecting network properties configured by the user and so the download could fail if you were on an IPv6-only machine, or behind a proxy, etc.
