### PR TITLE
Propagate event handlers' TApplicationExceptions to the client.

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
@@ -224,7 +224,7 @@ public class ThriftMethodProcessor
                             // unexpected exception
                             TNiftyTransport requestTransport = requestContext instanceof NiftyRequestContext ? ((NiftyRequestContext)requestContext).getNiftyTransport() : null;
                             TApplicationException applicationException =
-                                    ThriftServiceProcessor.writeApplicationException(
+                                    ThriftServiceProcessor.createAndWriteApplicationException(
                                             out,
                                             requestTransport,
                                             method.getName(),

--- a/swift-service/src/test/java/com/facebook/swift/service/base/SuiteBase.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/base/SuiteBase.java
@@ -41,6 +41,7 @@ public class SuiteBase<ServiceInterface, ClientInterface> {
     private ClientInterface client;
     private ThriftServer server;
     private ServiceInterface handler;
+    private ImmutableList<ThriftEventHandler> eventHandlers;
     private final ThriftServerConfig serverConfig;
 
     public SuiteBase(
@@ -53,10 +54,20 @@ public class SuiteBase<ServiceInterface, ClientInterface> {
             Class<? extends ServiceInterface> handlerClass,
             Class<? extends ClientInterface> clientClass,
             ThriftServerConfig serverConfig) {
+        this(handlerClass, clientClass, serverConfig, ImmutableList.<ThriftEventHandler>of());
+    }
+
+    public SuiteBase(
+            Class<? extends ServiceInterface> handlerClass,
+            Class<? extends ClientInterface> clientClass,
+            ThriftServerConfig serverConfig,
+            ImmutableList<ThriftEventHandler> eventHandlers) {
         this.clientClass = clientClass;
         this.handlerClass = handlerClass;
         this.serverConfig = serverConfig;
+        this.eventHandlers = eventHandlers;
     }
+
 
     @BeforeClass
     public void setupSuite() throws InstantiationException, IllegalAccessException {
@@ -90,7 +101,7 @@ public class SuiteBase<ServiceInterface, ClientInterface> {
 
     private ThriftServer createServer(ServiceInterface handler)
             throws IllegalAccessException, InstantiationException {
-        ThriftServiceProcessor processor = new ThriftServiceProcessor(codecManager, ImmutableList.<ThriftEventHandler>of(), handler);
+        ThriftServiceProcessor processor = new ThriftServiceProcessor(codecManager, eventHandlers, handler);
         return new ThriftServer(processor, serverConfig);
     }
 

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionService.java
@@ -53,4 +53,8 @@ public interface ExceptionService
 
     @ThriftMethod(exception = { @ThriftException(type = ThriftCheckedSubclassableException.class, id = 1) })
     public void throwSubclassOfSubclassableException() throws ThriftCheckedSubclassableException, TException;
+
+    @ThriftMethod
+    public void throwExceptionInEventHandlersCode() throws TException;
+
 }

--- a/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionServiceHandler.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/exceptions/ExceptionServiceHandler.java
@@ -70,4 +70,9 @@ public class ExceptionServiceHandler implements ExceptionService
             TException {
         throw new ThriftCheckedSubclassableException.Subclass("is subclass");
     }
+
+    @Override
+    public void throwExceptionInEventHandlersCode() throws TException {
+
+    }
 }


### PR DESCRIPTION
If a ThriftEventHandler throws a TApplicationException it is not propagated back to the client and the Netty channel just closes. This commit catches TApplicationExceptions in ThriftServiceProcessor and sends it to the client.

Example use case: if somebody is doing authorization in event handlers and needs to throw a useful exception for the client.
