### PR TITLE
Recursive types updates

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
@@ -50,11 +50,13 @@ public class ThriftFieldMetadata
     private final Optional<ThriftExtraction> extraction;
     private final Optional<TypeCoercion> coercion;
     private final ImmutableList<String> documentation;
+    private final boolean isRecursiveReference;
     private final Requiredness requiredness;
 
     public ThriftFieldMetadata(
             short id,
             boolean isLegacyId,
+            boolean isRecursiveReference,
             Requiredness requiredness,
             Map<String, String> idlAnnotations,
             ThriftTypeReference thriftTypeReference,
@@ -67,6 +69,7 @@ public class ThriftFieldMetadata
             Optional<TypeCoercion> coercion
     )
     {
+        this.isRecursiveReference = isRecursiveReference;
         this.requiredness = requiredness;
         this.thriftTypeReference = checkNotNull(thriftTypeReference, "thriftType is null");
         this.fieldKind = checkNotNull(fieldKind, "type is null");
@@ -145,16 +148,21 @@ public class ThriftFieldMetadata
         ImmutableMap.Builder<String, String> annotationsBuilder = ImmutableMap.builder();
         annotationsBuilder.putAll(idlAnnotations);
 
-        if (thriftTypeReference.isRecursive()) {
+        if (isRecursiveReference()) {
             annotationsBuilder.put(RECURSIVE_REFERENCE_ANNOTATION_NAME, "true");
         }
 
         return annotationsBuilder.build();
     }
 
-    public boolean isRecursive()
+    public boolean isTypeReferenceRecursive()
     {
         return thriftTypeReference.isRecursive();
+    }
+
+    public boolean isRecursiveReference()
+    {
+        return isRecursiveReference;
     }
 
     public boolean isInternal()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
@@ -95,6 +95,10 @@ public class ThriftFieldMetadata
                 break;
         }
 
+        checkArgument(!isRecursiveReference
+                      || requiredness == Requiredness.OPTIONAL,
+                      "Fields marked as recursive references must always be optional");
+
         checkArgument(!injections.isEmpty()
                       || extraction.isPresent()
                       || constructorInjection.isPresent()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
@@ -144,6 +144,7 @@ public class ThriftStructMetadataBuilder
         Map<String, String> idlAnnotations = null;
         String name = null;
         Requiredness requiredness = Requiredness.UNSPECIFIED;
+        boolean recursive = false;
         ThriftTypeReference thriftTypeReference = null;
 
         // process field injections and extractions
@@ -153,6 +154,7 @@ public class ThriftStructMetadataBuilder
             id = fieldMetadata.getId();
             isLegacyId = fieldMetadata.isLegacyId();
             name = fieldMetadata.getName();
+            recursive = fieldMetadata.isRecursiveReference();
             requiredness = fieldMetadata.getRequiredness();
             idlAnnotations = fieldMetadata.getIdlAnnotations();
             thriftTypeReference = catalog.getFieldThriftTypeReference(fieldMetadata);
@@ -189,6 +191,7 @@ public class ThriftStructMetadataBuilder
         ThriftFieldMetadata thriftFieldMetadata = new ThriftFieldMetadata(
                 id,
                 isLegacyId,
+                recursive,
                 requiredness,
                 idlAnnotations,
                 thriftTypeReference,

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
@@ -200,6 +200,7 @@ public class ThriftUnionMetadataBuilder
         short id = -1;
         boolean isLegacyId = false;
         String name = null;
+        boolean recursiveness = false;
         Requiredness requiredness = Requiredness.UNSPECIFIED;
         Map<String, String> idlAnnotations = null;
         FieldKind fieldType = FieldKind.THRIFT_FIELD;
@@ -214,6 +215,7 @@ public class ThriftUnionMetadataBuilder
             id = fieldMetadata.getId();
             isLegacyId = fieldMetadata.isLegacyId();
             name = fieldMetadata.getName();
+            recursiveness = fieldMetadata.isRecursiveReference();
             requiredness = fieldMetadata.getRequiredness();
             idlAnnotations = fieldMetadata.getIdlAnnotations();
             fieldType = fieldMetadata.getType();
@@ -279,6 +281,7 @@ public class ThriftUnionMetadataBuilder
         ThriftFieldMetadata thriftFieldMetadata = new ThriftFieldMetadata(
                 id,
                 isLegacyId,
+                recursiveness,
                 requiredness,
                 idlAnnotations,
                 thriftTypeReference,

--- a/swift-codec/src/test/java/com/facebook/swift/codec/recursion/CoRecursiveHelper.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/recursion/CoRecursiveHelper.java
@@ -20,12 +20,12 @@ import com.facebook.swift.codec.ThriftStruct;
 
 import java.util.Objects;
 
-import static com.facebook.swift.codec.ThriftField.Recursiveness.TRUE;
+import static com.facebook.swift.codec.ThriftField.*;
 
 @ThriftStruct
 public class CoRecursiveHelper
 {
-    @ThriftField(value = 1, isRecursive = TRUE)
+    @ThriftField(value = 1, requiredness = Requiredness.OPTIONAL, isRecursive = Recursiveness.TRUE)
     public CoRecursive child;
 
     @ThriftField(2)

--- a/swift-codec/src/test/java/com/facebook/swift/codec/recursion/RecursiveUnion.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/recursion/RecursiveUnion.java
@@ -22,7 +22,7 @@ import com.facebook.swift.codec.ThriftUnionId;
 
 import java.util.Objects;
 
-import static com.facebook.swift.codec.ThriftField.Recursiveness;
+import static com.facebook.swift.codec.ThriftField.*;
 
 @ThriftUnion
 public class RecursiveUnion
@@ -46,7 +46,7 @@ public class RecursiveUnion
         this.value = data;
     }
 
-    @ThriftField(value = 1, isRecursive = Recursiveness.TRUE)
+    @ThriftField(value = 1, requiredness = Requiredness.OPTIONAL, isRecursive = Recursiveness.TRUE)
     public RecursiveUnion getChild()
     {
         return (RecursiveUnion)value;

--- a/swift-codec/src/test/java/com/facebook/swift/codec/recursion/WithIdlRecursiveAnnotation.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/recursion/WithIdlRecursiveAnnotation.java
@@ -21,12 +21,16 @@ import com.facebook.swift.codec.ThriftStruct;
 
 import java.util.Objects;
 
+import static com.facebook.swift.codec.ThriftField.*;
 import static com.facebook.swift.codec.ThriftField.RECURSIVE_REFERENCE_ANNOTATION_NAME;
 
 @ThriftStruct
 public class WithIdlRecursiveAnnotation
 {
-    @ThriftField(value = 1, idlAnnotations = { @ThriftIdlAnnotation(key = RECURSIVE_REFERENCE_ANNOTATION_NAME, value = "true") })
+    @ThriftField(
+            value = 1,
+            requiredness = Requiredness.OPTIONAL,
+            idlAnnotations = { @ThriftIdlAnnotation(key = RECURSIVE_REFERENCE_ANNOTATION_NAME, value = "true") })
     public WithIdlRecursiveAnnotation child;
 
     @ThriftField(2)

--- a/swift-codec/src/test/java/com/facebook/swift/codec/recursion/WithSwiftRecursiveAnnotation.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/recursion/WithSwiftRecursiveAnnotation.java
@@ -20,12 +20,13 @@ import com.facebook.swift.codec.ThriftStruct;
 
 import java.util.Objects;
 
-import static com.facebook.swift.codec.ThriftField.Recursiveness.TRUE;
+import static com.facebook.swift.codec.ThriftField.*;
+
 
 @ThriftStruct
 public class WithSwiftRecursiveAnnotation
 {
-    @ThriftField(value = 1, isRecursive = TRUE)
+    @ThriftField(value = 1, requiredness = Requiredness.OPTIONAL, isRecursive = Recursiveness.TRUE)
     public WithSwiftRecursiveAnnotation child;
 
     @ThriftField(2)

--- a/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/swift2thrift/Swift2ThriftGenerator.java
@@ -408,7 +408,7 @@ public class Swift2ThriftGenerator
         knownTypes.add(t);
 
         for (ThriftFieldMetadata fieldMetadata: metadata.getFields(FieldKind.THRIFT_FIELD)) {
-            if (!recursive && fieldMetadata.isRecursive()) {
+            if (!recursive && fieldMetadata.isTypeReferenceRecursive()) {
                 continue;
             }
 

--- a/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/metadata/ThriftMethodMetadata.java
@@ -147,6 +147,7 @@ public class ThriftMethodMetadata
             ThriftFieldMetadata fieldMetadata = new ThriftFieldMetadata(
                     parameterId,
                     isLegacyId,
+                    false /* recursiveness */,
                     parameterRequiredness,
                     parameterIdlAnnotations,
                     new DefaultThriftTypeReference(thriftType),


### PR DESCRIPTION
Fixes:

swift2thrift was generating the swift.recursive_reference based on whether the ThriftTypeReference for the field was a recursive vs normal reference. change to use the more deterministic value of the 'isRecursive' property from the @ThriftField annotation

also realized that this would allow us to generate recursive cycles without optional anywhere, so added the requirement that isRecursive=TRUE be used in conjunction with requiredness=OPTIONAL
