### PR TITLE
Declare thrown exceptions for ThriftEventHandler and ContextChain methods

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ContextChain.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ContextChain.java
@@ -21,6 +21,8 @@ import com.facebook.swift.codec.ThriftCodec;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
+
 public class ContextChain
 {
     private final List<ThriftEventHandler> handlers;
@@ -37,56 +39,56 @@ public class ContextChain
         }
     }
 
-    public void preRead()
+    public void preRead() throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preRead(contexts.get(i), methodName);
         }
     }
 
-    public void postRead(Object[] args)
+    public void postRead(Object[] args) throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postRead(contexts.get(i), methodName, args);
         }
     }
 
-    public void preWrite(Object result)
+    public void preWrite(Object result) throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preWrite(contexts.get(i), methodName, result);
         }
     }
 
-    public void preWriteException(Throwable t)
+    public void preWriteException(Throwable t) throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).preWriteException(contexts.get(i), methodName, t);
         }
     }
 
-    public void postWrite(Object result)
+    public void postWrite(Object result) throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postWrite(contexts.get(i), methodName, result);
         }
     }
 
-    public void postWriteException(Throwable t)
+    public void postWriteException(Throwable t) throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).postWriteException(contexts.get(i), methodName, t);
         }
     }
 
-    public void declaredUserException(Throwable t, ThriftCodec<?> exceptionCodec)
+    public void declaredUserException(Throwable t, ThriftCodec<?> exceptionCodec) throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).declaredUserException(contexts.get(i), methodName, t, exceptionCodec);
         }
     }
 
-    public void undeclaredUserException(Throwable t)
+    public void undeclaredUserException(Throwable t) throws TException
     {
         for (int i = 0; i < handlers.size(); i++) {
             handlers.get(i).undeclaredUserException(contexts.get(i), methodName, t);

--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftEventHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftEventHandler.java
@@ -18,6 +18,8 @@ package com.facebook.swift.service;
 import com.facebook.nifty.core.RequestContext;
 import com.facebook.swift.codec.ThriftCodec;
 
+import org.apache.thrift.TException;
+
 public abstract class ThriftEventHandler
 {
     public Object getContext(String methodName, RequestContext requestContext)
@@ -25,13 +27,14 @@ public abstract class ThriftEventHandler
         return null;
     }
 
-    public void preRead(Object context, String methodName) {}
-    public void postRead(Object context, String methodName, Object[] args) {}
-    public void preWrite(Object context, String methodName, Object result) {}
-    public void preWriteException(Object context, String methodName, Throwable t) {}
-    public void postWrite(Object context, String methodName, Object result) {}
-    public void postWriteException(Object context, String methodName, Throwable t) {}
-    public void declaredUserException(Object o, String methodName, Throwable t, ThriftCodec<?> exceptionCodec) {}
-    public void undeclaredUserException(Object o, String methodName, Throwable t) {}
+    public void preRead(Object context, String methodName) throws TException {}
+    public void postRead(Object context, String methodName, Object[] args) throws TException {}
+    public void preWrite(Object context, String methodName, Object result) throws TException {}
+    public void preWriteException(Object context, String methodName, Throwable t) throws TException {}
+    public void postWrite(Object context, String methodName, Object result) throws TException {}
+    public void postWriteException(Object context, String methodName, Throwable t) throws TException {}
+    public void declaredUserException(Object o, String methodName, Throwable t, ThriftCodec<?> exceptionCodec)
+        throws TException {}
+    public void undeclaredUserException(Object o, String methodName, Throwable t) throws TException {}
     public void done(Object context, String methodName) {}
 }


### PR DESCRIPTION
ThriftServiceProcessor wraps calls to ThriftMethodProcessor in try {} catch (Exception e) {} so I think that we should declare checked exceptions in the ThriftEventHandler. Declared checked exceptions are useful, because once we have them, we could, for example, throw an exception in preRead() method if our ThriftEventHandler fails to authenticate a particular request.
