### PR TITLE
Adding toString method to exception

### DIFF
--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -108,12 +108,16 @@ import com.facebook.swift.codec.*;
 import com.facebook.swift.codec.ThriftField.Requiredness;
 import java.util.*;
 
+import static com.google.common.base.Objects.toStringHelper;
+
 @ThriftStruct("<context.name>")
 public final class <context.javaName> extends <if(tweaks.EXTEND_RUNTIME_EXCEPTION)>RuntimeException<else>Exception<endif>
 {
     private static final long serialVersionUID = 1L;
 
     <_structbody(context)>
+
+    <_toString(context)>
 }<\n>
 >>
 


### PR DESCRIPTION
There is no toString method in the exception class which generated by
swift-generator.
When we log the exception, we just get the name of the exception, no
more details.
