### PR TITLE
Log error if ThriftServiceProcessor failed to handle method.

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftServiceProcessor.java
@@ -149,6 +149,7 @@ public class ThriftServiceProcessor implements NiftyProcessor
                         @Override
                         public void onFailure(Throwable t)
                         {
+                            LOG.error("Failed to process method [" + method.getName() + "] of service [" + method.getServiceName() + "]", t);
                             context.done();
                             resultFuture.setException(t);
                         }


### PR DESCRIPTION
Currently if server handler failes to handle request for example due to message serialization
exception client receives ClosedChannelException and server side logs are silent.
This is a first step to provide more visibility in case of such errors.
