### PR TITLE
remove wrapperclass defalut val when it is null

### DIFF
--- a/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
+++ b/swift-service/src/main/java/com/facebook/swift/service/ThriftMethodProcessor.java
@@ -311,7 +311,6 @@ public class ThriftMethodProcessor
 
                     if (argumentType instanceof Class) {
                         Class<?> argumentClass = (Class<?>) argumentType;
-                        argumentClass = Primitives.unwrap(argumentClass);
                         args[argumentPosition] = Defaults.defaultValue(argumentClass);
                     }
                 }


### PR DESCRIPTION
I think that Wrapper Class can be null. If can‘t be null should define it base class. Otherwise it will confuse the original intention of code and It's against Java too. Swift works for Java, isn't it?