### PR TITLE
Fix issue where isLegacyId is not added to generated files where the field is negative.

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/FieldContext.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/FieldContext.java
@@ -57,6 +57,11 @@ public class FieldContext
     {
         return requiredness;
     }
+    
+    public boolean isLegacyId() 
+    {
+        return id < 0;
+    }
 
     public short getId()
     {

--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -223,7 +223,7 @@ _annotatedExceptions(method) ::= <<
 >>
 
 _fieldAnnotation(field) ::= <<
-@ThriftField(value=<field.id>, name="<field.name>"<if(field.requiredness)>, requiredness=Requiredness.<field.requiredness><endif>)
+@ThriftField(value=<field.id>, name="<field.name>"<if(field.requiredness)>, requiredness=Requiredness.<field.requiredness><endif><if(field.legacyId)>, isLegacyId=true<endif>)
 >>
 
 _params(parameters) ::= <<


### PR DESCRIPTION
Annotation field wasn't being set at all, so modified the template to handle that. Maestro.thrift has negative ids, so there is coverage.

This was a runtime, rather than compile time, issue.
