### PR TITLE
remove the exception for null result

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodHandler.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodHandler.java
@@ -293,9 +293,6 @@ public class ThriftMethodHandler
             return null;
         }
 
-        if (results == null) {
-            throw new TApplicationException(TApplicationException.MISSING_RESULT, name + " failed: unknown result");
-        }
         return results;
     }
 


### PR DESCRIPTION
I think the return value is null should not be an exception, because sometimes we have to do it.So why do we have to catch the exception to make sure the return value is null?(Swift works for Java, isn't it?)