### PR TITLE
[swift-generator] Skip more unhandled types

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/ConstantRenderer.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/ConstantRenderer.java
@@ -110,6 +110,12 @@ public class ConstantRenderer
 
         Set<Map.Entry<ConstValue, ConstValue>> entries = value.value().entrySet();
         for (Map.Entry<ConstValue, ConstValue> entry : entries) {
+            if (entry.getKey() instanceof ConstIdentifier) {
+                throw new IllegalStateException("Not yet implemented");
+            }
+            if (entry.getValue() instanceof ConstIdentifier) {
+                throw new IllegalStateException("Not yet implemented");
+            }
             sb.append(format("    .put(%s, %s)\n",
                              render(mapType.getKeyType(), entry.getKey()),
                              render(mapType.getValueType(), entry.getValue())));
@@ -129,6 +135,9 @@ public class ConstantRenderer
 
         List<ConstValue> elements = value.value();
         for (ConstValue element : elements) {
+            if (element instanceof ConstIdentifier) {
+                throw new IllegalStateException("Not yet implemented");
+            }
             sb.append(format("    .add(%s)\n", render(listType.getElementType(), element)));
         }
         sb.append("    .build()");
@@ -146,6 +155,9 @@ public class ConstantRenderer
 
         List<ConstValue> elements = value.value();
         for (ConstValue element : elements) {
+            if (element instanceof ConstIdentifier) {
+                throw new IllegalStateException("Not yet implemented");
+            }
             sb.append(format("    .add(%s)\n", render(setType.getElementType(), element)));
         }
         sb.append("    .build()");

--- a/swift-generator/src/test/resources/ConstantsDemo.thrift
+++ b/swift-generator/src/test/resources/ConstantsDemo.thrift
@@ -37,7 +37,7 @@ struct thing2 {
 typedef i32 myIntType
 const myIntType myInt = 3
 
-//const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
+const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
 
 const i32 hex_const = 0x0001F
 
@@ -69,8 +69,8 @@ const map<i32, map<i32, i32>> GEN_MAPMAP = { 235 : { 532 : 53255, 235:235}}
 const map<string,i32> GEN_MAP2 = { "hello" : 233, "lkj98d" : 853, 'lkjsdf' : 98325 }
 
 // swift-generator doesn't support struct constants yet
-//const thing GEN_THING = { 'hello' : 325, 'goodbye' : 325352 }
-//const map<i32,thing> GEN_WHAT = { 35 : { 'hello' : 325, 'goodbye' : 325352 } }
+const thing GEN_THING = { 'hello' : 325, 'goodbye' : 325352 }
+const map<i32,thing> GEN_WHAT = { 35 : { 'hello' : 325, 'goodbye' : 325352 } }
 
 const set<i32> GEN_SET = [ 235, 235, 53235 ]
 
@@ -83,3 +83,9 @@ service yowza {
   void blingity(),
   i32 blangity() throws (1: Blah hoot )
 }
+
+const set<string> GEN_SET_CONTAINING_CONSTANT = [ GEN_STRING ]
+const list<string> GEN_LIST_CONTAINING_CONSTANT = [ GEN_STRING ]
+const map<string, i32> GEN_MAP_CONTAINING_CONSTANT_KEY = { GEN_STRING: 235 }
+const map<string, i32> GEN_MAP_CONTAINING_CONSTANT_VALUE = { "hello": int_const_single_d }
+const map<string, i32> GEN_MAP_CONTAINING_CONSTANT_ENTRY = { GEN_STRING: int_const_single_d }


### PR DESCRIPTION
These types currently cause a crash. I actually have an upcoming fix to
_handle_ the types instead of just skipping them, but I want this in first
in case I need to back-port a "fix" to older release branches without adding
functionality.
