### PR TITLE
Tweaks to ThriftCodecModule

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecModule.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/guice/ThriftCodecModule.java
@@ -46,9 +46,6 @@ public class ThriftCodecModule implements Module
     @Override
     public void configure(Binder binder)
     {
-        binder.disableCircularProxies();
-        binder.requireExplicitBindings();
-
         binder.bind(ThriftCodecFactory.class).to(CompilerThriftCodecFactory.class).in(Scopes.SINGLETON);
         binder.bind(ThriftCatalog.class).in(Scopes.SINGLETON);
         binder.bind(ThriftCodecManager.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Summary:

Remove the `binder.disableCircularProxies()` and
`binder.requireExplicitBindings()` calls from ThriftCodecModule. They're not
required by ThriftCodecModule, but due to the way Guice works they are
propagated to sibling modules. This forces applications which want to use
ThriftCodecModule to either forego implicit bindings or embed their
ThriftCodecModule instance inside a child injector or private module, which
somewhat defeats the point of having a shared ThriftCodecModule.

Test plan: code review

Reviewers: @martint, @dain, @andrewcox

Cc: @cairnsjr
