### PR TITLE
Update paranamer dependency to fix a thread-safety issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
       <dependency>
         <groupId>com.thoughtworks.paranamer</groupId>
         <artifactId>paranamer</artifactId>
-        <version>2.5.2</version>
+        <version>2.8</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Paranamer fixed a thread-safety issue with the CachingParanamer (using the thread-unsafe WeakHashMap w/o synchronization) which first surfaced in v2.6.1
