### PR TITLE
Fix Swift recursive annotation compatiblity with unions

### DIFF
--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftFieldMetadata.java
@@ -95,10 +95,6 @@ public class ThriftFieldMetadata
                 break;
         }
 
-        checkArgument(!isRecursiveReference
-                      || requiredness == Requiredness.OPTIONAL,
-                      "Fields marked as recursive references must always be optional");
-
         checkArgument(!injections.isEmpty()
                       || extraction.isPresent()
                       || constructorInjection.isPresent()

--- a/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
+++ b/swift-codec/src/main/java/com/facebook/swift/codec/metadata/ThriftStructMetadataBuilder.java
@@ -207,6 +207,12 @@ public class ThriftStructMetadataBuilder
             coercion = catalog.getDefaultCoercion(thriftTypeReference.get().getJavaType());
         }
 
+        if (recursive && requiredness != Requiredness.OPTIONAL) {
+            metadataErrors.addError("Struct '%s' field '%s' is recursive but not marked optional",
+                    structName,
+                    name);
+        }
+
         ThriftFieldMetadata thriftFieldMetadata = new ThriftFieldMetadata(
                 id,
                 isLegacyId,

--- a/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
@@ -27,17 +27,7 @@ import com.facebook.swift.codec.internal.coercion.DefaultJavaCoercions;
 import com.facebook.swift.codec.metadata.ThriftCatalog;
 import com.facebook.swift.codec.metadata.ThriftStructMetadata;
 import com.facebook.swift.codec.metadata.ThriftType;
-import com.facebook.swift.codec.recursion.CoRecursive;
-import com.facebook.swift.codec.recursion.CoRecursiveHelper;
-import com.facebook.swift.codec.recursion.CoRecursiveTree;
-import com.facebook.swift.codec.recursion.CoRecursiveTreeHelper;
-import com.facebook.swift.codec.recursion.RecursiveUnion;
-import com.facebook.swift.codec.recursion.ViaListElementType;
-import com.facebook.swift.codec.recursion.ViaMapKeyAndValueTypes;
-import com.facebook.swift.codec.recursion.ViaNestedListElementType;
-import com.facebook.swift.codec.recursion.WithIdlRecursiveAnnotation;
-import com.facebook.swift.codec.recursion.WithSwiftRecursiveAnnotation;
-import com.facebook.swift.codec.recursion.WithoutRecursiveAnnotation;
+import com.facebook.swift.codec.recursion.*;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -582,6 +572,14 @@ public abstract class AbstractThriftCodecManagerTest
     {
         RecursiveUnion recursiveUnion = new RecursiveUnion(new RecursiveUnion("child"));
         testRoundTripSerialize(recursiveUnion, new TCompactProtocol.Factory());
+    }
+
+    @Test
+    public void testRecursiveDefaultUnion()
+            throws Exception
+    {
+        RecursiveDefaultUnion recursiveDefaultUnion = new RecursiveDefaultUnion(new RecursiveDefaultUnion("child"));
+        testRoundTripSerialize(recursiveDefaultUnion, new TCompactProtocol.Factory());
     }
 
     private void assertAllFieldsSet(IsSetBean isSetBean, boolean expected)

--- a/swift-codec/src/test/java/com/facebook/swift/codec/recursion/RecursiveDefaultUnion.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/recursion/RecursiveDefaultUnion.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.facebook.swift.codec.recursion;
+
+import com.facebook.swift.codec.ThriftConstructor;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftUnion;
+import com.facebook.swift.codec.ThriftUnionId;
+
+import java.util.Objects;
+
+import static com.facebook.swift.codec.ThriftField.*;
+
+@ThriftUnion
+public class RecursiveDefaultUnion
+{
+    @ThriftUnionId
+    public short unionId;
+
+    public Object value;
+
+    @ThriftConstructor
+    public RecursiveDefaultUnion(RecursiveDefaultUnion child)
+    {
+        this.unionId = 1;
+        this.value = child;
+    }
+
+    @ThriftConstructor
+    public RecursiveDefaultUnion(String data)
+    {
+        this.unionId = 2;
+        this.value = data;
+    }
+
+    @ThriftField(value = 1, requiredness = ThriftField.Requiredness.NONE, isRecursive = ThriftField.Recursiveness.TRUE)
+    public RecursiveDefaultUnion getChild()
+    {
+        return (RecursiveDefaultUnion)value;
+    }
+
+    @ThriftField(2)
+    public String getData()
+    {
+        return (String)value;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final RecursiveDefaultUnion that = (RecursiveDefaultUnion) obj;
+
+        return Objects.equals(this.unionId, that.unionId) &&
+                Objects.equals(this.value, that.value);
+    }
+}


### PR DESCRIPTION
Currently, for union fields annotated with recursive = True, Swift generates Java
code for these fields with Requiredness = None. This is currently the default setting
and fields with this setting may not exist on read and are written unless they are set
to null. However, the Swift codec that parses the Java code throws an error that all
fields with recursive = True must be optional. Since the default setting is essentially
optional (Thrift types will default to null), allow Requiredness = None as well.
