### PR TITLE
Revert adding Builder subclasses to unions

### DIFF
--- a/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/AbstractThriftCodecManagerTest.java
@@ -152,6 +152,22 @@ public abstract class AbstractThriftCodecManagerTest
 
         unionConstructor = new UnionConstructor(Fruit.APPLE);
         testRoundTripSerialize(unionConstructor, new TCompactProtocol.Factory());
+
+        unionConstructor = new UnionConstructor();
+        testRoundTripSerialize(unionConstructor, new TCompactProtocol.Factory());
+    }
+
+    @Test
+    public void testUnionConstructorDuplicateTypes()
+            throws Exception
+    {
+        UnionConstructorDuplicateTypes unionConstructor = new UnionConstructorDuplicateTypes();
+        unionConstructor.setFirstIntValue(1);
+        testRoundTripSerialize(unionConstructor, new TCompactProtocol.Factory());
+
+        unionConstructor = new UnionConstructorDuplicateTypes();
+        unionConstructor.setSecondIntValue(2);
+        testRoundTripSerialize(unionConstructor, new TCompactProtocol.Factory());
     }
 
     @Test

--- a/swift-codec/src/test/java/com/facebook/swift/codec/UnionConstructorDuplicateTypes.java
+++ b/swift-codec/src/test/java/com/facebook/swift/codec/UnionConstructorDuplicateTypes.java
@@ -15,81 +15,68 @@
  */
 package com.facebook.swift.codec;
 
+import com.facebook.swift.codec.ThriftField.Requiredness;
+
 import java.util.Arrays;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
-@ThriftUnion("Union")
-public final class UnionConstructor
-{
+@ThriftUnion("UnionConstructorDuplicateTypes")
+public class UnionConstructorDuplicateTypes {
     private Object value;
     private short id = -1;
     private String name;
 
     @ThriftConstructor
-    public UnionConstructor() {}
+    public UnionConstructorDuplicateTypes() {
+    }
 
-    @ThriftConstructor
-    public UnionConstructor(String stringValue)
-    {
-        this.value = stringValue;
+    @ThriftField
+    public void setFirstIntValue(final int firstIntValue) {
+        this.value = firstIntValue;
         this.id = 1;
-        this.name = "stringValue";
+        this.name = "firstIntValue";
     }
 
-    @ThriftConstructor
-    public UnionConstructor(Long longValue)
-    {
-        this.value = longValue;
+    @ThriftField
+    public void setSecondIntValue(final int secondIntValue) {
+        this.value = secondIntValue;
         this.id = 2;
-        this.name = "longValue";
+        this.name = "secondIntValue";
     }
 
-    @ThriftConstructor
-    public UnionConstructor(Fruit fruitValue)
-    {
-        this.value = fruitValue;
-        this.id = 3;
-        this.name = "fruitValue";
+    @ThriftField(value = 1, name = "firstIntValue", requiredness = Requiredness.NONE)
+    public int getFirstIntValue() {
+        if (this.id != 1) {
+            throw new IllegalStateException("Not a firstIntValue element!");
+        }
+        return (int) value;
+    }
+
+    public boolean isSetFirstIntValue() {
+        return this.id == 1;
+    }
+
+    @ThriftField(value = 2, name = "secondIntValue", requiredness = Requiredness.NONE)
+    public int getSecondIntValue() {
+        if (this.id != 2) {
+            throw new IllegalStateException("Not a secondIntValue element!");
+        }
+        return (int) value;
+    }
+
+    public boolean isSetSecondIntValue() {
+        return this.id == 2;
     }
 
     @ThriftUnionId
-    public short getThriftId()
-    {
+    public short getThriftId() {
         return this.id;
     }
 
-    public String getThriftName()
-    {
+    public String getThriftName() {
         return this.name;
-    }
-
-    @ThriftField(value = 1, name = "stringValue")
-    public String getStringValue()
-    {
-        if (id != 1) {
-            throw new IllegalStateException("not a stringValue");
-        }
-        return (String) value;
-    }
-
-    @ThriftField(value = 2, name = "longValue")
-    public Long getLongValue()
-    {
-        if (id != 2) {
-            throw new IllegalStateException("not a longValue");
-        }
-        return (Long) value;
-    }
-
-    @ThriftField(value = 3, name = "fruitValue")
-    public Fruit getFruitValue()
-    {
-        if (id != 3) {
-            throw new IllegalStateException("not a fruitValue");
-        }
-        return (Fruit) value;
     }
 
     @Override
@@ -103,24 +90,21 @@ public final class UnionConstructor
     }
 
     @Override
-    public boolean equals(Object obj)
-    {
+    public boolean equals(Object obj) {
         if (this == obj) {
             return true;
-        }
-        else if (obj == null || getClass() != obj.getClass()) {
+        } else if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
 
-        UnionConstructor that = (UnionConstructor) obj;
+        UnionConstructorDuplicateTypes that = (UnionConstructorDuplicateTypes) obj;
         return Objects.equals(this.id, that.id)
                 && Objects.equals(this.value, that.value)
                 && Objects.equals(this.name, that.name);
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return toStringHelper(this)
                 .add("value", value)
                 .add("id", id)

--- a/swift-generator/src/main/resources/templates/java/common.st
+++ b/swift-generator/src/main/resources/templates/java/common.st
@@ -70,12 +70,11 @@ package <context.javaPackage>;
 import com.facebook.swift.codec.*;
 import com.facebook.swift.codec.ThriftField.Requiredness;
 import com.facebook.swift.codec.ThriftField.Recursiveness;
-import com.google.common.base.Preconditions;
 import java.util.*;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
-@ThriftUnion(value = "<context.name>", builder = <context.javaName>.Builder.class)
+@ThriftUnion("<context.name>")
 public final class <context.javaName>
 {
     <_union_body(context)>
@@ -83,7 +82,7 @@ public final class <context.javaName>
     <context.fields : { field |<_union_field(field)>}; separator="\n\n">
 
     @ThriftUnionId
-    public int getThriftId()
+    public short getThriftId()
     {
         return this.id;
     }
@@ -95,7 +94,9 @@ public final class <context.javaName>
 
     <_union_toString(context)>
 
-    <_union_builder(context)>
+    <_union_equalsImpl(context)>
+
+    <_union_hashCodeImpl(context)>
 }<\n>
 >>
 
@@ -298,6 +299,35 @@ public boolean equals(Object o) {
 }
 >>
 
+_union_equalsImpl(context) ::= <<
+@Override
+public boolean equals(Object o) {
+    if (this == o) {
+        return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+        return false;
+    }
+
+    <context.javaName> other = (<context.javaName>)o;
+
+    return Objects.equals(this.id, other.id)
+            && Objects.equals(this.value, other.value)
+            && Objects.equals(this.name, other.name);
+}
+>>
+
+_union_hashCodeImpl(context) ::= <<
+@Override
+public int hashCode() {
+    return Arrays.deepHashCode(new Object[] {
+        id,
+        value,
+        name
+    });
+}
+>>
+
 _checkFieldEquality(field) ::= <<
 <if(field.arrayType)><_checkArrayFieldEquality(field)><else><_checkObjectFieldEquality(field)><endif>
 >>
@@ -349,46 +379,23 @@ public <context.javaName>(final <field.javaType> <field.javaName>) {
 _union_constructor(context) ::= <<
 
 private Object value;
-private int id = -1;
+private short id = -1;
 private String name;
 
+@ThriftConstructor
 public <context.javaName>() {
 }
 
 <if(context.hasUniqueFieldTypes)>
 <context.fields : { field |<_union_field_constructor(context, field)>}; separator="\n\n">
 <endif>
-
-private <context.javaName>(Object value, int id, String name) {
-    this.value = value;
-    this.id = id;
-    this.name = name;
-}
 >>
 
-_union_builder_setter(field) ::= <<
-<_fieldAnnotation(field)>
-public Builder <field.javaSetterName>(<field.javaType> <field.javaName>) {
-    Preconditions.checkState(name == null, "can't set <field.javaName> - already set to %s", name);
-    value = <field.javaName>;
-    id = <field.id>;
-    name = "<field.name>";
-    return this;
-}
->>
-
-_union_builder(context) ::= <<
-public static class Builder {
-
-    private Object value;
-    private int id = -1;
-    private String name;
-
-    @ThriftConstructor
-    public <context.javaName> build() {
-        return new <context.javaName>(value, id, name);
-    }
-
-    <context.fields : { field |<_union_builder_setter(field)>}; separator="\n\n">
+_union_setter(field) ::= <<
+@ThriftField
+public void <field.javaSetterName>(final <field.javaType> <field.javaName>) {
+    this.value = <field.javaName>;
+    this.id = <field.id>;
+    this.name = "<field.name>";
 }
 >>

--- a/swift-generator/src/main/resources/templates/java/ctor.st
+++ b/swift-generator/src/main/resources/templates/java/ctor.st
@@ -27,14 +27,6 @@ _ctorAssignment(field) ::= <<
 this.<field.javaName> = <field.javaName>;
 >>
 
-_union_setter(field) ::= <<
-public void <field.javaSetterName>(final <field.javaType> <field.javaName>) {
-    this.value = <field.javaName>;
-    this.id = <field.id>;
-    this.name = "<field.name>";
-}
->>
-
 _union_body(context) ::= <<
 <_union_constructor(context)>
 

--- a/swift-generator/src/main/resources/templates/java/immutable.st
+++ b/swift-generator/src/main/resources/templates/java/immutable.st
@@ -56,4 +56,8 @@ public Builder <field.javaSetterName>(<field.javaType> <field.javaName>) {
 
 _union_body(context) ::= <<
 <_union_constructor(context)>
+
+<if(!context.hasUniqueFieldTypes)>
+<context.fields : { field |<_union_setter(field)>}; separator="\n\n">
+<endif>
 >>

--- a/swift-generator/src/main/resources/templates/java/regular.st
+++ b/swift-generator/src/main/resources/templates/java/regular.st
@@ -19,15 +19,6 @@ public <element.javaName>() {
 }
 >>
 
-_union_setter(field) ::= <<
-@ThriftField
-public void <field.javaSetterName>(final <field.javaType> <field.javaName>) {
-    this.value = <field.javaName>;
-    this.id = <field.id>;
-    this.name = "<field.name>";
-}
->>
-
 _union_body(context) ::= <<
 <_union_constructor(context)>
 


### PR DESCRIPTION
Using builder subclasses in unions in Swift-generated code causes
separate errors to be triggered. This patch reverts the use of builders
and uses setters instead. It also adds more tests to swift-codec for unions
and makes the UnionConstructor test more similar to code generated from
swift-generator.

Error: Inject method com.facebook.swift.foo is not allowed on struct class, since struct has a builder
Attempted to resolve a recursive reference to type 'com.facebook.swift.foo' before the referenced type was cached (most likely a recursive type support bug)
