### PR TITLE
Fix calls to deprecated airlift config APIs

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientBinder.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientBinder.java
@@ -43,7 +43,7 @@ import java.util.UUID;
 
 import static com.facebook.swift.service.ThriftClientManager.DEFAULT_NAME;
 import static com.facebook.swift.service.metadata.ThriftServiceMetadata.getThriftServiceAnnotation;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.lang.String.format;
 
 public class ThriftClientBinder
@@ -71,7 +71,7 @@ public class ThriftClientBinder
         // ThriftClientConfig bindings collapse to a single instance which is shared by all
         // clients.
         Named thriftClientConfigKey = Names.named(typeName + "-" + UUID.randomUUID().toString());
-        bindConfig(binder).annotatedWith(thriftClientConfigKey).prefixedWith(typeName).to(ThriftClientConfig.class);
+        configBinder(binder).bindConfig(ThriftClientConfig.class, thriftClientConfigKey, typeName);
 
         // Bind ThriftClient to a provider which knows how to find the ThriftClientConfig using
         // the random @Named annotation
@@ -106,7 +106,7 @@ public class ThriftClientBinder
         // see comment on random Named annotation above
         Named thriftClientConfigKey = Names.named(typeName + "-" + UUID.randomUUID().toString());
         String prefix = String.format("%s.%s", typeName, name);
-        bindConfig(binder).annotatedWith(thriftClientConfigKey).prefixedWith(prefix).to(ThriftClientConfig.class);
+        configBinder(binder).bindConfig(ThriftClientConfig.class, thriftClientConfigKey, prefix);
 
         // Bind ThriftClient to a provider which knows how to find the ThriftClientConfig using
         // the random @Named annotation

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftClientModule.java
@@ -23,14 +23,14 @@ import com.facebook.swift.service.ThriftClientManagerConfig;
 import com.google.inject.*;
 
 import static com.facebook.swift.service.guice.ClientEventHandlersBinder.clientEventHandlersBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class ThriftClientModule implements Module
 {
     @Override
     public void configure(Binder binder)
     {
-        bindConfig(binder).to(ThriftClientManagerConfig.class);
+        configBinder(binder).bindConfig(ThriftClientManagerConfig.class);
 
         binder.bind(NiftyClient.class).toProvider(NiftyClientProvider.class).in(Scopes.SINGLETON);
 

--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
@@ -46,8 +46,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
-
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class ThriftServerModule implements Module
 {
@@ -78,7 +77,7 @@ public class ThriftServerModule implements Module
         binder.bind(ThriftServiceProcessor.class).toProvider(ThriftServiceProcessorProvider.class).in(Scopes.SINGLETON);
         binder.bind(NiftyProcessor.class).to(Key.get(ThriftServiceProcessor.class)).in(Scopes.SINGLETON);
 
-        bindConfig(binder).to(ThriftServerConfig.class);
+        configBinder(binder).bindConfig(ThriftServerConfig.class);
         binder.bind(ThriftServer.NiftySecurityFactoryHolder.class);
         binder.bind(ThriftServer.class).in(Scopes.SINGLETON);
     }

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftClientConfig.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftClientConfig.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class TestThriftClientConfig
 {
@@ -78,7 +78,7 @@ public class TestThriftClientConfig
             @Override
             public void configure(Binder binder)
             {
-                bindConfig(binder).to(ThriftClientConfig.class);
+                configBinder(binder).bindConfig(ThriftClientConfig.class);
             }
         });
 

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftServerConfig.java
@@ -23,6 +23,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 import io.airlift.bootstrap.Bootstrap;
+import io.airlift.configuration.ConfigBinder;
 import io.airlift.configuration.testing.ConfigAssertions;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -36,7 +37,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import static com.facebook.swift.service.guice.ThriftServerModule.bindWorkerExecutor;
 import static com.facebook.swift.service.guice.ThriftServiceExporter.thriftServerBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -115,7 +116,7 @@ public class TestThriftServerConfig
             @Override
             protected void configure()
             {
-                bindConfig(binder()).to(ThriftServerConfig.class);
+                configBinder(binder()).bindConfig(ThriftServerConfig.class);
             }
         });
 


### PR DESCRIPTION
import static io.airlift.configuration.ConfigurationModule.bindConfig is deprecated. This diff updates to non-deprecated syntax for the same thing.
