### PR TITLE
Fix generated Java code for Thrift unions with multiple fields of same type

### DIFF
--- a/swift-generator/src/main/java/com/facebook/swift/generator/template/StructContext.java
+++ b/swift-generator/src/main/java/com/facebook/swift/generator/template/StructContext.java
@@ -16,8 +16,11 @@
 package com.facebook.swift.generator.template;
 
 import java.util.List;
+import java.util.Set;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 public class StructContext implements JavaContext
 {
@@ -37,6 +40,15 @@ public class StructContext implements JavaContext
     public void addField(final FieldContext field)
     {
         this.fields.add(field);
+    }
+
+    public boolean getHasUniqueFieldTypes()
+    {
+      List<String> fieldTypesList = Lists.transform(this.fields, new Function<FieldContext, String>() {
+          public String apply(FieldContext field) { return field.getJavaType(); }
+      });
+      Set<String> fieldTypesSet = Sets.newHashSet(fieldTypesList);
+      return fieldTypesSet.size() == fieldTypesList.size();
     }
 
     public List<FieldContext> getFields()

--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -70,11 +70,12 @@ package <context.javaPackage>;
 import com.facebook.swift.codec.*;
 import com.facebook.swift.codec.ThriftField.Requiredness;
 import com.facebook.swift.codec.ThriftField.Recursiveness;
+import com.google.common.base.Preconditions;
 import java.util.*;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
-@ThriftUnion("<context.name>")
+@ThriftUnion(value = "<context.name>", builder = <context.javaName>.Builder.class)
 public final class <context.javaName>
 {
     <_union_body(context)>
@@ -93,6 +94,8 @@ public final class <context.javaName>
     }
 
     <_union_toString(context)>
+
+    <_union_builder(context)>
 }<\n>
 >>
 
@@ -331,5 +334,61 @@ public String toString()
         .add("name", name)
         .add("type", value == null ? "\<null\>" : value.getClass().getSimpleName())
         .toString();
+}
+>>
+
+_union_field_constructor(context, field) ::= <<
+@ThriftConstructor
+public <context.javaName>(final <field.javaType> <field.javaName>) {
+    this.value = <field.javaName>;
+    this.id = <field.id>;
+    this.name = "<field.name>";
+}
+>>
+
+_union_constructor(context) ::= <<
+
+private Object value;
+private int id = -1;
+private String name;
+
+public <context.javaName>() {
+}
+
+<if(context.hasUniqueFieldTypes)>
+<context.fields : { field |<_union_field_constructor(context, field)>}; separator="\n\n">
+<endif>
+
+private <context.javaName>(Object value, int id, String name) {
+    this.value = value;
+    this.id = id;
+    this.name = name;
+}
+>>
+
+_union_builder_setter(field) ::= <<
+<_fieldAnnotation(field)>
+public Builder <field.javaSetterName>(<field.javaType> <field.javaName>) {
+    Preconditions.checkState(name == null, "can't set <field.javaName> - already set to %s", name);
+    value = <field.javaName>;
+    id = <field.id>;
+    name = "<field.name>";
+    return this;
+}
+>>
+
+_union_builder(context) ::= <<
+public static class Builder {
+
+    private Object value;
+    private int id = -1;
+    private String name;
+
+    @ThriftConstructor
+    public <context.javaName> build() {
+        return new <context.javaName>(value, id, name);
+    }
+
+    <context.fields : { field |<_union_builder_setter(field)>}; separator="\n\n">
 }
 >>

--- a/swift-generator/src/main/resources/templates/java/ctor.st
+++ b/swift-generator/src/main/resources/templates/java/ctor.st
@@ -35,25 +35,8 @@ public void <field.javaSetterName>(final <field.javaType> <field.javaName>) {
 }
 >>
 
-_union_ctor(context, field) ::= <<
-@ThriftConstructor
-public <context.javaName>(final <field.javaType> <field.javaName>) {
-    this.value = <field.javaName>;
-    this.id = <field.id>;
-    this.name = "<field.name>";
-}
->>
-
 _union_body(context) ::= <<
-
-private Object value;
-private int id = -1;
-private String name;
-
-public <context.javaName>() {
-}
-
-<context.fields : { field |<_union_ctor(context, field)>}; separator="\n\n">
+<_union_constructor(context)>
 
 <context.fields : { field |<_union_setter(field)>}; separator="\n\n">
 >>

--- a/swift-generator/src/main/resources/templates/java/immutable.st
+++ b/swift-generator/src/main/resources/templates/java/immutable.st
@@ -54,19 +54,6 @@ public Builder <field.javaSetterName>(<field.javaType> <field.javaName>) {
 }
 >>
 
-_union_ctor(context, field) ::= <<
-@ThriftConstructor
-public <context.javaName>(final <field.javaType> <field.javaName>) {
-    this.value = <field.javaName>;
-    this.id = <field.id>;
-    this.name = "<field.name>";
-}
->>
-
 _union_body(context) ::= <<
-private final Object value;
-private final int id;
-private final String name;
-
-<context.fields : { field |<_union_ctor(context, field)>}; separator="\n\n">
+<_union_constructor(context)>
 >>

--- a/swift-generator/src/main/resources/templates/java/regular.st
+++ b/swift-generator/src/main/resources/templates/java/regular.st
@@ -28,15 +28,8 @@ public void <field.javaSetterName>(final <field.javaType> <field.javaName>) {
 }
 >>
 
-
 _union_body(context) ::= <<
-
-private Object value;
-private int id = -1;
-private String name;
-
-public <context.javaName>() {
-}
+<_union_constructor(context)>
 
 <context.fields : { field |<_union_setter(field)>}; separator="\n\n">
 >>

--- a/swift-generator/src/test/resources/basic/UnionTest.thrift
+++ b/swift-generator/src/test/resources/basic/UnionTest.thrift
@@ -1,0 +1,29 @@
+#!/usr/local/bin/thrift -java
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+union foo_unique_types {
+  1: string bar;
+  2: i32 baz;
+}
+
+union foo_duplicate_types {
+  1: i32 bar;
+  2: i32 baz;
+}


### PR DESCRIPTION
Currently, when generating Java code for Thrift unions with multiple fields
of the same type, the code won't compile. This is because Swift generates
a constructor per field, so multiple constructors will have the same
arguments even though they initialize fields differently.

This patch changes the union template to use a builder paradigm in order
to allow for this case.
