### PR TITLE
[codec] Fully support abstract struct types.

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/ThriftCodecByteCodeGenerator.java
@@ -361,7 +361,7 @@ public class ThriftCodecByteCodeGenerator<T>
             if (readMethod == null) {
                 throw new IllegalArgumentException("Unsupported field type " + field.getThriftType().getProtocolType());
             }
-            read.invokeVirtual(readMethod);
+            read.invokeMethod(readMethod);
 
             // todo this cast should be based on readMethod return type and fieldType (or coercion type)
             // add cast if necessary
@@ -559,7 +559,7 @@ public class ThriftCodecByteCodeGenerator<T>
             if (readMethod == null) {
                 throw new IllegalArgumentException("Unsupported field type " + field.getThriftType().getProtocolType());
             }
-            read.invokeVirtual(readMethod);
+            read.invokeMethod(readMethod);
 
             // todo this cast should be based on readMethod return type and fieldType (or coercion type)
             // add cast if necessary
@@ -750,7 +750,7 @@ public class ThriftCodecByteCodeGenerator<T>
         }
 
         // invoke the method
-        read.invokeVirtual(methodInjection.getMethod());
+        read.invokeMethod(methodInjection.getMethod());
 
         // if method has a return, we need to pop it off the stack
         if (methodInjection.getMethod().getReturnType() != void.class) {
@@ -776,7 +776,7 @@ public class ThriftCodecByteCodeGenerator<T>
             }
 
             // invoke the method
-            read.invokeVirtual(builderMethod.getMethod())
+            read.invokeMethod(builderMethod.getMethod())
                     .storeVariable(instance);
         }
     }
@@ -947,7 +947,7 @@ public class ThriftCodecByteCodeGenerator<T>
         if (writeMethod == null) {
             throw new IllegalArgumentException("Unsupported field type " + field.getThriftType().getProtocolType());
         }
-        write.invokeVirtual(writeMethod);
+        write.invokeMethod(writeMethod);
 
         //
         // If not written because of a null, clean-up the stack
@@ -989,7 +989,7 @@ public class ThriftCodecByteCodeGenerator<T>
             }
             else if (extraction instanceof ThriftMethodExtractor) {
                 ThriftMethodExtractor methodExtractor = (ThriftMethodExtractor) extraction;
-                write.invokeVirtual(methodExtractor.getMethod());
+                write.invokeMethod(methodExtractor.getMethod());
                 if (methodExtractor.isGeneric()) {
                   write.checkCast(type(methodExtractor.getType()));
                 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/byteCode/MethodDefinition.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/internal/compiler/byteCode/MethodDefinition.java
@@ -40,6 +40,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -78,6 +79,7 @@ import static org.objectweb.asm.Opcodes.IFEQ;
 import static org.objectweb.asm.Opcodes.IFNONNULL;
 import static org.objectweb.asm.Opcodes.IFNULL;
 import static org.objectweb.asm.Opcodes.ILOAD;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
@@ -380,11 +382,13 @@ public class MethodDefinition
         return this;
     }
 
-    public MethodDefinition invokeVirtual(Method method)
+    public MethodDefinition invokeMethod(Method method)
     {
+        boolean isInterface = Modifier.isInterface(method.getDeclaringClass().getModifiers());
+        int opcode = isInterface ? INVOKEINTERFACE : INVOKEVIRTUAL;
         instructionList.add(
                 new MethodInsnNode(
-                        INVOKEVIRTUAL,
+                        opcode,
                         Type.getInternalName(method.getDeclaringClass()),
                         method.getName(),
                         Type.getMethodDescriptor(method)

--- a/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
@@ -219,6 +219,36 @@ public abstract class AbstractThriftCodecManagerTest
     }
 
     @Test
+    public void testBuilderAbstract()
+            throws Exception
+    {
+        BonkBuilderAbstract bonkBuilderAbstract =
+                new BonkBuilderAbstract.Builder()
+                        .setMessage("message")
+                        .setType(42)
+                        .create();
+        testRoundTripSerialize(
+                TypeToken.of(BonkBuilderAbstract.class),
+                bonkBuilderAbstract,
+                new TCompactProtocol.Factory());
+    }
+
+    @Test
+    public void testBuilderInterface()
+            throws Exception
+    {
+        BonkBuilderInterface bonkBuilderInterface =
+                new BonkBuilderInterface.Builder()
+                        .setMessage("message")
+                        .setType(42)
+                        .create();
+        testRoundTripSerialize(
+                TypeToken.of(BonkBuilderInterface.class),
+                bonkBuilderInterface,
+                new TCompactProtocol.Factory());
+    }
+
+    @Test
     public void testArraysManual()
             throws Exception
     {

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkBuilderAbstract.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkBuilderAbstract.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2015 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@ThriftStruct(value = "Bonk", builder = BonkBuilderAbstract.Builder.class)
+public abstract class BonkBuilderAbstract
+{
+    BonkBuilderAbstract()
+    {
+        // hidden
+    }
+
+    @ThriftField(1)
+    public abstract String getMessage();
+
+    @ThriftField(2)
+    public abstract int getType();
+
+    public static final class Builder
+    {
+        @Immutable
+        static final class ImmutableBonk extends BonkBuilderAbstract
+        {
+            private final String message;
+            private final int type;
+
+            public ImmutableBonk(String message, int type)
+            {
+                this.message = message;
+                this.type = type;
+            }
+
+            @Override
+            public String getMessage()
+            {
+                return message;
+            }
+
+            @Override
+            public int getType()
+            {
+                return type;
+            }
+
+            @Override
+            public int hashCode()
+            {
+                int result = message != null ? message.hashCode() : 0;
+                result = 31 * result + type;
+                return result;
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                BonkBuilderAbstract that = (BonkBuilderAbstract) o;
+
+                if (type != that.getType()) {
+                    return false;
+                }
+                if (message != null ? !message.equals(that.getMessage()) : that.getMessage() != null) {
+                    return false;
+                }
+
+                return true;
+            }
+
+            @Override
+            public String toString()
+            {
+                final StringBuilder sb = new StringBuilder();
+                sb.append("BonkBuilderAbstract");
+                sb.append("{message='").append(message).append('\'');
+                sb.append(", type=").append(type);
+                sb.append('}');
+                return sb.toString();
+            }
+        }
+
+        private String message;
+        private int type;
+
+        @ThriftField
+        public Builder setMessage(String message)
+        {
+            this.message = message;
+            return this;
+        }
+
+        @ThriftField
+        public Builder setType(int type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        @ThriftConstructor
+        public BonkBuilderAbstract create()
+        {
+            return new ImmutableBonk(message, type);
+        }
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/BonkBuilderInterface.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/BonkBuilderInterface.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+@ThriftStruct(value = "Bonk", builder = BonkBuilderInterface.Builder.class)
+public interface BonkBuilderInterface
+{
+    @ThriftField(1)
+    String getMessage();
+
+    @ThriftField(2)
+    int getType();
+
+    final class Builder
+    {
+        @Immutable
+        static final class ImmutableBonk implements BonkBuilderInterface
+        {
+            private final String message;
+            private final int type;
+
+            public ImmutableBonk(String message, int type)
+            {
+                this.message = message;
+                this.type = type;
+            }
+
+            @Override
+            public String getMessage()
+            {
+                return message;
+            }
+
+            @Override
+            public int getType()
+            {
+                return type;
+            }
+
+            @Override
+            public int hashCode()
+            {
+                int result = message != null ? message.hashCode() : 0;
+                result = 31 * result + type;
+                return result;
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                BonkBuilderInterface that = (BonkBuilderInterface) o;
+
+                if (type != that.getType()) {
+                    return false;
+                }
+                if (message != null ? !message.equals(that.getMessage()) : that.getMessage() != null) {
+                    return false;
+                }
+
+                return true;
+            }
+
+            @Override
+            public String toString()
+            {
+                final StringBuilder sb = new StringBuilder();
+                sb.append("BonkBuilderAbstract");
+                sb.append("{message='").append(message).append('\'');
+                sb.append(", type=").append(type);
+                sb.append('}');
+                return sb.toString();
+            }
+        }
+
+        private String message;
+        private int type;
+
+        @ThriftField
+        public Builder setMessage(String message)
+        {
+            this.message = message;
+            return this;
+        }
+
+        @ThriftField
+        public Builder setType(int type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        @ThriftConstructor
+        public BonkBuilderInterface create()
+        {
+            return new ImmutableBonk(message, type);
+        }
+    }
+}


### PR DESCRIPTION
This addresses: https://github.com/facebook/swift/issues/279

Commit 243fa411 removed the 'structs must be final' check which paved
the way for builders to produce (hidden) implementations of abstract
structs.  Although a pure abstract struct class can be used today, a
struct interface cannot due to remaining assumptions in the
`ThriftCodecByteCodeGenerator` that the struct type is a class.

This change fixes up the `ThriftCodecByteCodeGenerator` to handle
structs of interface type and adds tests to cover both the abstract
class and interface struct builder cases.

Test Plan: Unit tests included. Also, works in a spike for Apache Aurora
where swift is being explored as a dual REST/thrift interface generator:
https://issues.apache.org/jira/browse/AURORA-987

Reviewers: @andrewcox, @jesboat, @alandau
