### PR TITLE
Allow for Swift plugin to bypass long directory scans in certain circumstances

### DIFF
--- a/swift-maven-plugin/src/main/java/com/facebook/mojo/SwiftMojo.java
+++ b/swift-maven-plugin/src/main/java/com/facebook/mojo/SwiftMojo.java
@@ -46,7 +46,8 @@ import static java.lang.String.format;
  * Process IDL files and generates source code from the IDL files.
  */
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
-public class SwiftMojo extends AbstractMojo {
+public class SwiftMojo extends AbstractMojo
+{
 
     private static final Pattern scanRequiredPattern
             = Pattern.compile("^[/\\\\]|[*?]|\\.\\.|[/\\\\]$");
@@ -58,17 +59,17 @@ public class SwiftMojo extends AbstractMojo {
     private boolean skip = false;
 
     /**
-     * Override java package for the generated classes. If unset, the java
-     * namespace from the IDL files is used. If a value is set here, the java
-     * package definition from the IDL files is ignored.
+     * Override java package for the generated classes. If unset, the java namespace from
+     * the IDL files is used. If a value is set here, the java package definition from
+     * the IDL files is ignored.
      */
     @Parameter
     private String overridePackage = null;
 
     /**
-     * Give a default Java package for generated classes if the IDL files do not
-     * contain a java namespace definition. This package is only used if the IDL
-     * files do not contain a java namespace definition.
+     * Give a default Java package for generated classes if the IDL files do not contain
+     * a java namespace definition. This package is only used if the IDL files do not
+     * contain a java namespace definition.
      */
     @Parameter
     private String defaultPackage = null;
@@ -86,17 +87,16 @@ public class SwiftMojo extends AbstractMojo {
     private File outputFolder = null;
 
     /**
-     * Generate code for included IDL files. If true, generate Java code for all
-     * IDL files that are listed in the idlFiles set and all IDL files loaded
-     * through include statements. Default is false (generate only code for
-     * explicitly listed IDL files).
+     * Generate code for included IDL files. If true, generate Java code for all IDL
+     * files that are listed in the idlFiles set and all IDL files loaded through include
+     * statements. Default is false (generate only code for explicitly listed IDL files).
      */
     @Parameter(defaultValue = "false")
     private boolean generateIncludedCode = false;
 
     /**
-     * Add {@link org.apache.thrift.TException} to each method signature. This
-     * exception is thrown when a thrift internal error occurs.
+     * Add {@link org.apache.thrift.TException} to each method signature. This exception
+     * is thrown when a thrift internal error occurs.
      */
     @Parameter(defaultValue = "true")
     private boolean addThriftExceptions = true;
@@ -108,15 +108,13 @@ public class SwiftMojo extends AbstractMojo {
     private boolean addCloseableInterface = false;
 
     /**
-     * Generated exceptions extends {@link RuntimeException}, not
-     * {@link Exception}.
+     * Generated exceptions extends {@link RuntimeException}, not {@link Exception}.
      */
     @Parameter(defaultValue = "true")
     private boolean extendRuntimeException = true;
 
     /**
-     * Select the flavor of the generated source code. Default is
-     * "java-regular".
+     * Select the flavor of the generated source code. Default is "java-regular".
      */
     @Parameter(defaultValue = "java-regular")
     private String codeFlavor = "java-regular";
@@ -131,35 +129,42 @@ public class SwiftMojo extends AbstractMojo {
     private MavenProject project = null;
 
     @Override
-    public final void execute() throws MojoExecutionException, MojoFailureException {
-        try {
-            if (!skip) {
+    public final void execute() throws MojoExecutionException, MojoFailureException
+    {
+        try
+        {
+            if (!skip)
+            {
 
                 final File inputFolder = new File(idlFiles.getDirectory());
 
                 final List<File> files = getFiles(inputFolder);
 
                 final SwiftGeneratorConfig.Builder configBuilder = SwiftGeneratorConfig.builder()
-                        .inputBase(inputFolder.toURI())
-                        .outputFolder(outputFolder)
-                        .overridePackage(overridePackage)
-                        .defaultPackage(defaultPackage)
-                        .generateIncludedCode(generateIncludedCode)
-                        .codeFlavor(codeFlavor);
+                    .inputBase(inputFolder.toURI())
+                    .outputFolder(outputFolder)
+                    .overridePackage(overridePackage)
+                    .defaultPackage(defaultPackage)
+                    .generateIncludedCode(generateIncludedCode)
+                    .codeFlavor(codeFlavor);
 
-                if (usePlainJavaNamespace) {
+                if (usePlainJavaNamespace)
+                {
                     configBuilder.addTweak(SwiftGeneratorTweak.USE_PLAIN_JAVA_NAMESPACE);
                 }
 
-                if (addThriftExceptions) {
+                if (addThriftExceptions)
+                {
                     configBuilder.addTweak(SwiftGeneratorTweak.ADD_THRIFT_EXCEPTION);
                 }
 
-                if (addCloseableInterface) {
+                if (addCloseableInterface)
+                {
                     configBuilder.addTweak(SwiftGeneratorTweak.ADD_CLOSEABLE_INTERFACE);
                 }
 
-                if (extendRuntimeException) {
+                if (extendRuntimeException)
+                {
                     configBuilder.addTweak(SwiftGeneratorTweak.EXTEND_RUNTIME_EXCEPTION);
                 }
 
@@ -168,7 +173,9 @@ public class SwiftMojo extends AbstractMojo {
 
                 project.addCompileSourceRoot(outputFolder.getPath());
             }
-        } catch (Exception e) {
+        } 
+        catch (Exception e)
+        {
             Throwables.propagateIfInstanceOf(e, MojoExecutionException.class);
             Throwables.propagateIfInstanceOf(e, MojoFailureException.class);
 
@@ -177,7 +184,8 @@ public class SwiftMojo extends AbstractMojo {
         }
     }
 
-    private static boolean requiresScan(String pattern) {
+    private static boolean requiresScan(String pattern)
+    {
         Matcher matcher = scanRequiredPattern.matcher(pattern);
         return matcher.find();
     }
@@ -185,7 +193,8 @@ public class SwiftMojo extends AbstractMojo {
     @VisibleForTesting
     static boolean canBypassScan(
             List<String> includedFiles,
-            List<String> excludedFiles) {
+            List<String> excludedFiles)
+    {
         // The directory scan can be bypassed, IFF
         // 1) There are no excludes
         // 2) There is at least one include string
@@ -202,12 +211,14 @@ public class SwiftMojo extends AbstractMojo {
     }
 
     @SuppressWarnings("unchecked")
-    private List<File> getFiles(File inputFolder) throws IOException {
+    private List<File> getFiles(File inputFolder) throws IOException
+    {
         // On large source trees under the input folder, the directory
         // search can take a very long time. 
         if (canBypassScan(
                 idlFiles.getIncludes(),
-                idlFiles.getExcludes())) {
+                idlFiles.getExcludes()))
+        {
             return idlFiles.getIncludes()
                     .stream()
                     .map(s -> new File(inputFolder, s))
@@ -215,7 +226,7 @@ public class SwiftMojo extends AbstractMojo {
         }
 
         return FileUtils.getFiles(inputFolder,
-                Joiner.on(',').join(idlFiles.getIncludes()),
-                Joiner.on(',').join(idlFiles.getExcludes()));
+                                  Joiner.on(',').join(idlFiles.getIncludes()),
+                                  Joiner.on(',').join(idlFiles.getExcludes()));
     }
 }

--- a/swift-maven-plugin/src/test/java/com/facebook/mojo/SwiftIntegrationTest.java
+++ b/swift-maven-plugin/src/test/java/com/facebook/mojo/SwiftIntegrationTest.java
@@ -50,7 +50,20 @@ public class SwiftIntegrationTest
     public void testBasic()
             throws Exception
     {
-        File basedir = resources.getBasedir("basic");
+       assertOutcomes("basic");
+    }
+    
+    @Test
+    public void testShortCircuit() 
+        throws Exception
+    {
+        assertOutcomes("shortcircuit");            
+    }
+    
+    private void assertOutcomes(String project) 
+        throws Exception
+    {
+        File basedir = resources.getBasedir(project);
         maven.forProject(basedir)
                 .execute("generate-sources")
                 .assertErrorFreeLog();

--- a/swift-maven-plugin/src/test/java/com/facebook/mojo/SwiftMojoTest.java
+++ b/swift-maven-plugin/src/test/java/com/facebook/mojo/SwiftMojoTest.java
@@ -17,20 +17,16 @@ package com.facebook.mojo;
 
 import java.util.Arrays;
 import java.util.Collections;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-public class SwiftMojoTest {
+public class SwiftMojoTest
+{
 
     @Test
-    public void posixFormat() {
+    public void posixFormat()
+    {
         assertTrue(canBypassScan("foo", "bar", "bar/foo/coo"));
         assertTrue(canBypassScan("foo/bar/./bar"));
         assertFalse(canBypassScan());
@@ -42,7 +38,8 @@ public class SwiftMojoTest {
     }
 
     @Test
-    public void windowsFormat() {
+    public void windowsFormat()
+    {
         assertTrue(canBypassScan("foo", "bar", "bar\\foo\\coo"));
         assertTrue(canBypassScan("foo\\bar\\.\\bar"));
         assertFalse(canBypassScan());
@@ -53,7 +50,8 @@ public class SwiftMojoTest {
         assertFalse(canBypassScan("\\foo", "bar"));
     }
 
-    private boolean canBypassScan(String... pattern) {
+    private boolean canBypassScan(String... pattern)
+    {
         return SwiftMojo.canBypassScan(Arrays.asList(pattern), Collections.emptyList());
     }
 }

--- a/swift-maven-plugin/src/test/java/com/facebook/mojo/SwiftMojoTest.java
+++ b/swift-maven-plugin/src/test/java/com/facebook/mojo/SwiftMojoTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.mojo;
+
+import java.util.Arrays;
+import java.util.Collections;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SwiftMojoTest {
+
+    @Test
+    public void posixFormat() {
+        assertTrue(canBypassScan("foo", "bar", "bar/foo/coo"));
+        assertTrue(canBypassScan("foo/bar/./bar"));
+        assertFalse(canBypassScan());
+        assertFalse(canBypassScan("foo", "???bar.java"));
+        assertFalse(canBypassScan("foo/**/*/java", "bar"));
+        assertFalse(canBypassScan("foo", "bar/../../foo"));
+        assertFalse(canBypassScan("foo", "bar/"));
+        assertFalse(canBypassScan("/foo", "bar"));
+    }
+
+    @Test
+    public void windowsFormat() {
+        assertTrue(canBypassScan("foo", "bar", "bar\\foo\\coo"));
+        assertTrue(canBypassScan("foo\\bar\\.\\bar"));
+        assertFalse(canBypassScan());
+        assertFalse(canBypassScan("foo", "???bar.java"));
+        assertFalse(canBypassScan("foo\\**\\*\\java", "bar"));
+        assertFalse(canBypassScan("foo", "bar\\..\\..\\foo"));
+        assertFalse(canBypassScan("foo", "bar\\"));
+        assertFalse(canBypassScan("\\foo", "bar"));
+    }
+
+    private boolean canBypassScan(String... pattern) {
+        return SwiftMojo.canBypassScan(Arrays.asList(pattern), Collections.emptyList());
+    }
+}

--- a/swift-maven-plugin/src/test/projects/shortcircuit/idl/scribe.thrift
+++ b/swift-maven-plugin/src/test/projects/shortcircuit/idl/scribe.thrift
@@ -1,0 +1,37 @@
+#!/usr/local/bin/thrift --gen cpp:pure_enums --gen php
+
+##  Copyright (c) 2007-2008 Facebook
+##
+##  Licensed under the Apache License, Version 2.0 (the "License");
+##  you may not use this file except in compliance with the License.
+##  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+## See accompanying file LICENSE or visit the Scribe site at:
+## http://developers.facebook.com/scribe/
+
+namespace java com.facebook.swift.service.scribe
+
+enum ResultCode
+{
+  OK,
+  TRY_LATER
+}
+
+struct LogEntry
+{
+  1:  string category,
+  2:  string message
+}
+
+service scribe
+{
+  ResultCode Log(1: list<LogEntry> messages);
+}

--- a/swift-maven-plugin/src/test/projects/shortcircuit/pom.xml
+++ b/swift-maven-plugin/src/test/projects/shortcircuit/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.facebook.swift.its</groupId>
+    <artifactId>basic</artifactId>
+    <version>1.0</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.facebook.mojo</groupId>
+                <artifactId>swift-maven-plugin</artifactId>
+                <version>${it-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <idlFiles>
+                        <directory>${project.basedir}/idl</directory>
+                        <includes>
+                            <include>scribe.thrift</include>
+                        </includes>
+                    </idlFiles>
+                    <defaultPackage>${project.groupId}.test</defaultPackage>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
The Swift plugin uses FileUtils from Plexus to find the thrift files to include (this differs from the CLI, which takes explicit files). Passing in explicit files in the includes still requires a directory scan to take place, even though no wildcards are being used. In a large repo, this scan can take prohibitively long.

This pull optimizes the file search to bypass the directory scan under certain circumstances, while maintaining the existing API. Extensive tests were made to make sure scans would happen in the right conditions so as to not break any customers.
