### PR TITLE
Fix recursive type stack double-push, double-pop bug

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftCatalog.java
@@ -259,7 +259,7 @@ public class ThriftCatalog
                 }
                 Type unresolvedJavaType = unresolvedJavaTypes.pop();
                 if (!typeCache.containsKey(unresolvedJavaType)) {
-                    ThriftType resolvedThriftType = buildThriftTypeInternal(deferredTypesWorkList.get().pop());
+                    ThriftType resolvedThriftType = buildThriftTypeInternal(unresolvedJavaType);
                     typeCache.putIfAbsent(unresolvedJavaType, resolvedThriftType);
                 }
             } while (true);
@@ -372,7 +372,6 @@ public class ThriftCatalog
              * involved in a recursive chain. Otherwise, it's just introducing unnecessary
              * references. We should see if we can clean this up.
              */
-            deferredTypesWorkList.get().add(javaType);
             return getThriftTypeReference(javaType, Recursiveness.FORCED);
         }
         else {
@@ -389,7 +388,6 @@ public class ThriftCatalog
              * involved in a recursive chain. Otherwise, it's just introducing unnecessary
              * references. We should see if we can clean this up.
              */
-            deferredTypesWorkList.get().add(javaType);
             return getThriftTypeReference(javaType, Recursiveness.FORCED);
         }
         else {
@@ -406,7 +404,6 @@ public class ThriftCatalog
              * involved in a recursive chain. Otherwise, it's just introducing unnecessary
              * references. We should see if we can clean this up.
              */
-            deferredTypesWorkList.get().add(javaType);
             return getThriftTypeReference(javaType, Recursiveness.FORCED);
         }
         else {


### PR DESCRIPTION
Code on 260 would pop the list, then 262 would pop it again.

Code for getThriftTypeReference already adds the type to the worklist, so it was added twice for all cases I've seen. But there are complex cases where I was calling getThriftTypeReference directly w/o pushing separately, and so it's possible to skip two types in the worklist and only process one.

The way I handled types in collections that were potentially recursive, this unfortunately affects even non-recursive types :(

This is the fix.
