### PR TITLE
Inject TransportAttachObserver dependency into ThriftServer

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/guice/ThriftServerModule.java
@@ -21,6 +21,7 @@ import com.facebook.nifty.core.NiftyTimer;
 import com.facebook.nifty.duplex.TDuplexProtocolFactory;
 import com.facebook.nifty.processor.NiftyProcessor;
 import com.facebook.nifty.ssl.SslServerConfiguration;
+import com.facebook.nifty.ssl.TransportAttachObserver;
 import com.facebook.swift.service.ThriftEventHandler;
 import com.facebook.swift.service.ThriftServer;
 import com.facebook.swift.service.ThriftServerConfig;
@@ -82,6 +83,7 @@ public class ThriftServerModule implements Module
         binder.bind(ThriftServer.NiftySecurityFactoryHolder.class);
         binder.bind(ThriftServer.class).in(Scopes.SINGLETON);
         binder.bind(ThriftServer.SslServerConfigurationHolder.class);
+        binder.bind(ThriftServer.TransportAttachObserverHolder.class);
     }
 
     // helpers for binding frame codec factories

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftSslService.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftSslService.java
@@ -129,7 +129,8 @@ public class TestThriftSslService
                 ThriftServer.DEFAULT_PROTOCOL_FACTORIES,
                 ThriftServer.DEFAULT_WORKER_EXECUTORS,
                 ThriftServer.DEFAULT_SECURITY_FACTORY,
-                new ThriftServer.SslServerConfigurationHolder(sslConfiguration)).start()) {
+                new ThriftServer.SslServerConfigurationHolder(sslConfiguration),
+                ThriftServer.DEFAULT_TRANSPORT_ATTACH_OBSERVER).start()) {
             assertEquals(logThrift(server.getPort(), messages), ResultCode.OK);
             assertEquals(logSwift(server.getPort(), toSwiftLogEntry(messages)), com.facebook.swift.service.ResultCode.OK);
         }

--- a/swift-service/src/test/java/com/facebook/swift/service/TestThriftTransportAttachObserver.java
+++ b/swift-service/src/test/java/com/facebook/swift/service/TestThriftTransportAttachObserver.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.swift.service;
+
+import com.facebook.nifty.core.NettyServerTransport;
+import com.facebook.nifty.core.NiftyTimer;
+import com.facebook.nifty.processor.NiftyProcessor;
+import com.facebook.nifty.processor.NiftyProcessorAdapters;
+import com.facebook.nifty.ssl.TransportAttachObserver;
+import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.service.scribe.scribe;
+import com.google.common.collect.ImmutableList;
+import org.apache.thrift.TProcessor;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class TestThriftTransportAttachObserver
+{
+    @Test
+    public void testSwiftService()
+            throws Exception
+    {
+        SwiftScribe scribeService = new SwiftScribe();
+        NiftyProcessor processor = new ThriftServiceProcessor(new ThriftCodecManager(), ImmutableList.<ThriftEventHandler>of(), scribeService);
+        testProcessor(processor);
+    }
+
+    @Test
+    public void testThriftService()
+            throws Exception
+    {
+        ThriftScribeService scribeService = new ThriftScribeService();
+        TProcessor processor = new scribe.Processor<>(scribeService);
+        testProcessor(NiftyProcessorAdapters.processorFromTProcessor(processor));
+    }
+
+    private void testProcessor(NiftyProcessor processor)
+            throws Exception
+    {
+        DummyTransportAttachObserver dummyTransportAttachObserver = new DummyTransportAttachObserver();
+        try (ThriftServer server = new ThriftServer(
+                processor,
+                new ThriftServerConfig(),
+                new NiftyTimer("timer"),
+                ThriftServer.DEFAULT_FRAME_CODEC_FACTORIES,
+                ThriftServer.DEFAULT_PROTOCOL_FACTORIES,
+                ThriftServer.DEFAULT_WORKER_EXECUTORS,
+                ThriftServer.DEFAULT_SECURITY_FACTORY,
+                ThriftServer.DEFAULT_SSL_SERVER_CONFIGURATION,
+                new ThriftServer.TransportAttachObserverHolder(dummyTransportAttachObserver)).start()) {
+            assertTrue(dummyTransportAttachObserver.getState());
+            server.close();
+            assertFalse(dummyTransportAttachObserver.getState());
+        }
+    }
+
+    public static class DummyTransportAttachObserver implements TransportAttachObserver
+    {
+        private boolean state;
+
+        public void attachTransport(NettyServerTransport transport)
+        {
+            state = true;
+        }
+
+        public void detachTransport()
+        {
+            state = false;
+        }
+
+        public boolean getState()
+        {
+            return state;
+        }
+    }
+}


### PR DESCRIPTION
This allows callers of ThriftServer to specify TransportAttachObserver
implementations like nifty's SslConfigFileWatcher to watch files for
changes and update the server configuration when they do.

This pull request depends on the nifty 0.22 release. It would be great if
we could wait to get this pull request in for the swift 0.22 release as well.
