### PR TITLE
Add support for IDL exceptions in @ThriftStruct/@ThriftUnion

### DIFF
--- a/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftStruct.java
+++ b/swift-annotations/src/main/java/com/facebook/swift/codec/ThriftStruct.java
@@ -30,4 +30,6 @@ public @interface ThriftStruct
     String value() default "";
 
     Class<?> builder() default void.class;
+
+    ThriftIdlAnnotation[] idlAnnotations() default {};
 }

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/AbstractThriftMetadataBuilder.java
@@ -118,6 +118,8 @@ public abstract class AbstractThriftMetadataBuilder
 
     protected abstract String extractName();
 
+    protected abstract Map<String, String> extractStructIdlAnnotations();
+
     protected abstract Class<?> extractBuilderClass();
 
     protected abstract void validateConstructors();

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadata.java
@@ -27,6 +27,7 @@ import javax.annotation.concurrent.Immutable;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 
 import static com.facebook.swift.codec.metadata.ThriftFieldMetadata.isTypePredicate;
@@ -38,10 +39,11 @@ public class ThriftStructMetadata
 {
     public static enum MetadataType {
         STRUCT, UNION;
-    }
 
+    }
     private final String structName;
 
+    private final Map<String, String> idlAnnotations;
     private final MetadataType metadataType;
     private final Optional<ThriftMethodInjection> builderMethod;
     private final ImmutableList<String> documentation;
@@ -56,6 +58,7 @@ public class ThriftStructMetadata
 
     public ThriftStructMetadata(
             String structName,
+            Map<String, String> idlAnnotations,
             Type structType,
             Type builderType,
             MetadataType metadataType,
@@ -68,6 +71,7 @@ public class ThriftStructMetadata
         this.builderType = builderType;
         this.builderMethod = checkNotNull(builderMethod, "builderMethod is null");
         this.structName = checkNotNull(structName, "structName is null");
+        this.idlAnnotations = checkNotNull(idlAnnotations, "idlAnnotations is null");
         this.metadataType = checkNotNull(metadataType, "metadataType is null");
         this.structType = checkNotNull(structType, "structType is null");
         this.constructorInjection = checkNotNull(constructorInjection, "constructorInjection is null");
@@ -116,6 +120,11 @@ public class ThriftStructMetadata
     public Optional<ThriftMethodInjection> getBuilderMethod()
     {
         return builderMethod;
+    }
+
+    public Map<String, String> getIdlAnnotations()
+    {
+        return idlAnnotations;
     }
 
     public ThriftFieldMetadata getField(int id)

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
@@ -15,11 +15,13 @@
  */
 package com.facebook.swift.codec.metadata;
 
+import com.facebook.swift.codec.ThriftIdlAnnotation;
 import com.facebook.swift.codec.ThriftStruct;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata.MetadataType;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -61,6 +63,22 @@ public class ThriftStructMetadataBuilder
         }
         else {
             return getStructClass().getSimpleName();
+        }
+    }
+
+    @Override
+    protected Map<String, String> extractStructIdlAnnotations()
+    {
+        ThriftStruct annotation = getStructClass().getAnnotation(ThriftStruct.class);
+        if (annotation == null) {
+            return ImmutableMap.of();
+        }
+        else {
+            ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder();
+            for (ThriftIdlAnnotation idlAnnotation : annotation.idlAnnotations()) {
+                builder.put(idlAnnotation.key(), idlAnnotation.value());
+            }
+            return builder.build();
         }
     }
 
@@ -113,6 +131,7 @@ public class ThriftStructMetadataBuilder
 
         return new ThriftStructMetadata(
                 structName,
+                extractStructIdlAnnotations(),
                 structType,
                 builderType,
                 MetadataType.STRUCT,

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftUnionMetadataBuilder.java
@@ -15,11 +15,13 @@
  */
 package com.facebook.swift.codec.metadata;
 
+import com.facebook.swift.codec.ThriftIdlAnnotation;
 import com.facebook.swift.codec.ThriftUnion;
 import com.facebook.swift.codec.ThriftUnionId;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata.MetadataType;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -65,6 +67,22 @@ public class ThriftUnionMetadataBuilder
         }
         else {
             return getStructClass().getSimpleName();
+        }
+    }
+
+    @Override
+    protected Map<String, String> extractStructIdlAnnotations()
+    {
+        ThriftUnion annotation = getStructClass().getAnnotation(ThriftUnion.class);
+        if (annotation == null) {
+            return ImmutableMap.of();
+        }
+        else {
+            ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder();
+            for (ThriftIdlAnnotation idlAnnotation : annotation.idlAnnotations()) {
+                builder.put(idlAnnotation.key(), idlAnnotation.value());
+            }
+            return builder.build();
         }
     }
 
@@ -171,6 +189,7 @@ public class ThriftUnionMetadataBuilder
 
         return new ThriftStructMetadata(
                 structName,
+                extractStructIdlAnnotations(),
                 structType,
                 builderType,
                 MetadataType.UNION,

--- a/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/ExceptionWithIdlAnnotations.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/ExceptionWithIdlAnnotations.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.idlannotations;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftIdlAnnotation;
+import com.facebook.swift.codec.ThriftStruct;
+
+@ThriftStruct(
+        idlAnnotations = {
+                @ThriftIdlAnnotation(key = "message", value = "message")
+        }
+)
+public class ExceptionWithIdlAnnotations extends Exception
+{
+    private int type;
+
+    @ThriftConstructor
+    public ExceptionWithIdlAnnotations(@ThriftField(1) String message,
+                                       @ThriftField(2) int type)
+    {
+        super(message);
+        this.type = type;
+    }
+
+    @ThriftField(1)
+    public String getMessage()
+    {
+        return super.getMessage();
+    }
+
+    @ThriftField(2)
+    public int getType()
+    {
+        return type;
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/StructWithIdlAnnotations.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/StructWithIdlAnnotations.java
@@ -13,23 +13,23 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.facebook.swift.codec;
+package com.facebook.swift.codec.idlannotations;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftIdlAnnotation;
+import com.facebook.swift.codec.ThriftStruct;
 
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-@Documented
-@Retention(RUNTIME)
-@Target({TYPE})
-public @interface ThriftUnion
+@ThriftStruct(
+        idlAnnotations = {
+                @ThriftIdlAnnotation(key = "testkey1", value = "testvalue1"),
+                @ThriftIdlAnnotation(key = "testkey2", value = "testvalue2"),
+        }
+)
+public class StructWithIdlAnnotations
 {
-    String value() default "";
+    @ThriftField(1)
+    public String message;
 
-    Class<?> builder() default void.class;
-
-    ThriftIdlAnnotation[] idlAnnotations() default {};
+    @ThriftField(2)
+    public int type;
 }

--- a/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/UnionWithIdlAnnotations.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/UnionWithIdlAnnotations.java
@@ -17,10 +17,10 @@ package com.facebook.swift.codec.idlannotations;
 
 import com.facebook.swift.codec.ThriftField;
 import com.facebook.swift.codec.ThriftIdlAnnotation;
-import com.facebook.swift.codec.ThriftStruct;
+import com.facebook.swift.codec.ThriftUnion;
 import com.facebook.swift.codec.ThriftUnionId;
 
-@ThriftStruct(
+@ThriftUnion(
         idlAnnotations = {
                 @ThriftIdlAnnotation(key = "testkey1", value = "testvalue1"),
                 @ThriftIdlAnnotation(key = "testkey2", value = "testvalue2"),

--- a/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/UnionWithIdlAnnotations.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/idlannotations/UnionWithIdlAnnotations.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.codec.idlannotations;
+
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftIdlAnnotation;
+import com.facebook.swift.codec.ThriftStruct;
+import com.facebook.swift.codec.ThriftUnionId;
+
+@ThriftStruct(
+        idlAnnotations = {
+                @ThriftIdlAnnotation(key = "testkey1", value = "testvalue1"),
+                @ThriftIdlAnnotation(key = "testkey2", value = "testvalue2"),
+        }
+)
+public class UnionWithIdlAnnotations
+{
+    private short unionType;
+    private Object value;
+
+    @ThriftUnionId
+    public short getUnionType()
+    {
+        return unionType;
+    }
+
+    @ThriftField(1)
+    public void setMessage(String message)
+    {
+        this.value = message;
+        this.unionType = 1;
+    }
+
+    @ThriftField(1)
+    public String getMessage()
+    {
+        if (unionType != 1) {
+            throw new IllegalStateException("not a message");
+        }
+        return (String) value;
+    }
+
+    @ThriftField(2)
+    public void setType(int type)
+    {
+        this.value = type;
+        this.unionType = 2;
+    }
+
+    @ThriftField(2)
+    public int getType()
+    {
+        if (unionType != 2) {
+            throw new IllegalStateException("not a type");
+        }
+        return (int) value;
+    }
+}

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
@@ -30,6 +30,7 @@ import com.facebook.swift.codec.metadata.ThriftStructMetadata.MetadataType;
 
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -41,9 +42,9 @@ import static org.testng.Assert.assertTrue;
 public class TestThriftStructMetadata
 {
     @Test
-    public void testField()
+    public void testField() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(BonkField.class, 0, 0);
+        ThriftStructMetadata metadata = testStructMetadataBuild(BonkField.class, 0, 0);
 
         verifyFieldInjection(metadata, 1, "message");
         verifyFieldExtraction(metadata, 1, "message");
@@ -69,9 +70,9 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testBean()
+    public void testBean() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(BonkBean.class, 0, 2);
+        ThriftStructMetadata metadata = testStructMetadataBuild(BonkBean.class, 0, 2);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 0);
@@ -99,9 +100,9 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testConstructor()
+    public void testConstructor() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(BonkConstructor.class, 2, 0);
+        ThriftStructMetadata metadata = testStructMetadataBuild(BonkConstructor.class, 2, 0);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 1);
@@ -109,9 +110,9 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testMethod()
+    public void testMethod() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(BonkMethod.class, 0, 1);
+        ThriftStructMetadata metadata = testStructMetadataBuild(BonkMethod.class, 0, 1);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 1);
@@ -119,9 +120,9 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testBuilder()
+    public void testBuilder() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(BonkBuilder.class, 0, 2);
+        ThriftStructMetadata metadata = testStructMetadataBuild(BonkBuilder.class, 0, 2);
         verifyParameterInjection(metadata, 1, "message", 0);
         verifyMethodExtraction(metadata, 1, "message", "getMessage");
         verifyParameterInjection(metadata, 2, "type", 0);
@@ -129,12 +130,12 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testFieldWithOneIdlAnnotationMap()
+    public void testFieldWithOneIdlAnnotationMap() throws Exception
     {
         /**
          * Single field with IDL annotation map on getter, but not on setter: should be okay
          */
-        ThriftStructMetadata metadata = testMetadataBuild(BeanWithOneIdlAnnotationMapForField.class, 0, 1);
+        ThriftStructMetadata metadata = testStructMetadataBuild(BeanWithOneIdlAnnotationMapForField.class, 0, 1);
         Map<String, String> idlAnnotations = metadata.getField(2).getIdlAnnotations();
         assertEquals(idlAnnotations.size(), 2);
         assertEquals(idlAnnotations.get("testkey1"), "testvalue1");
@@ -142,12 +143,12 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testFieldWithMatchingIdlAnnotationMaps()
+    public void testFieldWithMatchingIdlAnnotationMaps() throws Exception
     {
         /**
          * Single field with matching IDL annotation maps on setter vs getter: should be okay
          */
-        ThriftStructMetadata metadata = testMetadataBuild(BeanWithMatchingIdlAnnotationsMapsForField.class, 0, 1);
+        ThriftStructMetadata metadata = testStructMetadataBuild(BeanWithMatchingIdlAnnotationsMapsForField.class, 0, 1);
         Map<String, String> idlAnnotations = metadata.getField(2).getIdlAnnotations();
         assertEquals(idlAnnotations.size(), 2);
         assertEquals(idlAnnotations.get("testkey1"), "testvalue1");
@@ -155,18 +156,18 @@ public class TestThriftStructMetadata
     }
 
     @Test(expectedExceptions = MetadataErrorException.class)
-    public void testFieldWithConflictingIdlAnnotationMap()
+    public void testFieldWithConflictingIdlAnnotationMap() throws Exception
     {
         /**
          * Single field with conflicting IDL annotation maps on setter vs getter: should fail
          */
-        testMetadataBuild(BeanWIthConflictingIdlAnnotationMapsForField.class, 0, 1);
+        testStructMetadataBuild(BeanWIthConflictingIdlAnnotationMapsForField.class, 0, 1);
     }
 
     @Test
-    public void testStructWithIdlAnnotationsMap()
+    public void testStructWithIdlAnnotationsMap() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(StructWithIdlAnnotations.class, 0, 0);
+        ThriftStructMetadata metadata = testStructMetadataBuild(StructWithIdlAnnotations.class, 0, 0);
         Map<String, String> idlAnnotations = metadata.getIdlAnnotations();
         assertEquals(idlAnnotations.size(), 2);
         assertEquals(idlAnnotations.get("testkey1"), "testvalue1");
@@ -174,9 +175,9 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testUnionWithIdlAnnotationsMap()
+    public void testUnionWithIdlAnnotationsMap() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(UnionWithIdlAnnotations.class, 0, 2);
+        ThriftStructMetadata metadata = testUnionMetadataBuild(UnionWithIdlAnnotations.class, 0, 2);
         Map<String, String> idlAnnotations = metadata.getIdlAnnotations();
         assertEquals(idlAnnotations.size(), 2);
         assertEquals(idlAnnotations.get("testkey1"), "testvalue1");
@@ -184,27 +185,52 @@ public class TestThriftStructMetadata
     }
 
     @Test
-    public void testExceptionWithIdlAnnotationsMap()
+    public void testExceptionWithIdlAnnotationsMap() throws Exception
     {
-        ThriftStructMetadata metadata = testMetadataBuild(ExceptionWithIdlAnnotations.class, 2, 0);
+        ThriftStructMetadata metadata = testStructMetadataBuild(ExceptionWithIdlAnnotations.class, 2, 0);
         Map<String, String> idlAnnotations = metadata.getIdlAnnotations();
         assertEquals(idlAnnotations.size(), 1);
         assertEquals(idlAnnotations.get("message"), "message");
     }
 
-    private ThriftStructMetadata testMetadataBuild(Class<?> structClass, int expectedConstructorParameters, int expectedMethodInjections)
+    private ThriftStructMetadata testStructMetadataBuild(
+            Class<?> structClass,
+            int expectedConstructorParameters,
+            int expectedMethodInjections)
+            throws Exception
     {
-        ThriftCatalog catalog = new ThriftCatalog();
-        ThriftStructMetadataBuilder builder = new ThriftStructMetadataBuilder(catalog, structClass);
-        assertNotNull(builder);
+        return testMetadataBuild(
+                ThriftStructMetadataBuilder.class,
+                structClass,
+                expectedConstructorParameters,
+                expectedMethodInjections);
+    }
 
-        assertNotNull(builder.getMetadataErrors());
-        builder.getMetadataErrors().throwIfHasErrors();
-        assertEquals(builder.getMetadataErrors().getWarnings().size(), 0);
+    private ThriftStructMetadata testUnionMetadataBuild(
+            Class<?> structClass,
+            int expectedConstructorParameters,
+            int expectedMethodInjections)
+            throws Exception
+    {
+        return testMetadataBuild(
+                ThriftUnionMetadataBuilder.class,
+                structClass,
+                expectedConstructorParameters,
+                expectedMethodInjections);
+    }
 
-        ThriftStructMetadata metadata = builder.build();
+    private <T extends AbstractThriftMetadataBuilder> ThriftStructMetadata testMetadataBuild(
+            Class<T> metadataBuilderType,
+            Class<?> structClass,
+            int expectedConstructorParameters,
+            int expectedMethodInjections)
+            throws Exception
+    {
+        ThriftStructMetadata metadata = buildMetadata(structClass, metadataBuilderType);
         assertNotNull(metadata);
-        assertEquals(MetadataType.STRUCT, metadata.getMetadataType());
+        assertTrue(
+                MetadataType.UNION == metadata.getMetadataType() ||
+                MetadataType.STRUCT == metadata.getMetadataType());
 
         verifyField(metadata, 1, "message");
         verifyField(metadata, 2, "type");
@@ -216,6 +242,24 @@ public class TestThriftStructMetadata
         assertEquals(metadata.getMethodInjections().size(), expectedMethodInjections);
 
         return metadata;
+    }
+
+    private <T extends AbstractThriftMetadataBuilder> ThriftStructMetadata buildMetadata(
+            Class<?> structClass,
+            Class<T> metadataBuilderType)
+            throws Exception
+    {
+        ThriftCatalog catalog = new ThriftCatalog();
+        AbstractThriftMetadataBuilder builder =
+                metadataBuilderType.getConstructor(ThriftCatalog.class, Type.class)
+                                   .newInstance(catalog, structClass);
+        assertNotNull(builder);
+
+        assertNotNull(builder.getMetadataErrors());
+        builder.getMetadataErrors().throwIfHasErrors();
+        assertEquals(builder.getMetadataErrors().getWarnings().size(), 0);
+
+        return builder.build();
     }
 
     private <T> void verifyField(ThriftStructMetadata metadata, int id, String name)

--- a/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/metadata/TestThriftStructMetadata.java
@@ -20,10 +20,12 @@ import com.facebook.swift.codec.BonkBuilder;
 import com.facebook.swift.codec.BonkConstructor;
 import com.facebook.swift.codec.BonkField;
 import com.facebook.swift.codec.BonkMethod;
-import com.facebook.swift.codec.ThriftIdlAnnotation;
 import com.facebook.swift.codec.idlannotations.BeanWIthConflictingIdlAnnotationMapsForField;
 import com.facebook.swift.codec.idlannotations.BeanWithMatchingIdlAnnotationsMapsForField;
 import com.facebook.swift.codec.idlannotations.BeanWithOneIdlAnnotationMapForField;
+import com.facebook.swift.codec.idlannotations.ExceptionWithIdlAnnotations;
+import com.facebook.swift.codec.idlannotations.StructWithIdlAnnotations;
+import com.facebook.swift.codec.idlannotations.UnionWithIdlAnnotations;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata.MetadataType;
 
 import org.testng.annotations.Test;
@@ -161,6 +163,35 @@ public class TestThriftStructMetadata
         testMetadataBuild(BeanWIthConflictingIdlAnnotationMapsForField.class, 0, 1);
     }
 
+    @Test
+    public void testStructWithIdlAnnotationsMap()
+    {
+        ThriftStructMetadata metadata = testMetadataBuild(StructWithIdlAnnotations.class, 0, 0);
+        Map<String, String> idlAnnotations = metadata.getIdlAnnotations();
+        assertEquals(idlAnnotations.size(), 2);
+        assertEquals(idlAnnotations.get("testkey1"), "testvalue1");
+        assertEquals(idlAnnotations.get("testkey2"), "testvalue2");
+    }
+
+    @Test
+    public void testUnionWithIdlAnnotationsMap()
+    {
+        ThriftStructMetadata metadata = testMetadataBuild(UnionWithIdlAnnotations.class, 0, 2);
+        Map<String, String> idlAnnotations = metadata.getIdlAnnotations();
+        assertEquals(idlAnnotations.size(), 2);
+        assertEquals(idlAnnotations.get("testkey1"), "testvalue1");
+        assertEquals(idlAnnotations.get("testkey2"), "testvalue2");
+    }
+
+    @Test
+    public void testExceptionWithIdlAnnotationsMap()
+    {
+        ThriftStructMetadata metadata = testMetadataBuild(ExceptionWithIdlAnnotations.class, 2, 0);
+        Map<String, String> idlAnnotations = metadata.getIdlAnnotations();
+        assertEquals(idlAnnotations.size(), 1);
+        assertEquals(idlAnnotations.get("message"), "message");
+    }
+
     private ThriftStructMetadata testMetadataBuild(Class<?> structClass, int expectedConstructorParameters, int expectedMethodInjections)
     {
         ThriftCatalog catalog = new ThriftCatalog();
@@ -190,7 +221,7 @@ public class TestThriftStructMetadata
     private <T> void verifyField(ThriftStructMetadata metadata, int id, String name)
     {
         ThriftFieldMetadata messageField = metadata.getField(id);
-        assertNotNull(messageField, "messageField is null");
+        assertNotNull(messageField, "field '" + name + "' is null");
         assertEquals(messageField.getId(), id);
         assertEquals(messageField.getName(), name);
         assertFalse(messageField.isReadOnly());

--- a/swift-generator/src/main/resources/templates/thrift/common.st
+++ b/swift-generator/src/main/resources/templates/thrift/common.st
@@ -33,9 +33,17 @@ _maybeEnumValue(enum, enumElem) ::= <<
 
 _struct(struct) ::= <<
 <_doc(struct.documentation)><\\\>
-<_structkind(struct)> <struct.structName> {
+<_structkind(struct)> <struct.structName><_structAnnotations(struct.idlAnnotations)> {
   <struct.fields : {f | <if(!f.internal)><_field(f)>;<endif>}; separator="\n">
 }
+>>
+
+_structAnnotations(annotations) ::= <<
+<if(annotations)> ( <annotations.keys : {key | <_structAnnotation(key, annotations.(key))>}; separator=", "> )<endif>
+>>
+
+_structAnnotation(annotationKey, annotationValue) ::= <<
+<annotationKey> = "<annotationValue>"
 >>
 
 _structkind(struct) ::= <<

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -20,7 +20,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.airlift.units.MaxDataSize;
 
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -62,8 +61,8 @@ public class ThriftServerConfig
     private String protocolName = "binary";
     /**
      * The default maximum allowable size for a single incoming thrift request or outgoing thrift
-     * response. A server can configure the actual maximum to be much higher (up to 0x3FFFFFFF or
-     * almost 1 GB). This default could also be safely bumped up, but 64MB is chosen simply
+     * response. A server can configure the actual maximum to be much higher (up to 0x7FFFFFFF or
+     * almost 2 GB). This default could also be safely bumped up, but 64MB is chosen simply
      * because it seems reasonable that if you are sending requests or responses larger than
      * that, it should be a conscious decision (something you must manually configure).
      */
@@ -95,7 +94,6 @@ public class ThriftServerConfig
         return this;
     }
 
-    @MaxDataSize("1073741823B")
     public DataSize getMaxFrameSize()
     {
         return maxFrameSize;

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServerConfig.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MaxDataSize;
 
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -61,8 +62,8 @@ public class ThriftServerConfig
     private String protocolName = "binary";
     /**
      * The default maximum allowable size for a single incoming thrift request or outgoing thrift
-     * response. A server can configure the actual maximum to be much higher (up to 0x7FFFFFFF or
-     * almost 2 GB). This default could also be safely bumped up, but 64MB is chosen simply
+     * response. A server can configure the actual maximum to be much higher (up to 0x3FFFFFFF or
+     * almost 1 GB). This default could also be safely bumped up, but 64MB is chosen simply
      * because it seems reasonable that if you are sending requests or responses larger than
      * that, it should be a conscious decision (something you must manually configure).
      */
@@ -94,6 +95,7 @@ public class ThriftServerConfig
         return this;
     }
 
+    @MaxDataSize("1073741823B")
     public DataSize getMaxFrameSize()
     {
         return maxFrameSize;

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
@@ -19,6 +19,7 @@ import com.facebook.swift.codec.guice.ThriftCodecModule;
 import com.facebook.swift.service.guice.ThriftServerModule;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
+import com.google.inject.CreationException;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
@@ -19,7 +19,6 @@ import com.facebook.swift.codec.guice.ThriftCodecModule;
 import com.facebook.swift.service.guice.ThriftServerModule;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
-import com.google.inject.CreationException;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;


### PR DESCRIPTION
This change allows you to define IDL annotations that will be exported into the
IDL generated by Swift2Thrift
